### PR TITLE
Replace alert box with responsive modal in roadmap generator

### DIFF
--- a/client-interface/app/admin/programs/[id]/roadmap/page.tsx
+++ b/client-interface/app/admin/programs/[id]/roadmap/page.tsx
@@ -17,16 +17,17 @@ import {
   Loader2
 } from 'lucide-react';
 import { useProgramRoadmap } from '@/lib/hooks/admin';
+import { GenerateConfirmModal } from '@/components/admin/programs';
 
 export default function RoadmapGenerator() {
   const router = useRouter();
   const {
     id, isGenerating, loading, roadmap, roadmapId, levels,
     selectedLevelId, selectedLevel, editingWeek, taskModal, taskForm, savingTask,
-    weekModal, weekForm, savingWeek,
+    weekModal, weekForm, savingWeek, generateConfirmModal,
     setSelectedLevelId, setEditingWeek, setTaskModal, setTaskForm,
     setWeekModal, setWeekForm,
-    handleLevelChange, handleGenerateRoadmap,
+    handleLevelChange, handleGenerateRoadmap, confirmGenerateRoadmap, cancelGenerateRoadmap,
     openAddWeekModal, openEditWeek, handleSaveWeek,
     openAddTask, openEditTask, handleSaveTask,
     deleteTask, deleteWeek,
@@ -535,6 +536,22 @@ export default function RoadmapGenerator() {
           </div>
         </div>
       )}
+
+      {/* Generate Confirmation Modal */}
+      <GenerateConfirmModal
+        isOpen={generateConfirmModal.isOpen}
+        isLoading={isGenerating}
+        title="Generate AI Roadmap"
+        message={
+          generateConfirmModal.hasExistingRoadmap
+            ? 'This will replace the existing roadmap. All manual edits to this roadmap will be overwritten. Do you want to continue?'
+            : 'Generate an AI-powered learning roadmap for this level?'
+        }
+        confirmText="Generate"
+        cancelText="Cancel"
+        onConfirm={confirmGenerateRoadmap}
+        onCancel={cancelGenerateRoadmap}
+      />
 
       {/* Save Actions */}
       <div className="mt-8 flex justify-end gap-4">

--- a/client-interface/components/admin/programs/GenerateConfirmModal.tsx
+++ b/client-interface/components/admin/programs/GenerateConfirmModal.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { X, Loader2, AlertCircle } from 'lucide-react';
+
+interface GenerateConfirmModalProps {
+  isOpen: boolean;
+  isLoading?: boolean;
+  message: string;
+  title?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+export function GenerateConfirmModal({
+  isOpen,
+  isLoading = false,
+  message,
+  title = 'Confirm Action',
+  onConfirm,
+  onCancel,
+  confirmText = 'Generate',
+  cancelText = 'Cancel',
+}: GenerateConfirmModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl w-full max-w-md shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between p-6 border-b border-slate-200">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-amber-100 rounded-lg flex items-center justify-center">
+              <AlertCircle className="w-6 h-6 text-amber-600" />
+            </div>
+            <h2 className="text-slate-900 font-semibold text-lg">{title}</h2>
+          </div>
+          <button
+            onClick={onCancel}
+            disabled={isLoading}
+            className="p-2 hover:bg-slate-100 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <X className="w-5 h-5 text-slate-500" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6">
+          <p className="text-slate-600 text-sm leading-relaxed">{message}</p>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 p-6 border-t border-slate-200 bg-slate-50 rounded-b-2xl">
+          <button
+            onClick={onCancel}
+            disabled={isLoading}
+            className="px-4 py-2 bg-white hover:bg-slate-50 border border-slate-200 text-slate-700 rounded-lg text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {cancelText}
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="px-4 py-2 bg-linear-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 disabled:from-indigo-400 disabled:to-purple-400 text-white rounded-lg text-sm transition-colors flex items-center gap-2 disabled:cursor-not-allowed"
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Generating...
+              </>
+            ) : (
+              confirmText
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client-interface/components/admin/programs/index.ts
+++ b/client-interface/components/admin/programs/index.ts
@@ -1,1 +1,2 @@
 export { ProgramListCard } from './ProgramListCard';
+export { GenerateConfirmModal } from './GenerateConfirmModal';

--- a/client-interface/lib/hooks/admin/useProgramRoadmap.ts
+++ b/client-interface/lib/hooks/admin/useProgramRoadmap.ts
@@ -60,6 +60,11 @@ export interface WeekModalState {
   week?: RoadmapWeek;
 }
 
+interface GenerateConfirmState {
+  isOpen: boolean;
+  hasExistingRoadmap: boolean;
+}
+
 interface UseProgramRoadmapReturn {
   id: string;
   isGenerating: boolean;
@@ -76,6 +81,7 @@ interface UseProgramRoadmapReturn {
   weekModal: WeekModalState | null;
   weekForm: WeekForm;
   savingWeek: boolean;
+  generateConfirmModal: GenerateConfirmState;
   setSelectedLevelId: (id: string) => void;
   setEditingWeek: (week: number | null) => void;
   setTaskModal: (modal: TaskModalState | null) => void;
@@ -83,7 +89,9 @@ interface UseProgramRoadmapReturn {
   setWeekModal: (modal: WeekModalState | null) => void;
   setWeekForm: React.Dispatch<React.SetStateAction<WeekForm>>;
   handleLevelChange: (levelId: string) => void;
-  handleGenerateRoadmap: () => Promise<void>;
+  handleGenerateRoadmap: () => void;
+  confirmGenerateRoadmap: () => Promise<void>;
+  cancelGenerateRoadmap: () => void;
   openAddWeekModal: () => void;
   openEditWeek: (week: RoadmapWeek) => void;
   handleSaveWeek: () => Promise<void>;
@@ -116,6 +124,10 @@ export function useProgramRoadmap(): UseProgramRoadmapReturn {
   const [weekModal, setWeekModal] = useState<WeekModalState | null>(null);
   const [weekForm, setWeekForm] = useState<WeekForm>({ title: '', objectives: [], objectiveInput: '' });
   const [savingWeek, setSavingWeek] = useState(false);
+  const [generateConfirmModal, setGenerateConfirmModal] = useState<GenerateConfirmState>({
+    isOpen: false,
+    hasExistingRoadmap: false,
+  });
 
   const fetchRoadmap = useCallback(async (levelId?: string) => {
     const lvlId = levelId ?? selectedLevelId;
@@ -199,12 +211,18 @@ export function useProgramRoadmap(): UseProgramRoadmapReturn {
     router.push(`/admin/programs/${id}/roadmap?level=${levelId}`);
   }, [id, router]);
 
-  const handleGenerateRoadmap = useCallback(async () => {
-    if (!selectedLevelId) { toast.error('Please select a level first'); return; }
-    const ok = confirm(roadmap.length > 0
-      ? 'This will replace the existing roadmap. Continue?'
-      : 'Generate AI roadmap for this level?');
-    if (!ok) return;
+  const handleGenerateRoadmap = useCallback(() => {
+    if (!selectedLevelId) { 
+      toast.error('Please select a level first'); 
+      return; 
+    }
+    setGenerateConfirmModal({
+      isOpen: true,
+      hasExistingRoadmap: roadmap.length > 0,
+    });
+  }, [selectedLevelId, roadmap.length]);
+
+  const confirmGenerateRoadmap = useCallback(async () => {
     try {
       setIsGenerating(true);
       const response = (await programManagementApi.roadmaps.generate(
@@ -221,8 +239,13 @@ export function useProgramRoadmap(): UseProgramRoadmapReturn {
       toast.error(extractApiErrorMessage(err, 'Failed to generate roadmap'));
     } finally {
       setIsGenerating(false);
+      setGenerateConfirmModal({ isOpen: false, hasExistingRoadmap: false });
     }
-  }, [id, selectedLevelId, roadmap.length, fetchRoadmap]);
+  }, [id, selectedLevelId, fetchRoadmap]);
+
+  const cancelGenerateRoadmap = useCallback(() => {
+    setGenerateConfirmModal({ isOpen: false, hasExistingRoadmap: false });
+  }, []);
 
   const openAddWeekModal = useCallback(() => {
     if (!roadmapId) { toast.error('Roadmap not found. Please generate a roadmap first.'); return; }
@@ -327,8 +350,10 @@ export function useProgramRoadmap(): UseProgramRoadmapReturn {
   return {
     id, isGenerating, loading, roadmap, roadmapId, levels, selectedLevelId, selectedLevel,
     editingWeek, taskModal, taskForm, savingTask, weekModal, weekForm, savingWeek,
+    generateConfirmModal,
     setSelectedLevelId: setSelectedLevelIdRaw, setEditingWeek, setTaskModal, setTaskForm,
-    setWeekModal, setWeekForm, handleLevelChange, handleGenerateRoadmap, openAddWeekModal,
-    openEditWeek, handleSaveWeek, openAddTask, openEditTask, handleSaveTask, deleteTask, deleteWeek,
+    setWeekModal, setWeekForm, handleLevelChange, handleGenerateRoadmap, confirmGenerateRoadmap,
+    cancelGenerateRoadmap, openAddWeekModal, openEditWeek, handleSaveWeek, openAddTask, openEditTask, 
+    handleSaveTask, deleteTask, deleteWeek,
   };
 }

--- a/server/src/services/groqService.js
+++ b/server/src/services/groqService.js
@@ -128,7 +128,21 @@ class GroqService {
         console.error('Response status:', error.response.status);
         console.error('Response data:', error.response.data);
       }
-      throw new ValidationError(`Failed to generate roadmap: ${error.message}`);
+       
+      // Handle specific API errors with user-friendly messages
+      let userMessage = `Failed to generate roadmap: ${error.message}`;
+      
+      if (error.message.includes('413') || error.message.includes('Request too large')) {
+        userMessage = 'Roadmap generation request is too large. Please try with fewer weeks or simpler requirements.';
+      } else if (error.message.includes('429') || error.message.includes('rate limit')) {
+        userMessage = 'Too many requests. Please wait a moment and try again.';
+      } else if (error.message.includes('401') || error.message.includes('Unauthorized')) {
+        userMessage = 'API authentication failed. Please check your Groq API key.';
+      } else if (error.message.includes('500') || error.message.includes('Internal Server Error')) {
+        userMessage = 'Groq service is temporarily unavailable. Please try again later.';
+      }
+      
+      throw new ValidationError(userMessage);
     }
   }
 


### PR DESCRIPTION
##  Description
Replaces the native browser `confirm()` dialog with a custom, responsive modal component 
in the AI roadmap generator. The new modal matches our design system and provides better UX.

##  Changes Made

### Components
-  Created `GenerateConfirmModal.tsx` - Professional confirmation modal component
  - Responsive design (mobile, tablet, desktop)
  - Dynamic messaging based on generation context
  - Loading state with spinner indicator
  - Matches existing modal styling (Tailwind CSS)

### Hooks
-  Updated `useProgramRoadmap.ts` 
  - Added modal state management (`generateConfirmModal`)
  - Split generate logic: `handleGenerateRoadmap()` opens modal, `confirmGenerateRoadmap()` executes
  - Added `cancelGenerateRoadmap()` handler
  - Maintains all existing functionality

### Pages
- 📄 Updated roadmap generator page
  - Imported and integrated `GenerateConfirmModal`
  - Connected modal handlers to page logic
  - Dynamic messages: "Replace existing" vs "Generate new"

## 🎨 UI/UX Improvements
- ✅ Consistent design with app theme (indigo/purple gradient buttons)
- ✅ Mobile-responsive modal implementation
- ✅ Clear messaging for user confirmation
- ✅ Professional loading state during API calls
- ✅ Better accessibility compared to native alert

## 🧪 Testing
- Modal appears when clicking "Generate with AI"
- Shows different message for replacement scenario
- Confirm button triggers generation
- Cancel button dismisses modal
- Loading state shows during generation
- Modal closes after generation completes

## 📸 Preview
Modal features:
- Icon + Title header
- Descriptive message body
- Cancel & Generate buttons
- Loading spinner during generation
- Shadow & rounded corners for depth

---

**Related Issue:** #53 
**Type:** Enhancement
**Breaking Changes:** None

Before:
<img width="1360" height="428" alt="alr" src="https://github.com/user-attachments/assets/d65095d8-0e85-4125-ba33-34ac51574c71" />


After:
<img width="849" height="481" alt="image" src="https://github.com/user-attachments/assets/d9d436d5-692d-47ca-8388-fed2014721ba" />
