### PR TITLE
docs: update contribution guidelines to reflect branch naming and PR …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,11 @@ Thank you for your interest in contributing to Pathment.
    git clone https://github.com/<your-username>/pathment.git
    cd pathment
    ```
-3. **Create a branch** from `main` using the naming rules below.
+3. **Create a branch** from `staging` using the naming rules below.
 4. **Make focused changes** related to a single issue/task.
 5. **Commit** with clear, descriptive messages.
 6. **Push** your branch to your fork.
-7. **Open a Pull Request** against `pathment/pathment:main`.
+7. **Open a Pull Request** against `pathment/pathment:staging`.
 
 ## Branch Naming Convention
 
@@ -117,6 +117,7 @@ When opening a PR:
 - PRs require review from the appropriate code owners.
 - Address review feedback with follow-up commits.
 - Keep CI checks green for impacted projects.
-- Maintainers squash or merge once approvals and checks are complete.
+- Maintainers squash or merge into `staging` once approvals and checks are complete.
+- Changes are promoted from `staging` to `main` by maintainers after validation.
 
 Thank you for helping improve Pathment for the community.


### PR DESCRIPTION
## Description

<!-- What does this PR change and why? -->
PR will change the contributions pr flow from now they can create a pr to the staging not to the main.
## Related Issue

<!-- Example: Closes #123 -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [ ] I ran lint checks for impacted app(s)
- [ ] I ran build checks for impacted app(s)
- [ ] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

<!-- Add before/after screenshots or a short screen recording for frontend changes -->
