### PR TITLE
fix(ui): clarify notification bulk action label

### DIFF
--- a/client-interface/components/shared/NotificationDrawer.tsx
+++ b/client-interface/components/shared/NotificationDrawer.tsx
@@ -410,7 +410,7 @@ export default function NotificationDrawer({
                   onClick={handleMarkAllRead}
                   className="px-3 py-2 text-sm font-medium text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors"
                 >
-                  Mark all
+                  Mark all as read
                 </button>
                 <button
                   onClick={() => {


### PR DESCRIPTION
## Description

Updates the notification drawer bulk action label for clarity and consistency.

Changes the text from "Mark all" to "Mark all as read" to accurately reflect the action being performed.

## Related Issue

Closes #88

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [ ] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

<img width="547" height="1026" alt="Screenshot 2026-05-29 024524" src="https://github.com/user-attachments/assets/44ad3f97-0424-41c8-aa23-61362c44c764" />
