### PR TITLE
Feat/email template redesign

### DIFF
--- a/client-interface/app/admin/analytics/page.tsx
+++ b/client-interface/app/admin/analytics/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { AnalyticsDashboard } from '@/components/admin/analytics';
+
+export default function AnalyticsPage() {
+  return <AnalyticsDashboard />;
+}

--- a/client-interface/components/admin/analytics/AnalyticsDashboard.tsx
+++ b/client-interface/components/admin/analytics/AnalyticsDashboard.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Users,
+  UserCheck,
+  BookOpen,
+  BarChart3,
+  Link2,
+  TrendingUp,
+  Loader2,
+  RefreshCw
+} from 'lucide-react';
+import { useAnalyticsOverview } from '@/lib/hooks/admin';
+import { KPICard } from './KPICard';
+import { EnrollmentPipeline } from './EnrollmentPipeline';
+import { EnrollmentDonutChart } from './EnrollmentDonutChart';
+import { MatchDistributionChart } from './MatchDistributionChart';
+import { MetricGaugesPanel } from './MetricGaugesPanel';
+import { SystemHealthRadar } from './SystemHealthRadar';
+import { UserDistributionChart } from './UserDistributionChart';
+
+export function AnalyticsDashboard() {
+  const { data, loading, error, refetch } = useAnalyticsOverview();
+  const router = useRouter();
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="flex flex-col items-center gap-3">
+          <Loader2 className="w-8 h-8 animate-spin text-indigo-600" />
+          <p className="text-sm text-slate-500">Loading analytics...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="p-6 bg-rose-50 border border-rose-200 rounded-2xl">
+        <p className="text-rose-700 font-medium">Failed to load analytics</p>
+        <p className="text-rose-600 text-sm mt-1">{error}</p>
+        <button
+          onClick={refetch}
+          className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-rose-100 text-rose-700 rounded-xl hover:bg-rose-200 transition-colors text-sm font-medium"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="p-6 bg-slate-50 border border-slate-200 rounded-2xl text-center">
+        <p className="text-slate-500">No analytics data available</p>
+      </div>
+    );
+  }
+
+  const completedMatches = Math.max(
+    0,
+    data.matches.totalMatches - data.matches.activeMatches - data.matches.pendingMatches
+  );
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">Analytics Dashboard</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            Last updated: {new Date(data.lastUpdated).toLocaleTimeString()}
+          </p>
+        </div>
+        <button
+          onClick={refetch}
+          disabled={loading}
+          className="inline-flex items-center gap-2 px-4 py-2.5 bg-white border border-slate-200 text-slate-700 rounded-xl hover:bg-slate-50 transition-colors text-sm font-medium disabled:opacity-50"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+        <KPICard
+          title="Active Mentors"
+          value={data.mentors.totalMentors}
+          subtitle={`${data.mentors.activeMatches} active matches`}
+          icon={UserCheck}
+          iconColor="blue"
+          onClick={() => router.push('/admin/users/mentors')}
+        />
+
+        <KPICard
+          title="Active Mentees"
+          value={data.mentees.totalMentees}
+          subtitle={`${data.mentees.avgProgress}% avg progress`}
+          icon={Users}
+          iconColor="green"
+          onClick={() => router.push('/admin/users/mentees')}
+        />
+
+        <KPICard
+          title="Published Programs"
+          value={data.programs.publishedPrograms}
+          subtitle={`${data.programs.completionRate}% completion rate`}
+          icon={BookOpen}
+          iconColor="indigo"
+          onClick={() => router.push('/admin/programs/list')}
+        />
+
+        <KPICard
+          title="Total Enrollments"
+          value={data.enrollments.total}
+          subtitle={`${data.enrollments.byStatus.active || 0} active`}
+          icon={BarChart3}
+          iconColor="purple"
+          onClick={() => router.push('/admin/enrollment/overview')}
+        />
+
+        <KPICard
+          title="Mentor Matches"
+          value={data.matches.activeMatches}
+          subtitle={`${data.matches.pendingMatches} pending`}
+          icon={Link2}
+          iconColor="orange"
+          onClick={() => router.push('/admin/matching/mentor-assignment')}
+        />
+
+        <KPICard
+          title="Engagement Score"
+          value={`${data.mentees.engagementScore}%`}
+          subtitle={`Satisfaction: ${data.matches.avgSatisfaction}/5`}
+          icon={TrendingUp}
+          iconColor="rose"
+        />
+      </div>
+
+      {/* Row 2: Charts (Radar, User Distribution, Match Distribution) */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        <SystemHealthRadar 
+          mentorUtilization={data.mentors.utilization}
+          menteeEngagement={data.mentees.engagementScore}
+          menteeProgress={data.mentees.avgProgress}
+          programCompletion={data.programs.completionRate}
+          mentorRating={data.mentors.avgRating}
+          matchSatisfaction={data.matches.avgSatisfaction}
+        />
+        
+        <UserDistributionChart 
+          totalMentors={data.mentors.totalMentors}
+          activeMentors={data.mentors.activeMatches}
+          totalMentees={data.mentees.totalMentees}
+          activeMentees={data.mentees.activeEnrollments}
+        />
+
+        <MatchDistributionChart
+          totalMatches={data.matches.totalMatches}
+          activeMatches={data.matches.activeMatches}
+          pendingMatches={data.matches.pendingMatches}
+          completedMatches={completedMatches}
+          cancelledMatches={0}
+          avgSatisfaction={data.matches.avgSatisfaction}
+        />
+      </div>
+
+      {/* Row 3: Enrollments (Donut + Pipeline) */}
+      <div className="space-y-5">
+        <EnrollmentDonutChart
+          byStatus={data.enrollments.byStatus}
+          total={data.enrollments.total}
+        />
+        <EnrollmentPipeline byStatus={data.enrollments.byStatus} />
+      </div>
+
+      {/* Row 4: Metric Gauges Panels */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        <MetricGaugesPanel
+          title="Mentor Performance"
+          gauges={[
+            {
+              value: parseFloat(data.mentors.avgRating),
+              maxValue: 5,
+              label: 'Avg Rating',
+              color: '#3b82f6',
+            },
+            {
+              value: data.mentors.utilization,
+              maxValue: 100,
+              label: 'Utilization',
+              color: '#8b5cf6',
+            },
+          ]}
+          stats={[
+            { label: 'Total Mentors', value: data.mentors.totalMentors },
+            { label: 'Active Matches', value: data.mentors.activeMatches, color: 'text-emerald-600' },
+          ]}
+        />
+
+        <MetricGaugesPanel
+          title="Program Health"
+          gauges={[
+            {
+              value: data.programs.completionRate,
+              maxValue: 100,
+              label: 'Completion',
+              color: '#6366f1',
+            },
+            {
+              value: data.programs.totalPrograms > 0
+                ? Math.round((data.programs.publishedPrograms / data.programs.totalPrograms) * 100)
+                : 0,
+              maxValue: 100,
+              label: 'Published',
+              color: '#10b981',
+            },
+          ]}
+          stats={[
+            {
+              label: 'Total Programs',
+              value: `${data.programs.publishedPrograms} / ${data.programs.totalPrograms}`,
+            },
+            { label: 'Draft Programs', value: data.programs.draftPrograms, color: 'text-amber-600' },
+          ]}
+        />
+
+        <MetricGaugesPanel
+          title="Mentee Progress"
+          gauges={[
+            {
+              value: data.mentees.avgProgress,
+              maxValue: 100,
+              label: 'Avg Progress',
+              color: '#10b981',
+            },
+            {
+              value: data.mentees.engagementScore,
+              maxValue: 100,
+              label: 'Engagement',
+              color: '#f43f5e',
+            },
+          ]}
+          stats={[
+            { label: 'Active Enrollments', value: data.mentees.activeEnrollments },
+            { label: 'Total Mentees', value: data.mentees.totalMentees },
+          ]}
+        />
+      </div>
+    </div>
+  );
+}

