### PR TITLE
fix: add spacing between UserProfileCard and NotificationDrawer in si…

### DIFF
--- a/client-interface/components/shared/Navigation.tsx
+++ b/client-interface/components/shared/Navigation.tsx
@@ -216,7 +216,7 @@ export default function Navigation({ role }: NavigationProps) {
           {/* Bottom Section */}
           <div className="px-3 py-4 border-t border-slate-100 space-y-1">
             <UserProfileCard />
-            <div className="relative">
+            <div className="relative mt-2">
               {user?.id && (
                 <NotificationDrawer userId={user.id} apiBaseUrl={apiBaseUrl} showLabel />
               )}
@@ -279,4 +279,3 @@ export default function Navigation({ role }: NavigationProps) {
 }
 
 export { Navigation };
-


### PR DESCRIPTION
…debar

## Description
Added `mt-2` class to the NotificationDrawer wrapper div in the Desktop Sidebar bottom section to create clear visual separation between the UserProfileCard (MFA/security card) and the Notifications button.

## Related Issue
Closes #37

## Type of Change
- [x] Bug fix

## Validation Checklist
- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [x] I updated documentation where needed

## Screenshots (Required for UI changes)
Before: MFA card and Notifications button were merged with no spacing.
After: Clear visual separation added between MFA/security card and Notifications button using mt-2 Tailwind class.

<img width="1919" height="1060" alt="After" src="https://github.com/user-attachments/assets/4f4eceb3-2ccf-4830-b5c8-cb087e4ef736" />
<img width="1919" height="1062" alt="before" src="https://github.com/user-attachments/assets/83932f3f-39c8-4d17-9533-e5a670181243" />