### PR TITLE
fix(#36): use AI-generated pointsBase instead of hardcoded default 10

### DIFF
--- a/client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts
+++ b/client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts
@@ -61,7 +61,7 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
   const [feedbackText, setFeedbackText] = useState('');
   const [revisionNotes, setRevisionNotes] = useState('');
   const [decision, setDecision] = useState<'approve' | 'revision' | null>(null);
-  const [pointsAwarded, setPointsAwarded] = useState(10);
+  const [pointsAwarded, setPointsAwarded] = useState(0);
   const [inlineFeedback, setInlineFeedback] = useState<InlineFeedbackItem[]>([]);
 
   const [error, setError] = useState('');
@@ -80,9 +80,11 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
         if (taskData.submissions && taskData.submissions.length > 0) {
           setSubmission(taskData.submissions[0]);
         }
-        if (taskData.pointsBase) {
-          setPointsAwarded(taskData.pointsBase);
-        }
+        // ✅ Fix: correct path + nullish coalescing
+      const pointsBase = taskData?.roadmapTask?.pointsBase ?? 0;
+      if (pointsBase > 0) {
+        setPointsAwarded(pointsBase);
+      }
       } catch (err: unknown) {
         setError(extractApiErrorMessage(err, 'Failed to load task'));
       } finally {

--- a/client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts
+++ b/client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts
@@ -143,10 +143,27 @@ export function useMentorTaskFeedback(taskId: string): UseMentorTaskFeedbackRetu
         setRevisionError('Revision notes are required when requesting a revision.');
         hasError = true;
       }
-      if (hasError) return;
+   // AFTER (add points validation):
+if (hasError) return;
 
-      setIsSubmitting(true);
-      try {
+   // NEW: Validate points cannot exceed task base
+if (decision === 'approve' && task?.roadmapTask) {
+  const maxPoints = task.roadmapTask.pointsBase ?? 10;
+  
+  if (pointsAwarded > maxPoints) {
+    setDecisionError(`Points cannot exceed the task base of ${maxPoints}. You can only decrease or keep it equal.`);
+    hasError = true;
+  }
+  if (pointsAwarded < 0) {
+    setDecisionError('Points cannot be negative.');
+    hasError = true;
+  }
+}
+
+if (hasError) return;
+
+setIsSubmitting(true);
+try {
         const validInlineFeedback = inlineFeedback
           .filter((item) => item.comment.trim())
           .map((item) => ({ line: 0, comment: item.comment, type: item.type }));

--- a/server/src/services/groqService.js
+++ b/server/src/services/groqService.js
@@ -206,6 +206,11 @@ Create a ${levelDuration}-week roadmap with:
 5. Define clear acceptance criteria for each task
 6. Specify deliverables (what the learner should submit)
 7. Include a weekly milestone
+8. Assign points to each task based on type and difficulty
+  - reading/video: 5 points
+  - exercise/quiz: 10 points
+  - assignment: 15 points
+  - project: 20-30 points (scale with difficulty)
 
 **Task Types:**
 - reading: Reading articles, documentation, books
@@ -243,7 +248,8 @@ Respond with this exact structure:
           "estimatedHours": 5,
           "orderIndex": 1,
           "acceptanceCriteria": ["criteria 1", "criteria 2"],
-          "deliverable": "What to submit"
+          "deliverable": "What to submit",
+          "points": 10
         }
       ]
     }
@@ -256,7 +262,8 @@ CRITICAL RULES:
 - NO explanations before or after the JSON
 - Ensure all quotes are properly escaped
 - Make sure all strings are complete (no unterminated strings)