--- a/client-interface/components/admin/analytics/EnrollmentDonutChart.tsx
+++ b/client-interface/components/admin/analytics/EnrollmentDonutChart.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import React from 'react';
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+
+interface EnrollmentDonutChartProps {
+  byStatus: Record<string, number>;
+  total: number;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  pending_approval: '#f59e0b',
+  approved: '#0ea5e9',
+  rejected: '#ef4444',
+  pending_match: '#8b5cf6',
+  matched: '#6366f1',
+  active: '#10b981',
+  pending_completion: '#14b8a6',
+  level_completed: '#3b82f6',
+  program_completed: '#22c55e',
+  dropped: '#94a3b8',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  pending_approval: 'Pending Approval',
+  approved: 'Approved',
+  rejected: 'Rejected',
+  pending_match: 'Pending Match',
+  matched: 'Matched',
+  active: 'Active',
+  pending_completion: 'Pending Completion',
+  level_completed: 'Level Completed',
+  program_completed: 'Completed',
+  dropped: 'Dropped',
+};
+
+const CustomTooltip = ({ active, payload }: any) => {
+  if (active && payload && payload.length) {
+    const entry = payload[0];
+    return (
+      <div className="bg-slate-900 text-white px-3 py-2 rounded-lg shadow-xl text-xs">
+        <p className="font-medium">{entry.name}</p>
+        <p className="text-slate-300 mt-0.5">{entry.value} enrollments</p>
+      </div>
+    );
+  }
+  return null;
+};
+
+export function EnrollmentDonutChart({ byStatus, total }: EnrollmentDonutChartProps) {
+  const chartData = Object.entries(byStatus)
+    .filter(([, count]) => count > 0)
+    .map(([status, count]) => ({
+      name: STATUS_LABELS[status] || status.replace(/_/g, ' '),
+      value: count,
+      color: STATUS_COLORS[status] || '#94a3b8',
+    }));
+
+  if (chartData.length === 0) {
+    return (
+      <div className="bg-white rounded-2xl border border-slate-200 p-6">
+        <h2 className="text-base font-semibold text-slate-900 mb-4">Enrollment Distribution</h2>
+        <p className="text-sm text-slate-500">No enrollment data available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-2xl border border-slate-200 p-6">
+      <h2 className="text-base font-semibold text-slate-900 mb-2">Enrollment Distribution</h2>
+      <div className="flex flex-col lg:flex-row items-center gap-6">
+        <div className="relative w-56 h-56 shrink-0">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                innerRadius={65}
+                outerRadius={95}
+                paddingAngle={3}
+                dataKey="value"
+                strokeWidth={0}
+                animationBegin={0}
+                animationDuration={800}
+              >
+                {chartData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.color} />
+                ))}
+              </Pie>
+              <Tooltip content={<CustomTooltip />} />
+            </PieChart>
+          </ResponsiveContainer>
+          <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+            <span className="text-3xl font-bold text-slate-900">{total}</span>
+            <span className="text-xs text-slate-400 font-medium">Total</span>
+          </div>
+        </div>
+
+        <div className="flex-1 grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-2.5 w-full">
+          {chartData.map((entry) => (
+            <div key={entry.name} className="flex items-center gap-2.5 min-w-0">
+              <div
+                className="w-2.5 h-2.5 rounded-full shrink-0"
+                style={{ backgroundColor: entry.color }}
+              />
+              <div className="min-w-0 flex-1">
+                <p className="text-xs text-slate-500 truncate">{entry.name}</p>
+                <p className="text-sm font-semibold text-slate-900">{entry.value}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client-interface/components/admin/analytics/EnrollmentPipeline.tsx
+++ b/client-interface/components/admin/analytics/EnrollmentPipeline.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React from 'react';
+
+interface EnrollmentPipelineProps {
+  byStatus: Record<string, number>;
+}
+
+const statusConfig: Record<string, { label: string; color: string }> = {
+  pending_approval: { label: 'Pending Approval', color: 'bg-amber-50 text-amber-700 border-amber-200' },
+  approved: { label: 'Approved', color: 'bg-sky-50 text-sky-700 border-sky-200' },
+  rejected: { label: 'Rejected', color: 'bg-rose-50 text-rose-700 border-rose-200' },
+  pending_match: { label: 'Pending Match', color: 'bg-violet-50 text-violet-700 border-violet-200' },
+  matched: { label: 'Matched', color: 'bg-indigo-50 text-indigo-700 border-indigo-200' },
+  active: { label: 'Active', color: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
+  pending_completion: { label: 'Pending Completion', color: 'bg-teal-50 text-teal-700 border-teal-200' },
+  level_completed: { label: 'Level Completed', color: 'bg-blue-50 text-blue-700 border-blue-200' },
+  program_completed: { label: 'Completed', color: 'bg-green-50 text-green-700 border-green-200' },
+  dropped: { label: 'Dropped', color: 'bg-slate-50 text-slate-600 border-slate-200' }
+};
+
+const pipelineOrder = [
+  'pending_approval',
+  'approved',
+  'pending_match',
+  'matched',
+  'active',
+  'pending_completion',
+  'level_completed',
+  'program_completed',
+  'rejected',
+  'dropped'
+];
+
+export function EnrollmentPipeline({ byStatus }: EnrollmentPipelineProps) {
+  const sortedEntries = pipelineOrder
+    .filter(status => byStatus[status] !== undefined)
+    .map(status => ({ status, count: byStatus[status] }));
+
+  const extraEntries = Object.entries(byStatus)
+    .filter(([status]) => !pipelineOrder.includes(status))
+    .map(([status, count]) => ({ status, count }));
+
+  const allEntries = [...sortedEntries, ...extraEntries];
+
+  if (allEntries.length === 0) {
+    return (
+      <div className="bg-white rounded-2xl border border-slate-200 p-6">
+        <h2 className="text-base font-semibold text-slate-900 mb-4">Enrollment Pipeline</h2>
+        <p className="text-sm text-slate-500">No enrollment data available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-2xl border border-slate-200 p-6">
+      <h2 className="text-base font-semibold text-slate-900 mb-4">Enrollment Pipeline</h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+        {allEntries.map(({ status, count }) => {
+          const config = statusConfig[status] || {
+            label: status.replace(/_/g, ' '),
+            color: 'bg-slate-50 text-slate-600 border-slate-200'
+          };
+          return (
+            <div
+              key={status}
+              className={`rounded-xl border px-4 py-3 transition-all duration-150 hover:shadow-sm ${config.color}`}
+            >
+              <p className="text-xs font-medium opacity-80 mb-1 capitalize">{config.label}</p>
+              <p className="text-xl font-bold">{count}</p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client-interface/components/admin/analytics/KPICard.tsx
+++ b/client-interface/components/admin/analytics/KPICard.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React from 'react';
+import { type LucideIcon, TrendingUp, TrendingDown } from 'lucide-react';
+
+interface KPICardProps {
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  icon: LucideIcon;
+  iconColor: 'indigo' | 'green' | 'blue' | 'purple' | 'orange' | 'rose';
+  trend?: {
+    value: number;
+    isPositive: boolean;
+  };
+  onClick?: () => void;
+}
+
+const colorMap: Record<string, string> = {
+  indigo: 'text-indigo-600 bg-indigo-50',
+  green: 'text-emerald-600 bg-emerald-50',
+  blue: 'text-blue-600 bg-blue-50',
+  purple: 'text-purple-600 bg-purple-50',
+  orange: 'text-amber-600 bg-amber-50',
+  rose: 'text-rose-600 bg-rose-50'
+};
+
+const iconBorderMap: Record<string, string> = {
+  indigo: 'border-indigo-100',
+  green: 'border-emerald-100',
+  blue: 'border-blue-100',
+  purple: 'border-purple-100',
+  orange: 'border-amber-100',
+  rose: 'border-rose-100'
+};
+
+export function KPICard({
+  title,
+  value,
+  subtitle,
+  icon: Icon,
+  iconColor,
+  trend,
+  onClick
+}: KPICardProps) {
+  return (
+    <div
+      onClick={onClick}
+      className={`group relative bg-white rounded-2xl border border-slate-200 p-6 transition-all duration-200 hover:shadow-lg hover:shadow-slate-100 hover:-translate-y-0.5 ${
+        onClick ? 'cursor-pointer' : ''
+      }`}
+    >
+      <div className="flex items-start justify-between mb-4">
+        <div className={`p-3 rounded-xl border ${colorMap[iconColor]} ${iconBorderMap[iconColor]}`}>
+          <Icon className="w-5 h-5" />
+        </div>
+        {trend && (
+          <div className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${
+            trend.isPositive
+              ? 'bg-emerald-50 text-emerald-700'
+              : 'bg-rose-50 text-rose-700'
+          }`}>
+            {trend.isPositive ? (
+              <TrendingUp className="w-3 h-3" />
+            ) : (
+              <TrendingDown className="w-3 h-3" />
+            )}
+            {trend.value}%
+          </div>
+        )}
+      </div>
+
+      <p className="text-sm font-medium text-slate-500 mb-1">{title}</p>
+      <p className="text-3xl font-bold text-slate-900 tracking-tight">{value}</p>
+
+      {subtitle && (
+        <p className="text-xs text-slate-400 mt-2">{subtitle}</p>
+      )}
+    </div>
+  );
+}

--- a/client-interface/components/admin/analytics/MatchDistributionChart.tsx
+++ b/client-interface/components/admin/analytics/MatchDistributionChart.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+
+interface MatchDistributionChartProps {
+  totalMatches: number;
+  activeMatches: number;
+  pendingMatches: number;
+  completedMatches: number;
+  cancelledMatches: number;
+  avgSatisfaction: string;
+}
+
+const COLORS = {
+  active: '#10b981',
+  pending: '#f59e0b',
+  completed: '#6366f1',
+  cancelled: '#94a3b8',
+};
+
+const CustomTooltip = ({ active, payload }: any) => {
+  if (active && payload && payload.length) {
+    const entry = payload[0];
+    return (
+      <div className="bg-slate-900 text-white px-3 py-2 rounded-lg shadow-xl text-xs">
+        <p className="font-medium">{entry.payload.label}</p>
+        <p className="text-slate-300 mt-0.5">{entry.value} matches</p>
+      </div>
+    );
+  }
+  return null;
+};
+
+export function MatchDistributionChart({
+  totalMatches,
+  activeMatches,
+  pendingMatches,
+  completedMatches,
+  cancelledMatches,
+  avgSatisfaction,
+}: MatchDistributionChartProps) {
+  const chartData = [
+    { label: 'Active', value: activeMatches, color: COLORS.active },
+    { label: 'Pending', value: pendingMatches, color: COLORS.pending },
+    { label: 'Completed', value: completedMatches, color: COLORS.completed },
+    { label: 'Cancelled', value: cancelledMatches, color: COLORS.cancelled },
+  ].filter((d) => d.value > 0);
+
+  return (
+    <div className="bg-white rounded-2xl border border-slate-200 p-6">
+      <div className="flex items-start justify-between mb-5">
+        <div>
+          <h3 className="text-base font-semibold text-slate-900">Match Distribution</h3>
+          <p className="text-xs text-slate-400 mt-0.5">{totalMatches} total matches</p>
+        </div>
+        <div className="text-right">
+          <p className="text-2xl font-bold text-slate-900">{avgSatisfaction}</p>
+          <p className="text-xs text-slate-400">Avg Satisfaction</p>
+        </div>
+      </div>
+
+      {chartData.length > 0 ? (
+        <div className="h-52">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} barSize={36} margin={{ top: 0, right: 0, left: -20, bottom: 0 }}>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                vertical={false}
+                stroke="#f1f5f9"
+              />
+              <XAxis
+                dataKey="label"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 12, fill: '#94a3b8' }}
+              />
+              <YAxis
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 11, fill: '#94a3b8' }}
+                allowDecimals={false}
+              />
+              <Tooltip content={<CustomTooltip />} cursor={{ fill: '#f8fafc', radius: 8 }} />
+              <Bar dataKey="value" radius={[8, 8, 0, 0]} animationDuration={700}>
+                {chartData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.color} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <div className="h-52 flex items-center justify-center">
+          <p className="text-sm text-slate-400">No match data available</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client-interface/components/admin/analytics/MetricGaugesPanel.tsx
+++ b/client-interface/components/admin/analytics/MetricGaugesPanel.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import React from 'react';
+import {
+  RadialBarChart,
+  RadialBar,
+  ResponsiveContainer,
+  PolarAngleAxis,
+} from 'recharts';
+
+interface RadialGaugeProps {
+  value: number;
+  maxValue?: number;
+  label: string;
+  color: string;
+  size?: number;
+}
+
+function RadialGauge({ value, maxValue = 100, label, color, size = 100 }: RadialGaugeProps) {
+  const percentage = Math.min((value / maxValue) * 100, 100);
+  const data = [{ value: percentage, fill: color }];
+
+  return (
+    <div className="flex flex-col items-center">
+      <div style={{ width: size, height: size }} className="relative">
+        <ResponsiveContainer width="100%" height="100%">
+          <RadialBarChart
+            cx="50%"
+            cy="50%"
+            innerRadius="75%"
+            outerRadius="100%"
+            data={data}
+            startAngle={90}
+            endAngle={-270}
+            barSize={8}
+          >
+            <PolarAngleAxis type="number" domain={[0, 100]} tick={false} angleAxisId={0} />
+            <RadialBar
+              dataKey="value"
+              cornerRadius={12}
+              background={{ fill: '#f1f5f9' }}
+              animationDuration={800}
+            />
+          </RadialBarChart>
+        </ResponsiveContainer>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="text-lg font-bold text-slate-900">
+            {maxValue === 5 ? value : `${Math.round(value)}%`}
+          </span>
+        </div>
+      </div>
+      <p className="text-xs text-slate-500 mt-1.5 text-center font-medium">{label}</p>
+    </div>
+  );
+}
+
+interface MetricGaugesPanelProps {
+  title: string;
+  gauges: Array<{
+    value: number;
+    maxValue?: number;
+    label: string;
+    color: string;
+  }>;
+  stats: Array<{
+    label: string;
+    value: string | number;
+    color?: string;
+  }>;
+}
+
+export function MetricGaugesPanel({ title, gauges, stats }: MetricGaugesPanelProps) {
+  return (
+    <div className="bg-white rounded-2xl border border-slate-200 p-6">
+      <h3 className="text-base font-semibold text-slate-900 mb-5">{title}</h3>
+
+      <div className="flex items-center justify-center gap-6 mb-5">
+        {gauges.map((gauge) => (
+          <RadialGauge
+            key={gauge.label}
+            value={gauge.value}
+            maxValue={gauge.maxValue}
+            label={gauge.label}
+            color={gauge.color}
+          />
+        ))}
+      </div>
+
+      <div className="border-t border-slate-100 pt-4 space-y-2.5">
+        {stats.map((stat) => (
+          <div key={stat.label} className="flex items-center justify-between">
+            <span className="text-sm text-slate-500">{stat.label}</span>
+            <span className={`text-sm font-semibold ${stat.color || 'text-slate-900'}`}>
+              {stat.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client-interface/components/admin/analytics/SystemHealthRadar.tsx
+++ b/client-interface/components/admin/analytics/SystemHealthRadar.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import React from 'react';
+import {
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+
+interface SystemHealthRadarProps {
+  mentorUtilization: number;
+  menteeEngagement: number;
+  menteeProgress: number;
+  programCompletion: number;
+  mentorRating: string | number;
+  matchSatisfaction: string | number;
+}
+
+const CustomTooltip = ({ active, payload }: any) => {
+  if (active && payload && payload.length) {
+    const data = payload[0].payload;
+    return (
+      <div className="bg-slate-900 text-white px-3 py-2 rounded-lg shadow-xl text-xs border border-slate-700">
+        <p className="font-semibold mb-1 text-slate-100">{data.subject}</p>
+        <p className="text-indigo-300">
+          Score: <span className="text-white font-medium">{data.rawScore}</span>
+        </p>
+        <p className="text-slate-400 mt-0.5 text-[10px]">Normalized: {data.fullMark}%</p>
+      </div>
+    );
+  }
+  return null;
+};
+
+export function SystemHealthRadar({
+  mentorUtilization,
+  menteeEngagement,
+  menteeProgress,
+  programCompletion,
+  mentorRating,
+  matchSatisfaction,
+}: SystemHealthRadarProps) {
+  // Normalize ratings (out of 5) to percentages (out of 100)
+  const normMentorRating = Math.min(100, (parseFloat(String(mentorRating)) / 5) * 100);
+  const normMatchSatisfaction = Math.min(100, (parseFloat(String(matchSatisfaction)) / 5) * 100);
+
+  const data = [
+    {
+      subject: 'Utilization',
+      fullMark: Math.round(mentorUtilization),
+      rawScore: `${Math.round(mentorUtilization)}%`,
+    },
+    {
+      subject: 'Engagement',
+      fullMark: Math.round(menteeEngagement),
+      rawScore: `${Math.round(menteeEngagement)}%`,
+    },
+    {
+      subject: 'Progress',
+      fullMark: Math.round(menteeProgress),
+      rawScore: `${Math.round(menteeProgress)}%`,
+    },
+    {
+      subject: 'Completion',
+      fullMark: Math.round(programCompletion),
+      rawScore: `${Math.round(programCompletion)}%`,
+    },
+    {
+      subject: 'Mentor Rating',
+      fullMark: Math.round(normMentorRating),
+      rawScore: `${parseFloat(String(mentorRating)).toFixed(1)}/5.0`,
+    },
+    {
+      subject: 'Satisfaction',
+      fullMark: Math.round(normMatchSatisfaction),
+      rawScore: `${parseFloat(String(matchSatisfaction)).toFixed(1)}/5.0`,
+    },
+  ];
+
+  return (
+    <div className="bg-white rounded-2xl border border-slate-200 p-6 flex flex-col">
+      <div className="mb-2">
+        <h3 className="text-base font-semibold text-slate-900">System Health Overview</h3>
+        <p className="text-xs text-slate-500 mt-1">Normalized metrics across all modules</p>
+      </div>
+      
+      <div className="flex-1 min-h-[250px] -mx-4">
+        <ResponsiveContainer width="100%" height="100%">
+          <RadarChart cx="50%" cy="50%" outerRadius="70%" data={data}>
+            <PolarGrid stroke="#e2e8f0" />
+            <PolarAngleAxis 
+              dataKey="subject" 
+              tick={{ fill: '#64748b', fontSize: 11, fontWeight: 500 }} 
+            />
+            <PolarRadiusAxis angle={30} domain={[0, 100]} tick={false} axisLine={false} />
+            <Radar
+              name="Health Score"
+              dataKey="fullMark"
+              stroke="#6366f1"
+              strokeWidth={2}
+              fill="#818cf8"
+              fillOpacity={0.4}
+              animationDuration={1200}
+            />
+            <Tooltip content={<CustomTooltip />} />
+          </RadarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/client-interface/components/admin/analytics/UserDistributionChart.tsx
+++ b/client-interface/components/admin/analytics/UserDistributionChart.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+
+interface UserDistributionChartProps {
+  totalMentors: number;
+  activeMentors: number; // For mentors, active matches can be a proxy, or just use total if we don't have 'active' status distinct
+  totalMentees: number;
+  activeMentees: number; // For mentees, active enrollments
+}
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="bg-white border border-slate-200 px-3 py-2 rounded-lg shadow-lg text-xs">
+        <p className="font-semibold text-slate-900 mb-1">{label}</p>
+        {payload.map((entry: any, index: number) => (
+          <div key={index} className="flex items-center gap-2 mt-1">
+            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: entry.color }} />
+            <span className="text-slate-600">{entry.name}:</span>
+            <span className="font-medium text-slate-900">{entry.value}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return null;
+};
+
+export function UserDistributionChart({
+  totalMentors,
+  activeMentors,
+  totalMentees,
+  activeMentees,
+}: UserDistributionChartProps) {
+  const data = [
+    {
+      name: 'Mentors',
+      Total: totalMentors,
+      Active: activeMentors,
+    },
+    {
+      name: 'Mentees',
+      Total: totalMentees,
+      Active: activeMentees,
+    },
+  ];
+
+  return (
+    <div className="bg-white rounded-2xl border border-slate-200 p-6 flex flex-col">
+      <div className="mb-6">
+        <h3 className="text-base font-semibold text-slate-900">User Distribution</h3>
+        <p className="text-xs text-slate-500 mt-1">Total vs Active users by role</p>
+      </div>
+
+      <div className="flex-1 min-h-[200px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={data}
+            layout="vertical"
+            margin={{ top: 0, right: 20, left: 0, bottom: 0 }}
+            barGap={4}
+          >
+            <CartesianGrid strokeDasharray="3 3" horizontal={true} vertical={false} stroke="#f1f5f9" />
+            <XAxis type="number" hide />
+            <YAxis 
+              dataKey="name" 
+              type="category" 
+              axisLine={false} 
+              tickLine={false} 
+              tick={{ fill: '#475569', fontSize: 12, fontWeight: 500 }} 
+              width={60}
+            />
+            <Tooltip content={<CustomTooltip />} cursor={{ fill: '#f8fafc' }} />
+            <Legend 
+              iconType="circle" 
+              wrapperStyle={{ fontSize: '12px', paddingTop: '10px' }} 
+            />
+            <Bar 
+              dataKey="Total" 
+              fill="#cbd5e1" 
+              radius={[0, 4, 4, 0]} 
+              barSize={16} 
+              animationDuration={1000} 
+            />
+            <Bar 
+              dataKey="Active" 
+              fill="#3b82f6" 
+              radius={[0, 4, 4, 0]} 
+              barSize={16} 
+              animationDuration={1000} 
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/client-interface/components/admin/analytics/index.ts
+++ b/client-interface/components/admin/analytics/index.ts
@@ -1,0 +1,8 @@
+export { KPICard } from './KPICard';
+export { EnrollmentPipeline } from './EnrollmentPipeline';
+export { EnrollmentDonutChart } from './EnrollmentDonutChart';
+export { MatchDistributionChart } from './MatchDistributionChart';
+export { MetricGaugesPanel } from './MetricGaugesPanel';
+export { SystemHealthRadar } from './SystemHealthRadar';
+export { UserDistributionChart } from './UserDistributionChart';
+export { AnalyticsDashboard } from './AnalyticsDashboard';

--- a/client-interface/lib/config/api.ts
+++ b/client-interface/lib/config/api.ts
@@ -57,5 +57,9 @@ export const apiConfig = {
     // Admin invites
     adminInvites: '/admin/invites',
     revokeAdminInvite: (id: string) => `/admin/invites/${id}/revoke`,
+
+    analyticsOverview: '/admin/analytics/overview',
+    analyticsProgramsList: '/admin/analytics/programs',
+    analyticsMentorsList: '/admin/analytics/mentors',
   },
 };

--- a/client-interface/lib/config/navigation.ts
+++ b/client-interface/lib/config/navigation.ts
@@ -10,6 +10,7 @@ import {
   Settings,
   GraduationCap,
   School,
+  BarChart3,
   type LucideIcon
 } from 'lucide-react';
 import { UserRole } from '@/lib/types';
@@ -32,6 +33,7 @@ export interface NavLink {
 export const navigationConfig: Record<string, NavLink[]> = {
   admin: [
     { path: '/admin/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
+    { path: '/admin/analytics', icon: BarChart3, label: 'Analytics' },
     { path: '/admin/programs/list', icon: BookOpen, label: 'Programs' },
     { path: '/admin/matching/mentor-assignment', icon: UserCheck, label: 'Mentor Matching' },
     { path: '/admin/enrollment/overview', icon: Users, label: 'Enrollments' },

--- a/client-interface/lib/hooks/admin/index.ts
+++ b/client-interface/lib/hooks/admin/index.ts
@@ -61,3 +61,7 @@ export type {
   TaskModalState,
   WeekModalState,
 } from './useProgramRoadmap';
+
+export { useAnalyticsOverview } from './useAnalyticsOverview';
+export type { AnalyticsOverview } from './useAnalyticsOverview';
+

--- a/client-interface/lib/hooks/admin/useAnalyticsOverview.ts
+++ b/client-interface/lib/hooks/admin/useAnalyticsOverview.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { adminApi } from '@/lib/services/admin-api';
+import { extractApiErrorMessage } from '@/lib/utils/api-error';
+import { toast } from 'sonner';
+
+export interface AnalyticsOverview {
+  mentors: {
+    totalMentors: number;
+    activeMatches: number;
+    avgRating: string;
+    utilization: number;
+  };
+  mentees: {
+    totalMentees: number;
+    activeEnrollments: number;
+    avgProgress: number;
+    engagementScore: number;
+  };
+  programs: {
+    totalPrograms: number;
+    publishedPrograms: number;
+    completionRate: number;
+    draftPrograms: number;
+  };
+  enrollments: {
+    total: number;
+    byStatus: Record<string, number>;
+  };
+  matches: {
+    totalMatches: number;
+    activeMatches: number;
+    pendingMatches: number;
+    avgSatisfaction: string;
+  };
+  lastUpdated: string;
+}
+
+interface UseAnalyticsOverviewReturn {
+  data: AnalyticsOverview | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export function useAnalyticsOverview(): UseAnalyticsOverviewReturn {
+  const [data, setData] = useState<AnalyticsOverview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchOverview = useCallback(async () => {
+    try {
+      setLoading(true);
+      const response = await adminApi.analytics.getOverview();
+      setData(response as AnalyticsOverview);
+      setError(null);
+    } catch (err: unknown) {
+      const message = extractApiErrorMessage(err, 'Failed to load analytics');
+      setError(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchOverview();
+
+    const interval = setInterval(fetchOverview, 60000);
+
+    return () => clearInterval(interval);
+  }, [fetchOverview]);
+
+  return { data, loading, error, refetch: fetchOverview };
+}

--- a/client-interface/lib/services/admin-api.ts
+++ b/client-interface/lib/services/admin-api.ts
@@ -6,5 +6,19 @@ export const adminApi = {
       const response = await apiClient.get('/admin/dashboard/stats');
       return response.data;
     }
+  },
+  analytics: {
+    getOverview: async () => {
+      const response = await apiClient.get('/admin/analytics/overview');
+      return response.data;
+    },
+    getProgramsList: async (params?: { page?: number; limit?: number; search?: string }) => {
+      const response = await apiClient.get('/admin/analytics/programs', { params });
+      return response.data;
+    },
+    getMentorsList: async (params?: { page?: number; limit?: number }) => {
+      const response = await apiClient.get('/admin/analytics/mentors', { params });
+      return response.data;
+    }
   }
 };

--- a/server/src/controllers/analyticsController.js
+++ b/server/src/controllers/analyticsController.js
@@ -1,0 +1,42 @@
+const analyticsService = require('../services/analyticsService');
+const { successResponse } = require('../utils/responses');
+const { catchAsync } = require('../middlewares/errorHandler');
+
+class AnalyticsController {
+  getOverview = catchAsync(async (req, res) => {
+    const overview = await analyticsService.getSystemOverview();
+
+    res.status(200).json(
+      successResponse('Analytics overview retrieved', overview)
+    );
+  });
+
+  getProgramsList = catchAsync(async (req, res) => {
+    const { page = 1, limit = 20, search } = req.query;
+
+    const programs = await analyticsService.getProgramsList({
+      page: parseInt(page),
+      limit: parseInt(limit),
+      search
+    });
+
+    res.status(200).json(
+      successResponse('Programs list retrieved', programs)
+    );
+  });
+
+  getMentorsList = catchAsync(async (req, res) => {
+    const { page = 1, limit = 20 } = req.query;
+
+    const mentors = await analyticsService.getMentorsList({
+      page: parseInt(page),
+      limit: parseInt(limit)
+    });
+
+    res.status(200).json(
+      successResponse('Mentors list retrieved', mentors)
+    );
+  });
+}
+
+module.exports = new AnalyticsController();

--- a/server/src/routes/analytics.js
+++ b/server/src/routes/analytics.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const router = express.Router();
+const analyticsController = require('../controllers/analyticsController');
+const { authenticate, authorize } = require('../middlewares/auth');
+
+router.get(
+  '/overview',
+  authenticate,
+  authorize('admin'),
+  analyticsController.getOverview
+);
+
+router.get(
+  '/programs',
+  authenticate,
+  authorize('admin'),
+  analyticsController.getProgramsList
+);
+
+router.get(
+  '/mentors',
+  authenticate,
+  authorize('admin'),
+  analyticsController.getMentorsList
+);
+
+module.exports = router;

--- a/server/src/routes/index.js
+++ b/server/src/routes/index.js
@@ -17,6 +17,7 @@ const profileRoutes = require('./profile');
 const skillRoutes = require('./skills');
 const messagingRoutes = require('./messaging');
 const gamificationRoutes = require('./gamification');
+const analyticsRoutes = require('./analytics');
 
 /**
  * API Routes
@@ -40,6 +41,7 @@ router.use('/skills', skillRoutes);
 
 // Admin routes (protected)
 router.use('/admin', adminRoutes);
+router.use('/admin/analytics', analyticsRoutes);
 
 // Program routes (includes nested level and roadmap routes)
 router.use('/programs', programRoutes);

--- a/server/src/services/analyticsService.js
+++ b/server/src/services/analyticsService.js
@@ -1,0 +1,288 @@
+const { Op } = require('sequelize');
+const { sequelize, models } = require('../db');
+
+class AnalyticsService {
+  async getSystemOverview() {
+    const [mentors, mentees, programs, enrollments, matches] =
+      await Promise.all([
+        this.getMentorStats(),
+        this.getMenteeStats(),
+        this.getProgramStats(),
+        this.getEnrollmentStats(),
+        this.getMatchingStats()
+      ]);
+
+    return {
+      mentors,
+      mentees,
+      programs,
+      enrollments,
+      matches,
+      lastUpdated: new Date()
+    };
+  }
+
+  async getMentorStats() {
+    const [total, avgRating, currentMatches] = await Promise.all([
+      models.User.count({
+        where: { role: 'mentor', status: 'active' }
+      }),
+      models.MentorProfile.findOne({
+        attributes: [
+          [sequelize.fn('AVG', sequelize.col('avg_feedback_rating')), 'rating']
+        ],
+        raw: true
+      }),
+      models.MentorMenteeMatch.count({
+        where: { status: 'active' }
+      })
+    ]);
+
+    return {
+      totalMentors: total,
+      activeMatches: currentMatches,
+      avgRating: parseFloat(avgRating?.rating || 0).toFixed(1),
+      utilization: total > 0 ? Math.round((currentMatches / (total * 5)) * 100) : 0
+    };
+  }
+
+  async getMenteeStats() {
+    const [total, avgProgress, activeEnrollments, engagementScore] = await Promise.all([
+      models.User.count({
+        where: { role: 'mentee', status: 'active' }
+      }),
+      models.MenteeAnalytics.findOne({
+        attributes: [
+          [sequelize.fn('AVG', sequelize.col('overall_progress_percentage')), 'avg']
+        ],
+        raw: true
+      }),
+      models.Enrollment.count({
+        where: { status: { [Op.in]: ['active', 'matched'] } }
+      }),
+      this.#calculateEngagementScore()
+    ]);
+
+    return {
+      totalMentees: total,
+      activeEnrollments,
+      avgProgress: Math.round(parseFloat(avgProgress?.avg || 0)),
+      engagementScore
+    };
+  }
+
+  async getProgramStats() {
+    const [total, published, completionRate] = await Promise.all([
+      models.Program.count(),
+      models.Program.count({
+        where: { status: 'published' }
+      }),
+      models.Enrollment.findOne({
+        attributes: [
+          [sequelize.fn('AVG', sequelize.col('overall_progress_percentage')), 'avg']
+        ],
+        where: { status: { [Op.in]: ['program_completed', 'level_completed'] } },
+        raw: true
+      })
+    ]);
+
+    return {
+      totalPrograms: total,
+      publishedPrograms: published,
+      completionRate: Math.round(parseFloat(completionRate?.avg || 0)),
+      draftPrograms: total - published
+    };
+  }
+
+  async getEnrollmentStats() {
+    const result = await models.Enrollment.findAll({
+      attributes: [
+        'status',
+        [sequelize.fn('COUNT', sequelize.col('id')), 'count']
+      ],
+      group: ['status'],
+      raw: true
+    });
+
+    const counts = {};
+    result.forEach(r => {
+      counts[r.status] = parseInt(r.count);
+    });
+
+    return {
+      total: Object.values(counts).reduce((a, b) => a + b, 0),
+      byStatus: counts
+    };
+  }
+
+  async getMatchingStats() {
+    const [total, active, pending, avgSatisfaction] = await Promise.all([
+      models.MentorMenteeMatch.count(),
+      models.MentorMenteeMatch.count({
+        where: { status: 'active' }
+      }),
+      models.MentorMenteeMatch.count({
+        where: { status: 'pending' }
+      }),
+      models.MentorMenteeMatch.findOne({
+        attributes: [
+          [sequelize.fn('AVG', sequelize.col('mentee_satisfaction_rating')), 'avg']
+        ],
+        raw: true
+      })
+    ]);
+
+    return {
+      totalMatches: total,
+      activeMatches: active,
+      pendingMatches: pending,
+      avgSatisfaction: parseFloat(avgSatisfaction?.avg || 0).toFixed(1)
+    };
+  }
+
+  async getProgramsList({ page = 1, limit = 20, search } = {}) {
+    const offset = (page - 1) * limit;
+    const where = {};
+
+    if (search) {
+      where.name = { [Op.iLike]: `%${search}%` };
+    }
+
+    const { rows, count } = await models.Program.findAndCountAll({
+      where,
+      include: [
+        {
+          model: models.Enrollment,
+          as: 'enrollments',
+          attributes: ['id', 'status', 'overallProgressPercentage']
+        }
+      ],
+      order: [['createdAt', 'DESC']],
+      limit,
+      offset,
+      distinct: true
+    });
+
+    const programs = rows.map(program => {
+      const enrollments = program.enrollments || [];
+      const activeEnrollments = enrollments.filter(e =>
+        ['active', 'matched'].includes(e.status)
+      );
+      const completedEnrollments = enrollments.filter(e =>
+        ['program_completed', 'level_completed'].includes(e.status)
+      );
+      const avgProgress = enrollments.length > 0
+        ? Math.round(
+            enrollments.reduce((sum, e) => sum + parseFloat(e.overallProgressPercentage || 0), 0) /
+            enrollments.length
+          )
+        : 0;
+
+      return {
+        id: program.id,
+        name: program.name,
+        type: program.type,
+        status: program.status,
+        totalEnrollments: enrollments.length,
+        activeEnrollments: activeEnrollments.length,
+        completedEnrollments: completedEnrollments.length,
+        completionRate: enrollments.length > 0
+          ? Math.round((completedEnrollments.length / enrollments.length) * 100)
+          : 0,
+        avgProgress,
+        createdAt: program.createdAt
+      };
+    });
+
+    return {
+      programs,
+      pagination: {
+        page,
+        limit,
+        totalItems: count,
+        totalPages: Math.ceil(count / limit)
+      }
+    };
+  }
+
+  async getMentorsList({ page = 1, limit = 20 } = {}) {
+    const offset = (page - 1) * limit;
+
+    const { rows, count } = await models.User.findAndCountAll({
+      where: { role: 'mentor', status: 'active' },
+      include: [
+        {
+          model: models.MentorProfile,
+          as: 'mentorProfile',
+          attributes: [
+            'specialization',
+            'currentMenteeCount',
+            'maxMentees',
+            'avgFeedbackRating',
+            'avgResponseTimeHours',
+            'successRate',
+            'totalMenteesGuided'
+          ]
+        }
+      ],
+      attributes: ['id', 'firstName', 'lastName', 'email', 'createdAt'],
+      order: [['createdAt', 'DESC']],
+      limit,
+      offset
+    });
+
+    const mentors = rows.map(mentor => ({
+      id: mentor.id,
+      name: `${mentor.firstName} ${mentor.lastName}`,
+      email: mentor.email,
+      specialization: mentor.mentorProfile?.specialization || [],
+      currentMenteeCount: mentor.mentorProfile?.currentMenteeCount || 0,
+      maxMentees: mentor.mentorProfile?.maxMentees || 5,
+      avgRating: parseFloat(mentor.mentorProfile?.avgFeedbackRating || 0).toFixed(1),
+      avgResponseTimeHours: parseFloat(mentor.mentorProfile?.avgResponseTimeHours || 0).toFixed(1),
+      successRate: parseFloat(mentor.mentorProfile?.successRate || 0).toFixed(0),
+      totalMenteesGuided: mentor.mentorProfile?.totalMenteesGuided || 0,
+      joinedAt: mentor.createdAt
+    }));
+
+    return {
+      mentors,
+      pagination: {
+        page,
+        limit,
+        totalItems: count,
+        totalPages: Math.ceil(count / limit)
+      }
+    };
+  }
+
+  async #calculateEngagementScore() {
+    const activeUsers = await models.User.count({
+      where: { status: 'active' }
+    });
+
+    if (activeUsers === 0) return 0;
+
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    let recentActivity = 0;
+    try {
+      recentActivity = await models.AnalyticsEvent.count({
+        where: {
+          createdAt: { [Op.gte]: oneDayAgo }
+        }
+      });
+    } catch {
+      const recentLogins = await models.User.count({
+        where: {
+          lastLoginAt: { [Op.gte]: oneDayAgo }
+        }
+      });
+      return Math.min(100, Math.round((recentLogins / activeUsers) * 100));
+    }
+
+    return Math.min(100, Math.round((recentActivity / activeUsers) * 100));
+  }
+}
+
+module.exports = new AnalyticsService();

--- a/server/src/services/notificationOrchestrator.js
+++ b/server/src/services/notificationOrchestrator.js
@@ -105,7 +105,6 @@ class NotificationOrchestrator {
           });
         }
       }
-
     }
 
     return { delivered, skipped };
@@ -146,7 +145,26 @@ class NotificationOrchestrator {
         title: 'Welcome to Pathment',
         message: `Welcome ${user.firstName || 'there'}! Your account is now ready.`,
         emailSubject: 'Welcome to Pathment',
-        emailText: `Hi ${user.firstName || ''}, welcome to Pathment. Start your learning journey today.`
+        emailText: `Hi ${user.firstName || ''}, welcome to Pathment. Start your learning journey today.`,
+        emailHtml: `
+          <div style="font-family: 'Inter', 'Segoe UI', sans-serif; background-color: #f8fafc; padding: 40px 20px; margin: 0;">
+            <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 16px; box-shadow: 0 10px 25px rgba(0,0,0,0.05); overflow: hidden;">
+              <div style="background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%); padding: 40px 20px; text-align: center;">
+                <h1 style="color: #ffffff; margin: 0; font-size: 32px; font-weight: 700; letter-spacing: 0.5px;">Pathment</h1>
+              </div>
+              <div style="padding: 40px; color: #334155;">
+                <h2 style="margin-top: 0; color: #0f172a; font-size: 24px;">Welcome aboard, ${user.firstName || 'there'}! 👋</h2>
+                <p style="font-size: 16px; line-height: 1.6; color: #475569;">We are thrilled to have you join Pathment. Get ready to embark on an exciting learning journey with top mentors and structured paths.</p>
+                <div style="text-align: center; margin: 35px 0;">
+                  <a href="${process.env.CLIENT_URL || 'http://localhost:3000'}/login" style="background-color: #3b82f6; color: #ffffff; padding: 14px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 16px; display: inline-block; box-shadow: 0 4px 6px rgba(59, 130, 246, 0.25);">Get Started Now</a>
+                </div>
+              </div>
+              <div style="background-color: #f1f5f9; padding: 24px; text-align: center; border-top: 1px solid #e2e8f0;">
+                <p style="margin: 0; color: #64748b; font-size: 14px;">&copy; ${new Date().getFullYear()} Pathment. All rights reserved.</p>
+              </div>
+            </div>
+          </div>
+        `
       }
     });
   }
@@ -161,10 +179,24 @@ class NotificationOrchestrator {
       subject: 'Reset your Pathment password',
       text: `Hi ${user.firstName || ''}, use this secure link to reset your password: ${resetUrl}`,
       html: `
-        <p>Hi ${user.firstName || 'there'},</p>
-        <p>We received a request to reset your password.</p>
-        <p><a href="${resetUrl}">Reset Password</a></p>
-        <p>If you did not request this, you can ignore this email.</p>
+        <div style="font-family: 'Inter', 'Segoe UI', sans-serif; background-color: #f8fafc; padding: 40px 20px; margin: 0;">
+          <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 16px; box-shadow: 0 10px 25px rgba(0,0,0,0.05); overflow: hidden;">
+            <div style="background: linear-gradient(135deg, #8b5cf6 0%, #6d28d9 100%); padding: 40px 20px; text-align: center;">
+              <h1 style="color: #ffffff; margin: 0; font-size: 32px; font-weight: 700; letter-spacing: 0.5px;">Pathment</h1>
+            </div>
+            <div style="padding: 40px; color: #334155;">
+              <h2 style="margin-top: 0; color: #0f172a; font-size: 24px;">Reset Password 🔒</h2>
+              <p style="font-size: 16px; line-height: 1.6; color: #475569;">Hi ${user.firstName || 'there'}, we received a request to reset your password. It's okay, it happens to the best of us! Click the button below to choose a new one.</p>
+              <div style="text-align: center; margin: 35px 0;">
+                <a href="${resetUrl}" style="background-color: #8b5cf6; color: #ffffff; padding: 14px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 16px; display: inline-block; box-shadow: 0 4px 6px rgba(139, 92, 246, 0.25);">Reset Password</a>
+              </div>
+              <p style="font-size: 14px; color: #64748b; line-height: 1.5; margin-bottom: 0;">If you did not request this, please safely ignore this email.</p>
+            </div>
+            <div style="background-color: #f1f5f9; padding: 24px; text-align: center; border-top: 1px solid #e2e8f0;">
+              <p style="margin: 0; color: #64748b; font-size: 14px;">&copy; ${new Date().getFullYear()} Pathment. All rights reserved.</p>
+            </div>
+          </div>
+        </div>
       `
     });
   }
@@ -179,9 +211,23 @@ class NotificationOrchestrator {
       subject: 'Verify your Pathment email',
       text: `Hi ${user.firstName || ''}, verify your email by opening this link: ${verifyUrl}`,
       html: `
-        <p>Hi ${user.firstName || 'there'},</p>
-        <p>Welcome to Pathment. Please verify your email address to continue.</p>
-        <p><a href="${verifyUrl}">Verify Email</a></p>
+        <div style="font-family: 'Inter', 'Segoe UI', sans-serif; background-color: #f8fafc; padding: 40px 20px; margin: 0;">
+          <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 16px; box-shadow: 0 10px 25px rgba(0,0,0,0.05); overflow: hidden;">
+            <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); padding: 40px 20px; text-align: center;">
+              <h1 style="color: #ffffff; margin: 0; font-size: 32px; font-weight: 700; letter-spacing: 0.5px;">Pathment</h1>
+            </div>
+            <div style="padding: 40px; color: #334155;">
+              <h2 style="margin-top: 0; color: #0f172a; font-size: 24px;">Verify Your Email ✉️</h2>
+              <p style="font-size: 16px; line-height: 1.6; color: #475569;">Hi ${user.firstName || 'there'}, you're almost ready to start! Please click the button below to verify your email address and activate your account.</p>
+              <div style="text-align: center; margin: 35px 0;">
+                <a href="${verifyUrl}" style="background-color: #10b981; color: #ffffff; padding: 14px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 16px; display: inline-block; box-shadow: 0 4px 6px rgba(16, 185, 129, 0.25);">Verify Email Address</a>
+              </div>
+            </div>
+            <div style="background-color: #f1f5f9; padding: 24px; text-align: center; border-top: 1px solid #e2e8f0;">
+              <p style="margin: 0; color: #64748b; font-size: 14px;">&copy; ${new Date().getFullYear()} Pathment. All rights reserved.</p>
+            </div>
+          </div>
+        </div>
       `
     });
   }
@@ -192,10 +238,24 @@ class NotificationOrchestrator {
       subject: `You're invited to join Pathment as a ${role}`,
       text: `You were invited to join Pathment as a ${role}. Use this one-time invite link: ${inviteUrl}`,
       html: `
-        <p>Hello,</p>
-        <p>You were invited to join Pathment as a <strong>${role}</strong>.</p>
-        <p><a href="${inviteUrl}">Accept Invite</a></p>
-        <p>This invite link is one-time use and may expire.</p>
+        <div style="font-family: 'Inter', 'Segoe UI', sans-serif; background-color: #f8fafc; padding: 40px 20px; margin: 0;">
+          <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 16px; box-shadow: 0 10px 25px rgba(0,0,0,0.05); overflow: hidden;">
+            <div style="background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%); padding: 40px 20px; text-align: center;">
+              <h1 style="color: #ffffff; margin: 0; font-size: 32px; font-weight: 700; letter-spacing: 0.5px;">Pathment</h1>
+            </div>
+            <div style="padding: 40px; color: #334155;">
+              <h2 style="margin-top: 0; color: #0f172a; font-size: 24px;">You're Invited! 🎉</h2>
+              <p style="font-size: 16px; line-height: 1.6; color: #475569;">Hello! You have been specially invited to join the Pathment community as a <strong>${role}</strong>. Tap the button below to accept your invitation and set up your profile.</p>
+              <div style="text-align: center; margin: 35px 0;">
+                <a href="${inviteUrl}" style="background-color: #f59e0b; color: #ffffff; padding: 14px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 16px; display: inline-block; box-shadow: 0 4px 6px rgba(245, 158, 11, 0.25);">Accept Invitation</a>
+              </div>
+              <p style="font-size: 14px; color: #64748b; line-height: 1.5; margin-bottom: 0;">Note: This is a secure, one-time use link that may expire.</p>
+            </div>
+            <div style="background-color: #f1f5f9; padding: 24px; text-align: center; border-top: 1px solid #e2e8f0;">
+              <p style="margin: 0; color: #64748b; font-size: 14px;">&copy; ${new Date().getFullYear()} Pathment. All rights reserved.</p>
+            </div>
+          </div>
+        </div>
       `
     });
   }


### PR DESCRIPTION
Issue close: #62 

## What does this PR do?
This PR significantly improves the visual presentation of our automated system emails to provide a better and more professional user experience.

### Email Enhancements (`notificationOrchestrator.js`)
- Replaced plain text email content with modern, responsive HTML templates.
- Added custom linear-gradient headers, improved typography (Inter/Segoe UI), and clear CTA (Call to Action) buttons for:
  - **Welcome Emails** (Blue theme)
  - **Password Reset** (Purple theme)
  - **Email Verification** (Green theme)
  - **Registration Invites** (Orange theme)
- Maintained existing functionality and placeholders for user data.

## How should this be tested?
1. Pull this branch (`feat/Email-template-redesign`) and run `npm run dev` in the `server` directory.
2. Ensure your `server/.env` has a valid `RESEND_API_KEY` and your registered testing email.
3. Trigger an authentication event (e.g., Request a password reset or register a new user).
4. Verify that the received email reflects the new card-based HTML layout.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have tested the new email templates locally
- [x] The templates render correctly on standard email clients
