### PR TITLE
fix/Dynamically set task points using pointsBase in mentor feedback modal 

### DIFF
--- a/client-interface/app/mentor/tasks/[id]/feedback/page.tsx
+++ b/client-interface/app/mentor/tasks/[id]/feedback/page.tsx
@@ -79,6 +79,7 @@ export default function FeedbackProvision({ params }: PageProps) {
   const taskDescription = task.roadmapTask?.description || task.description;
   const taskDeliverable = task.roadmapTask?.deliverable || task.deliverable;
   const acceptanceCriteria = task.roadmapTask?.acceptanceCriteria || task.acceptanceCriteria || [];
+  const maxPoints = task.roadmapTask?.pointsBase || 10;
 
   return (
     <div className="space-y-6">
@@ -406,9 +407,17 @@ export default function FeedbackProvision({ params }: PageProps) {
             <input
               type="number"
               value={pointsAwarded}
-              onChange={(e) => setPointsAwarded(Number(e.target.value))}
+              onChange={(e) => {
+                const value = e.target.value;
+                const numericValue = Number(value);
+                const cleanedValue = value === ''
+                  ? 0
+                  : Math.min(Math.max(0, numericValue), maxPoints);
+
+                setPointsAwarded(cleanedValue);
+              }}
               min="0"
-              max="100"
+              max={maxPoints}
               className="w-32 px-3 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>

--- a/client-interface/app/mentor/tasks/[id]/feedback/page.tsx
+++ b/client-interface/app/mentor/tasks/[id]/feedback/page.tsx
@@ -43,6 +43,7 @@ export default function FeedbackProvision({ params }: PageProps) {
     feedbackError,
     decisionError,
     revisionError,
+    pointsError,
     setRating,
     setHoveredRating,
     setFeedbackText,
@@ -53,6 +54,7 @@ export default function FeedbackProvision({ params }: PageProps) {
     setFeedbackError,
     setDecisionError,
     setRevisionError,
+    setPointsError,
     addInlineFeedback,
     updateInlineFeedback,
     removeInlineFeedback,
@@ -410,16 +412,22 @@ export default function FeedbackProvision({ params }: PageProps) {
               onChange={(e) => {
                 const value = e.target.value;
                 const numericValue = Number(value);
-                const cleanedValue = value === ''
+                const cleanedValue = value === '' || Number.isNaN(numericValue)
                   ? 0
-                  : Math.min(Math.max(0, numericValue), maxPoints);
+                  : Math.max(0, numericValue);
 
                 setPointsAwarded(cleanedValue);
+                setPointsError('');
               }}
               min="0"
-              max={maxPoints}
               className="w-32 px-3 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
+            {pointsError && (
+              <p className="mt-2 text-sm text-red-600 flex items-center gap-1">
+                <AlertCircle className="w-4 h-4 shrink-0" />
+                {pointsError}
+              </p>
+            )}
           </div>
         )}
 

--- a/client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts
+++ b/client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts
@@ -61,7 +61,7 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
   const [feedbackText, setFeedbackText] = useState('');
   const [revisionNotes, setRevisionNotes] = useState('');
   const [decision, setDecision] = useState<'approve' | 'revision' | null>(null);
-  const [pointsAwarded, setPointsAwarded] = useState(10);
+  const [pointsAwarded, setPointsAwarded] = useState(0);
   const [inlineFeedback, setInlineFeedback] = useState<InlineFeedbackItem[]>([]);
 
   const [error, setError] = useState('');
@@ -80,8 +80,8 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
         if (taskData.submissions && taskData.submissions.length > 0) {
           setSubmission(taskData.submissions[0]);
         }
-        if (taskData.pointsBase) {
-          setPointsAwarded(taskData.pointsBase);
+        if (taskData.roadmapTask?.pointsBase) {
+          setPointsAwarded(taskData.roadmapTask.pointsBase);
         }
       } catch (err: unknown) {
         setError(extractApiErrorMessage(err, 'Failed to load task'));

--- a/client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts
+++ b/client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts
@@ -145,6 +145,11 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
 
       setIsSubmitting(true);
       try {
+        const maxPoints = task?.roadmapTask?.pointsBase || 10;
+        const safePointsAwarded = decision === 'approve'
+          ? Math.min(Math.max(0, pointsAwarded), maxPoints)
+          : 0;
+
         const validInlineFeedback = inlineFeedback
           .filter((item) => item.comment.trim())
           .map((item) => ({ line: 0, comment: item.comment, type: item.type }));
@@ -154,7 +159,7 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
           feedbackText,
           isApproved: decision === 'approve',
           revisionNotes: decision === 'revision' ? revisionNotes : undefined,
-          pointsAwarded: decision === 'approve' ? pointsAwarded : 0,
+          pointsAwarded: safePointsAwarded,
           inlineFeedback: validInlineFeedback,
         } as any);
 
@@ -173,6 +178,7 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
       decision,
       revisionNotes,
       pointsAwarded,
+      task,
       inlineFeedback,
       router,
     ]

--- a/client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts
+++ b/client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts
@@ -31,6 +31,7 @@ export interface UseMentorTaskFeedbackReturn {
   feedbackError: string;
   decisionError: string;
   revisionError: string;
+  pointsError: string;
   setRating: (v: number) => void;
   setHoveredRating: (v: number) => void;
   setFeedbackText: (v: string) => void;
@@ -41,6 +42,7 @@ export interface UseMentorTaskFeedbackReturn {
   setFeedbackError: (v: string) => void;
   setDecisionError: (v: string) => void;
   setRevisionError: (v: string) => void;
+  setPointsError: (v: string) => void;
   addInlineFeedback: () => void;
   updateInlineFeedback: (id: number, field: string, value: string) => void;
   removeInlineFeedback: (id: number) => void;
@@ -69,6 +71,7 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
   const [feedbackError, setFeedbackError] = useState('');
   const [decisionError, setDecisionError] = useState('');
   const [revisionError, setRevisionError] = useState('');
+  const [pointsError, setPointsError] = useState('');
 
   useEffect(() => {
     if (!taskId) return;
@@ -117,6 +120,7 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
       setFeedbackError('');
       setDecisionError('');
       setRevisionError('');
+      setPointsError('');
 
       if (!submission) {
         setError('No submission found');
@@ -141,15 +145,17 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
         setRevisionError('Revision notes are required when requesting a revision.');
         hasError = true;
       }
+      if (decision === 'approve') {
+        const maxPoints = task?.roadmapTask?.pointsBase ?? 10;
+        if (pointsAwarded > maxPoints) {
+          setPointsError(`Maximum points are ${maxPoints}.`);
+          hasError = true;
+        }
+      }
       if (hasError) return;
 
       setIsSubmitting(true);
       try {
-        const maxPoints = task?.roadmapTask?.pointsBase || 10;
-        const safePointsAwarded = decision === 'approve'
-          ? Math.min(Math.max(0, pointsAwarded), maxPoints)
-          : 0;
-
         const validInlineFeedback = inlineFeedback
           .filter((item) => item.comment.trim())
           .map((item) => ({ line: 0, comment: item.comment, type: item.type }));
@@ -159,7 +165,7 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
           feedbackText,
           isApproved: decision === 'approve',
           revisionNotes: decision === 'revision' ? revisionNotes : undefined,
-          pointsAwarded: safePointsAwarded,
+          pointsAwarded: decision === 'approve' ? pointsAwarded : 0,
           inlineFeedback: validInlineFeedback,
         } as any);
 
@@ -202,6 +208,7 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
     feedbackError,
     decisionError,
     revisionError,
+    pointsError,
     setRating,
     setHoveredRating,
     setFeedbackText,
@@ -212,6 +219,7 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
     setFeedbackError,
     setDecisionError,
     setRevisionError,
+    setPointsError,
     addInlineFeedback,
     updateInlineFeedback,
     removeInlineFeedback,

--- a/server/src/services/submissionService.js
+++ b/server/src/services/submissionService.js
@@ -268,7 +268,10 @@ class SubmissionService {
 
     if (isApproved) {
       updateData.completedAt = new Date();
-      updateData.pointsAwarded = pointsAwarded || 10;
+      const maxPoints = task.roadmapTask?.pointsBase ?? 10;
+      const parsedPoints = Number(pointsAwarded);
+      const safePoints = Number.isFinite(parsedPoints) ? parsedPoints : maxPoints;
+      updateData.pointsAwarded = Math.min(Math.max(0, safePoints), maxPoints);
     } else {
       updateData.revisionCount = task.revisionCount + 1;
     }
@@ -284,9 +287,7 @@ class SubmissionService {
       await this.updateMenteeGamificationProgress(task.menteeId);
 
       const gamificationService = require('./gamificationService');
-      const pointsToAward = Number.isFinite(Number(pointsAwarded))
-        ? Math.max(0, Number(pointsAwarded))
-        : 10;
+      const pointsToAward = updateData.pointsAwarded;
 
       try {
         if (pointsToAward > 0) {

--- a/server/src/services/submissionService.js
+++ b/server/src/services/submissionService.js
@@ -205,7 +205,11 @@ class SubmissionService {
     const submission = await models.TaskSubmission.findByPk(submissionId, {
       include: [{
         model: models.AssignedTask,
-        as: 'assignedTask'
+        as: 'assignedTask',
+        include: [{
+          model: models.RoadmapTask,
+          as: 'roadmapTask'
+        }]
       }]
     });
 
@@ -238,6 +242,24 @@ class SubmissionService {
       throw new ValidationError('Rating must be between 0 and 5');
     }
 
+    const maxPoints = task.roadmapTask?.pointsBase ?? 10;
+
+    if (isApproved && pointsAwarded !== undefined && pointsAwarded !== null) {
+      const parsedPoints = Number(pointsAwarded);
+
+      if (!Number.isFinite(parsedPoints)) {
+        throw new ValidationError('Points awarded must be a valid number');
+      }
+
+      if (parsedPoints < 0) {
+        throw new ValidationError('Points awarded cannot be less than 0');
+      }
+
+      if (parsedPoints > maxPoints) {
+        throw new ValidationError(`Points awarded cannot be greater than maximum marks ${maxPoints}`);
+      }
+    }
+
     // Create feedback
     const feedbackType = inlineFeedback && inlineFeedback.length > 0 ? 'both' : 'general';
     
@@ -268,10 +290,9 @@ class SubmissionService {
 
     if (isApproved) {
       updateData.completedAt = new Date();
-      const maxPoints = task.roadmapTask?.pointsBase ?? 10;
       const parsedPoints = Number(pointsAwarded);
       const safePoints = Number.isFinite(parsedPoints) ? parsedPoints : maxPoints;
-      updateData.pointsAwarded = Math.min(Math.max(0, safePoints), maxPoints);
+      updateData.pointsAwarded = safePoints;
     } else {
       updateData.revisionCount = task.revisionCount + 1;
     }


### PR DESCRIPTION
## Description
This PR fixes a bug in the mentor task review workflow where the "Points Awarded" input field in the approval modal always defaults to a hardcoded value of 10 instead of using the dynamic base points value (roadmapTask.pointsBase) configured for that task in the program's roadmap.

<!-- What does this PR change and why? -->
Changed the useMentorTaskFeedback hook to correctly read the data from api response from the backend and display correct points sent by the backend instead of using hardcoded value of 10.

## Related Issue

<!-- Closes #36   -->

## Type of Change

- [+] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [+] I ran lint checks for impacted app(s)
- [+] I ran build checks for impacted app(s)
- [+] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

<!-- Add before/after screenshots or a short screen recording for frontend changes -->
Before:

The response from api was not being correctly handled and a hardcoded value "10" was shown in the modal by default.

Corrected the property mapping: instead of trying to read taskData.pointsBase directly (which is undefined on AssignedTask), we now read taskData.roadmapTask.pointsBase with safe if statement.


<img width="1920" height="890" alt="image" src="https://github.com/user-attachments/assets/f98cc537-2f65-4f66-a5f2-9f96d70d183d" />

After: The points modal now shows the response sent by the backend api and handles it correctly and shows it in the frontend see image below for reference
<img width="1920" height="890" alt="image" src="https://github.com/user-attachments/assets/2bfdac4f-6e91-4118-bc82-eb91abc3b7aa" />


