### PR TITLE
Fix:  user reference in 2FA verification handling

### DIFF
--- a/client-interface/lib/context/AuthContext.tsx
+++ b/client-interface/lib/context/AuthContext.tsx
@@ -148,16 +148,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       // apiClient.post returns response.data directly
       const responseData = response.data;
+      const currentUser = responseData?.user;
       const accessToken = responseData?.tokens?.accessToken;
       const refreshToken = responseData?.tokens?.refreshToken;
 
-      if (!user || !accessToken || !refreshToken) {
+      if (!currentUser || !accessToken || !refreshToken) {
         throw new Error('Invalid 2FA verification response');
       }
 
       localStorage.setItem('token', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
-      localStorage.setItem('user', JSON.stringify(user));
+      localStorage.setItem('user', JSON.stringify(currentUser));
       
       console.log('2FA verified, tokens stored');
       


### PR DESCRIPTION
# Use API Response Instead of React State for User Variable

## Description

Fixed a critical bug in the `verify2FA` function where 2FA verification could fail even with correct OTP. The issue was caused by validating and storing user data from stale React state instead of the fresh API response.

**Changes:**
- Extract `user` from API response: `const currentUser = responseData?.user`
- Validate using response user: Check `currentUser` instead of state `user`
- Store response user to localStorage: `localStorage.setItem('user', JSON.stringify(currentUser))`

This ensures that valid 2FA verification always succeeds and user data is properly stored from the authentication API response.

## Related Issue

<!-- Example: Closes #48 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Changes Made

**File:** `client-interface/lib/context/AuthContext.tsx`

modified the logic to use the user object received from api response instead of using the user in state variable.

## Validation Checklist

- [-] I ran lint checks for impacted app(s)
  
- [-] I ran build checks for impacted app(s)
  
- [-] I ran tests for impacted app(s), or confirmed no test suite exists for this change
  - Manual testing: Login → 2FA verification with correct OTP → ✅ Success
- [] I updated documentation where needed
 
## Testing Performed

✅ **Manual Testing:**
- Login with valid credentials
- Enter correct 2FA OTP
- Verified no "Invalid 2FA verification response" error
- Confirmed redirect to dashboard
- Checked localStorage contains complete user object (not null/stale)

✅ **Console Verification:**
- "2FA verified, tokens stored" message appears
- No errors in browser console

✅ **DevTools Check:**
- `localStorage.getItem('token')` - ✅ Set
- `localStorage.getItem('refreshToken')` - ✅ Set
- `JSON.parse(localStorage.getItem('user'))` - ✅ Contains user object with id, email, etc.

## Screenshots (Required for UI Changes)


## Additional Notes

- **Root Cause:** React state `user` is null/stale during 2FA verification, but the API response contains fresh user data
- **Impact:** Users with 2FA enabled can now successfully authenticate