### PR TITLE
feat: add GitHub Actions workflow for backend deployment to DigitalOcean

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy Backend
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+    paths:
+      - 'server/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to DigitalOcean
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            # Determine which app to restart based on branch
+            BRANCH="${{ github.ref_name }}"
+
+            if [ "$BRANCH" = "main" ]; then
+              APP_DIR=~/apps/pathment
+              PM2_NAME=pathment-devweekends
+            elif [ "$BRANCH" = "staging" ]; then
+              APP_DIR=~/apps/pathment-staging
+              PM2_NAME=pathment-staging
+            fi
+
+            echo "Deploying branch $BRANCH → $PM2_NAME"
+
+            cd $APP_DIR
+            git pull origin $BRANCH
+
+            cd server
+            npm install --production
+
+            pm2 restart $PM2_NAME
+            pm2 save
+
+            echo "✅ $PM2_NAME deployed successfully"


### PR DESCRIPTION
## Description

<!-- What does this PR change and why? -->

This PR introduces automated CI/CD pipelines for the Pathment backend to eliminate manual deployment steps and improve deployment reliability across staging and production environments.

It enables GitHub Actions-based deployments that automatically trigger on changes to `staging` and `main` branches, connect securely to the DigitalOcean droplet via SSH, and restart PM2 services after pulling the latest code.

This improves:

* deployment speed
* system reliability
* contributor experience
* production safety

---

## Related Issue

Closes #<!-- issue number -->

---

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [x] DevOps / Infrastructure change
* [ ] Documentation update
* [ ] Refactor

---

## Validation Checklist

* [ ] I tested deployment workflow on staging environment
* [ ] I confirmed GitHub Actions pipeline runs successfully
* [ ] I verified SSH-based deployment to DigitalOcean droplet works
* [ ] I confirmed PM2 processes restart correctly after deployment
* [ ] I ensured no manual SSH deployment steps are required anymore
* [ ] I validated staging and production deployments are isolated
* [ ] I checked logs in GitHub Actions for errors or failures

---