-- Keep descriptions concise (max 200 characters each)`;
+- Keep descriptions concise (max 200 characters each)
+- "points" must reflect task type and difficulty, NOT a fixed value`
   }
 
   /**
@@ -281,7 +288,8 @@ CRITICAL RULES:
         acceptanceCriteria: Array.isArray(task.acceptanceCriteria) 
           ? task.acceptanceCriteria 
           : [],
-        estimatedHours: parseInt(task.estimatedHours) || 5
+        estimatedHours: parseInt(task.estimatedHours) || 5,
+        points: parseInt(task.points) || 10
       })) || []
     }));
 

--- a/server/src/services/roadmapService.js
+++ b/server/src/services/roadmapService.js
@@ -71,7 +71,8 @@ class RoadmapService {
             estimatedHours: taskData.estimatedHours || 5,
             taskOrder: taskData.orderIndex || 1,
             acceptanceCriteria: taskData.acceptanceCriteria || [],
-            deliverable: taskData.deliverable || 'Task completion'
+            deliverable: taskData.deliverable || 'Task completion',
+            pointsBase: taskData.points || 10 
           });
         }
       }
@@ -379,7 +380,8 @@ class RoadmapService {
               estimatedHours: sourceTask.estimatedHours,
               taskOrder: sourceTask.taskOrder || sourceTask.orderIndex || 1,
               acceptanceCriteria: sourceTask.acceptanceCriteria,
-              deliverable: sourceTask.deliverable || 'Complete the assigned task'
+              deliverable: sourceTask.deliverable || 'Complete the assigned task',
+              pointsBase: sourceTask.pointsBase || 10
             });
           }
         }
@@ -441,7 +443,8 @@ class RoadmapService {
               estimatedHours: taskData.estimatedHours || 5,
               taskOrder: taskData.taskOrder || taskData.orderIndex || 1,
               acceptanceCriteria: taskData.acceptanceCriteria || [],
-              deliverable: taskData.deliverable || 'Task completion'
+              deliverable: taskData.deliverable || 'Task completion',
+              pointsBase: taskData.pointsBase || taskData.points || 10 
             });
           }
         }

--- a/server/src/services/taskService.js
+++ b/server/src/services/taskService.js
@@ -512,8 +512,21 @@ class TaskService {
     };
 
     if (status === 'completed') {
-      updateData.completedAt = new Date();
-      updateData.pointsAwarded = pointsAwarded || task.roadmapTask?.pointsBase || 10;
+     updateData.completedAt = new Date();
+  const maxPoints = task.roadmapTask?.pointsBase || 10;
+  
+  // Validation: mentor cannot increase points above task base
+  if (Number.isFinite(pointsAwarded)) {
+    if (pointsAwarded > maxPoints) {
+      throw new ValidationError(`Points cannot exceed task base of ${maxPoints}`);
+    }
+    if (pointsAwarded < 0) {
+      throw new ValidationError('Points cannot be negative');
+    }
+    updateData.pointsAwarded = pointsAwarded;
+  } else {
+    updateData.pointsAwarded = maxPoints; // Default to task base
+  }
     } else if (status === 'revision_needed') {
       updateData.revisionCount = task.revisionCount + 1;
     }


### PR DESCRIPTION
## Description

## Main Issue: #36 - Mentor Approval Points Defaults to 10

### Fixes issue #36:

The mentor approval points input always showed `10` as the default value instead of the actual `roadmapTask.pointsBase` from the API. This was caused by two separate bugs across the frontend and backend that needed to be fixed together.
Additionally, this PR adds **points validation** to ensure mentors can only **decrease or maintain** task points, not increase them above the task's base points.

### Why This Matters

1. **Initial Fix (PR #55 Part 1)**: Points now default to AI-generated `roadmapTask.pointsBase` instead of hardcoded `10`
2. **New Feature (PR #55 Extended)**: Mentors cannot award more points than the task base
   - Example: If task base = 60 points, mentor can award 0-60, but NOT 61+
   - Ensures fair and consistent grading across mentees

## Why Both Fixes in One PR?

The frontend fix alone would not fully solve the issue because the backend was also storing `10` for every task regardless of difficulty — the AI was never instructed to generate meaningful points. Fixing only the UI would mean the correct path `taskData.roadmapTask.pointsBase` would still return `10` from the DB. Both layers needed to be fixed together for the issue to be truly resolved.
Additionally, without points validation, mentors could bypass the system by increasing points manually, defeating the purpose of AI-generated point values.


## Backend (Root Cause)

### Problems Found

1. Groq AI prompt never instructed to generate `points` per task — so AI never included them in the response
2. `validateAndFormatRoadmap` in `groqService.js` was stripping `points` from AI response before it reached the service layer
3. `generateRoadmap` in `roadmapService.js` never passed `pointsBase` when saving tasks to DB — so model `defaultValue: 10` was always used for every task
4. `cloneRoadmap` never copied `pointsBase` from source tasks when cloning a roadmap
5. `createRoadmap` never accepted `pointsBase` from manual input data

### Solution

## `groqService.js`:
- Added requirement to AI prompt — points assigned by task type:
  - `reading/video: 5 points`
  - `exercise/quiz: 10 points`
  - `assignment: 15 points`
  - `project: 20-30 points (scale with difficulty)`
- Added `"points"` field to JSON output format so AI knows to include it in response
- Added critical rule — `"points"` must reflect task type and difficulty, NOT a fixed value
- Added `points: parseInt(task.points) || 10` in `validateAndFormatRoadmap` to preserve AI-generated points

## `roadmapService.js`:
- Added `pointsBase: taskData.points || 10` in `generateRoadmap` — AI points now saved to DB
- Added `pointsBase: sourceTask.pointsBase || 10` in `cloneRoadmap` — points preserved when cloning
- Added `pointsBase: taskData.pointsBase || taskData.points || 10` in `createRoadmap` — manual tasks now accept points from input

## Screenshots — Backend Before: All tasks have points_base = 10

### Inside DataBase 


https://github.com/user-attachments/assets/492945a3-51dd-4689-8b61-1578b87d2e50



### Inside UI


https://github.com/user-attachments/assets/f53d986c-dc7b-4266-9867-971089ed23c3





## Screenshots — Backend After: Varied points based on task type and difficulty ✅

### Inside DataBase


https://github.com/user-attachments/assets/88ee2895-d327-45cb-93cb-d984aee4651b



### Inside UI

<img width="1351" height="533" alt="solve ui" src="https://github.com/user-attachments/assets/99433054-c4b4-488f-90c0-83debc2a488a" />


## Frontend (Issue #36 — Directly Reported)

### Problems Found

1. `useState(10)` on line 64 of `useMentorTaskFeedback.ts` hardcoded the default points value
2. Wrong API path used — `taskData.pointsBase` does not exist; the correct path is `taskData.roadmapTask.pointsBase`
3. Points input never reflected the actual task value from the API response even when it was present

### Solution

## `useMentorTaskFeedback.ts`:

- Changed `useState(10)` → `useState(0)` — no hardcoded default
- Fixed API path: `taskData.pointsBase` → `taskData.roadmapTask?.pointsBase ?? 0`
- Points input now correctly initializes from API response after async data loads
- `[taskId]` was already in `useEffect` dependency array — task switching works correctly ✅

## Screenshots 
### Frontend Before: Points input always defaults to 10

https://github.com/user-attachments/assets/37421ac1-6c40-4cac-9830-66e4ae3f576c


### Frontend After: Points input shows correct roadmapTask.pointsBase value ✅


https://github.com/user-attachments/assets/81a6165a-1c19-48be-95c7-ba36dda96c3b

## Complete Solution (Backend to Frontend)


https://github.com/user-attachments/assets/1ba6952c-1163-4c30-aa63-37ea94fcf422


## Points Validation Fix

## Backend 

## `taskService.js`: **[NEW]**
- Added points validation in `reviewTask()` method:
  - Extract `maxPoints = task.roadmapTask?.pointsBase || 10`
  - Check `if (pointsAwarded > maxPoints)` → throw ValidationError
  - Check `if (pointsAwarded < 0)` → throw ValidationError
  - Prevents mentors from awarding more than task base value
  - Allows full range: 0 to maxPoints (decrease or maintain, but not increase)

## Frontend 

## `useMentorTaskFeedback.ts`:**[NEW]:**
- In `handleSubmit()`, before `setIsSubmitting(true)`:
  - Extract `maxPoints = task.roadmapTask?.pointsBase ?? 10`
  - Check `if (pointsAwarded > maxPoints)` → show user-friendly error
  - Check `if (pointsAwarded < 0)` → show user-friendly error
  - Error message: `"Points cannot exceed the task base of {maxPoints}. You can only decrease or keep it equal."`
  - Prevents invalid submission before reaching backend

## **Validation Flow:**
1. Mentor enters points in input field
2. Frontend validates before submission → shows error if > maxPoints
3. Mentor corrects input
4. Frontend sends valid data to backend
5. Backend validates again (defense-in-depth)
6. Task completed with correct points (0 to maxPoints)

## Screenshots


https://github.com/user-attachments/assets/dd95dd15-61e7-4f39-8428-49d4c63185e4



## Testing Verified

- ✅ Points input reflects `roadmapTask.pointsBase` correctly (e.g., `20` instead of `10`)
- ✅ No hardcoded `useState(10)` remains in UI logic
- ✅ Works correctly after page refresh
- ✅ Works correctly when switching between different tasks
- ✅ AI now generates varied points based on task type and difficulty
- ✅ DB stores correct points per task — not all `10`
- ✅ Cloned roadmaps preserve original task points
- ✅ **[NEW]** Frontend prevents mentor from entering points > task base
- ✅ **[NEW]** Backend rejects mentor attempts to increase points above task base
- ✅ **[NEW]** Mentor can award 0 to maxPoints (decrease or maintain)
- ✅ **[NEW]** Negative points rejected on both frontend and backend

## Files Modified

- `client-interface/lib/hooks/mentor/useMentorTaskFeedback.ts`
  - Fixed `useState(10)` → `useState(0)`
  - Fixed wrong API path to `taskData.roadmapTask?.pointsBase ?? 0`
  - **[NEW]** Added points validation before submit

- `server/src/services/groqService.js`
  - Added points generation rules to AI prompt
  - Added `"points"` field to JSON output format
  - Added critical rule for dynamic points
  - Preserved `points` in `validateAndFormatRoadmap`

- `server/src/services/roadmapService.js`
  - Added `pointsBase` in `generateRoadmap`
  - Added `pointsBase` in `cloneRoadmap`
  - Added `pointsBase` in `createRoadmap`

- `server/src/services/taskService.js` **[NEW]**
  - Added points validation in `reviewTask()` method
  - Prevents points from exceeding task base
  - Rejects negative points

## Related Issue

Closes #36

## Type of Change

- [x] Bug fix
- [x] Validation/Security enhancement
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor


## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [x] I updated documentation where needed
- [x] Backend validation added (defense-in-depth)
- [x] Frontend validation added (user-friendly errors)
- [x] Tested points decrease scenario (valid)
- [x] Tested points increase scenario (invalid - rejected)
- [x] Tested negative points (invalid - rejected)


## Notes for Maintainers

The frontend fix (Issue #36) depends on the backend fix to work correctly end-to-end. Without the backend changes, `roadmapTask.pointsBase` would still return `10` for every task in the API response since the AI was never generating real values and the DB always stored the model default. Both fixes are minimal, targeted, and introduce no new dependencies or breaking changes.

**NEW:** Points validation has been added on both frontend and backend to ensure mentors cannot increase points above the task's AI-generated base value. This maintains fairness and consistency in grading. Frontend validation provides immediate user feedback, while backend validation serves as a security layer. Safe to merge. ✅