### PR TITLE
feat(marketing): redesign landing page and ground copy in real features

### DIFF
--- a/marketing-site/app/globals.css
+++ b/marketing-site/app/globals.css
@@ -1,18 +1,21 @@
-:root {
-  --bg-1: #060b16;
-  --bg-2: #0c162b;
-  --surface: rgba(14, 24, 45, 0.78);
-  --surface-strong: rgba(11, 20, 40, 0.9);
-  --line: rgba(129, 164, 216, 0.26);
-  --text: #eaf1ff;
-  --muted: #afc2e4;
-  --brand: #58d3ff;
-  --brand-strong: #0ea8de;
-  --accent: #ffbd66;
-}
+@import 'tailwindcss';
 
-* {
-  box-sizing: border-box;
+@theme {
+  --font-sans: var(--font-inter), 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-display: var(--font-instrument), 'Instrument Sans', ui-sans-serif, sans-serif;
+
+  --color-brand-50: #f5f7ff;
+  --color-brand-100: #ebf0ff;
+  --color-brand-200: #dae3ff;
+  --color-brand-500: #2563eb;
+  --color-brand-600: #1d4ed8;
+  --color-brand-700: #1d4ed8;
+  --color-brand-900: #1e3a8a;
+  --color-brand-950: #0f172a;
+
+  --shadow-sm-soft: 0 1px 2px 0 rgba(0, 0, 0, 0.02);
+  --shadow-md-soft: 0 4px 12px -2px rgba(0, 0, 0, 0.03), 0 2px 6px -1px rgba(0, 0, 0, 0.02);
+  --shadow-lg-soft: 0 10px 25px -5px rgba(0, 0, 0, 0.04), 0 8px 16px -6px rgba(0, 0, 0, 0.02);
 }
 
 html,
@@ -22,292 +25,13 @@ body {
 }
 
 body {
-  min-height: 100vh;
-  color: var(--text);
-  font-family: var(--font-body), sans-serif;
-  background:
-    radial-gradient(circle at 12% 6%, rgba(14, 168, 222, 0.2), transparent 34%),
-    radial-gradient(circle at 86% 8%, rgba(255, 189, 102, 0.16), transparent 30%),
-    linear-gradient(165deg, var(--bg-1) 8%, var(--bg-2) 58%, #070e1d 100%);
+  font-family: var(--font-sans);
+  background-color: #fcfcfd;
+  color: #09090b;
+  -webkit-font-smoothing: antialiased;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.landing-shell {
-  padding-bottom: 3rem;
-}
-
-.container {
-  width: min(1140px, 92vw);
-  margin: 0 auto;
-}
-
-.nav-shell {
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  backdrop-filter: blur(8px);
-  background: linear-gradient(180deg, rgba(6, 11, 22, 0.92), rgba(6, 11, 22, 0.65));
-  border-bottom: 1px solid rgba(129, 164, 216, 0.16);
-}
-
-.nav-inner {
-  min-height: 74px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.58rem;
-  font-family: var(--font-display), sans-serif;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-}
-
-.brand-wordmark {
-  font-size: 1rem;
-}
-
-.nav-items {
-  display: flex;
-  align-items: center;
-  gap: 1.15rem;
-}
-
-.nav-link {
-  color: var(--muted);
-  font-size: 0.94rem;
-  transition: color 0.18s ease;
-}
-
-.nav-link:hover {
-  color: var(--text);
-}
-
-.section {
-  padding: 4.25rem 0 0;
-}
-
-.hero {
-  padding-top: 5rem;
-}
-
-.eyebrow,
-.kicker {
-  margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.74rem;
-  color: var(--brand);
-}
-
-.hero h1 {
-  margin: 0.7rem 0 1rem;
-  max-width: 14ch;
-  font-family: var(--font-display), sans-serif;
-  line-height: 0.96;
-  font-size: clamp(2.3rem, 5vw, 4.3rem);
-}
-
-.lead {
-  margin: 0;
-  max-width: 64ch;
-  color: var(--muted);
-  line-height: 1.7;
-  font-size: clamp(1rem, 1.9vw, 1.14rem);
-}
-
-.cta-row {
-  display: flex;
-  align-items: center;
-  gap: 0.72rem;
-  flex-wrap: wrap;
-  margin-top: 1.5rem;
-}
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  font-size: 0.93rem;
-  font-weight: 700;
-  padding: 0.7rem 1.06rem;
-  transition: transform 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
-}
-
-.btn:hover {
-  transform: translateY(-1px);
-}
-
-.btn-primary {
-  background: linear-gradient(128deg, var(--brand), #8ae6ff);
-  color: #063142;
-}
-
-.btn-secondary {
-  border-color: var(--line);
-  background: rgba(8, 16, 33, 0.6);
-}
-
-.section-head h2,
-.panel h2,
-.panel h3,
-.cta-panel h2 {
-  font-family: var(--font-display), sans-serif;
-}
-
-.section-head h2 {
-  margin: 0.65rem 0 1.2rem;
-  max-width: 22ch;
-  font-size: clamp(1.6rem, 3vw, 2.3rem);
-  line-height: 1.1;
-}
-
-.split-grid,
-.card-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.84rem;
-}
-
-.split-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.panel,
-.card {
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 16px;
-  padding: 1.05rem;
-  backdrop-filter: blur(5px);
-}
-
-.panel-accent {
-  background:
-    linear-gradient(155deg, rgba(10, 22, 42, 0.92), rgba(10, 22, 42, 0.68)),
-    radial-gradient(circle at 88% 22%, rgba(88, 211, 255, 0.12), transparent 38%);
-}
-
-.panel h2,
-.panel h3,
-.card h3 {
-  margin: 0.5rem 0 0.65rem;
-  font-size: 1.13rem;
-}
-
-.panel ul,
-.card ul {
-  margin: 0;
-  padding-left: 1.1rem;
-  color: var(--muted);
-  line-height: 1.62;
-}
-
-.card p {
-  margin: 0.5rem 0 0;
-  color: var(--muted);
-  line-height: 1.62;
-}
-
-.card-step {
-  margin: 0;
-  color: var(--brand);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  font-size: 0.82rem;
-}
-
-.cta-panel {
-  border: 1px solid var(--line);
-  border-radius: 22px;
-  padding: 1.35rem;
-  background:
-    linear-gradient(160deg, rgba(9, 19, 38, 0.94), rgba(9, 19, 38, 0.62)),
-    radial-gradient(circle at 0% 0%, rgba(14, 168, 222, 0.16), transparent 45%);
-}
-
-.cta-panel h2 {
-  margin: 0;
-  max-width: 26ch;
-  font-size: clamp(1.6rem, 2.8vw, 2.2rem);
-}
-
-.cta-panel p {
-  margin: 0.7rem 0 0;
-  max-width: 64ch;
-  color: var(--muted);
-  line-height: 1.64;
-}
-
-.footer-shell {
-  margin-top: 2.5rem;
-  border-top: 1px solid rgba(129, 164, 216, 0.2);
-}
-
-.footer-inner {
-  min-height: 82px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.footer-inner p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-
-.hero,
-.section,
-.cta-panel {
-  animation: rise-in 0.48s ease both;
-}
-
-.section {
-  animation-delay: 0.05s;
-}
-
-@keyframes rise-in {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@media (max-width: 980px) {
-  .nav-items {
-    display: none;
-  }
-
-  .split-grid,
-  .card-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .hero h1,
-  .section-head h2 {
-    max-width: 100%;
-  }
-
-  .footer-inner {
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 1rem 0;
-  }
+.grid-pattern {
+  background-image: radial-gradient(#e4e4e7 1px, transparent 1px);
+  background-size: 24px 24px;
 }

--- a/marketing-site/app/globals.css
+++ b/marketing-site/app/globals.css
@@ -2,7 +2,8 @@
 
 @theme {
   --font-sans: var(--font-inter), 'Inter', ui-sans-serif, system-ui, sans-serif;
-  --font-display: var(--font-instrument), 'Instrument Sans', ui-sans-serif, sans-serif;
+  --font-display: var(--font-sora), 'Sora', ui-sans-serif, sans-serif;
+  --font-mono: var(--font-jetbrains), ui-monospace, 'JetBrains Mono', monospace;
 
   --color-brand-50: #f5f7ff;
   --color-brand-100: #ebf0ff;
@@ -24,11 +25,32 @@ body {
   padding: 0;
 }
 
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
 body {
   font-family: var(--font-sans);
   background-color: #fcfcfd;
   color: #09090b;
+  font-feature-settings: 'cv11', 'ss01';
+  letter-spacing: -0.011em;
+  text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Display font: tighter tracking and balanced wrapping for headings */
+.font-display {
+  letter-spacing: -0.025em;
+  font-feature-settings: normal;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  text-wrap: balance;
 }
 
 .grid-pattern {

--- a/marketing-site/app/globals.css
+++ b/marketing-site/app/globals.css
@@ -27,6 +27,19 @@ body {
 
 html {
   -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
+  scroll-padding-top: 5.5rem;
+}
+
+::selection {
+  background-color: rgba(37, 99, 235, 0.16);
+  color: #0f172a;
+}
+
+:where(a, button, [role='button'], [tabindex]):focus-visible {
+  outline: 2px solid var(--color-brand-500);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 body {

--- a/marketing-site/app/layout.tsx
+++ b/marketing-site/app/layout.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from 'next';
-import { Manrope, Sora } from 'next/font/google';
+import { Inter, Instrument_Sans } from 'next/font/google';
 import './globals.css';
 
-const manrope = Manrope({
+const inter = Inter({
   subsets: ['latin'],
-  variable: '--font-body',
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-inter',
 });
 
-const sora = Sora({
+const instrumentSans = Instrument_Sans({
   subsets: ['latin'],
-  variable: '--font-display',
+  variable: '--font-instrument',
 });
 
 export const metadata: Metadata = {
@@ -49,7 +50,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body suppressHydrationWarning className={`${manrope.variable} ${sora.variable}`}>
+      <body suppressHydrationWarning className={`${inter.variable} ${instrumentSans.variable}`}>
         {children}
       </body>
     </html>

--- a/marketing-site/app/layout.tsx
+++ b/marketing-site/app/layout.tsx
@@ -1,16 +1,26 @@
 import type { Metadata } from 'next';
-import { Inter, Instrument_Sans } from 'next/font/google';
+import { Inter, JetBrains_Mono, Sora } from 'next/font/google';
 import './globals.css';
 
 const inter = Inter({
   subsets: ['latin'],
   weight: ['300', '400', '500', '600', '700'],
   variable: '--font-inter',
+  display: 'swap',
 });
 
-const instrumentSans = Instrument_Sans({
+const sora = Sora({
   subsets: ['latin'],
-  variable: '--font-instrument',
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-sora',
+  display: 'swap',
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  variable: '--font-jetbrains',
+  display: 'swap',
 });
 
 export const metadata: Metadata = {
@@ -50,7 +60,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body suppressHydrationWarning className={`${inter.variable} ${instrumentSans.variable}`}>
+      <body
+        suppressHydrationWarning
+        className={`${inter.variable} ${sora.variable} ${jetbrainsMono.variable}`}
+      >
         {children}
       </body>
     </html>

--- a/marketing-site/app/page.tsx
+++ b/marketing-site/app/page.tsx
@@ -11,7 +11,7 @@ export default function HomePage() {
   return (
     <>
       <Navbar />
-      <main className="landing-shell">
+      <main>
         <Hero />
         <ProblemSolution />
         <Workflow />

--- a/marketing-site/components/landing/Brand.tsx
+++ b/marketing-site/components/landing/Brand.tsx
@@ -1,21 +1,25 @@
-import Image from 'next/image';
 import Link from 'next/link';
 
 interface BrandProps {
   compact?: boolean;
+  href?: string;
 }
 
-export function Brand({ compact = false }: BrandProps) {
+export function Brand({ compact = false, href = '#' }: BrandProps) {
+  const box = compact ? 'h-6 w-6' : 'h-7 w-7';
+  const glyph = compact ? 'text-xs' : 'text-sm';
+  const word = compact ? 'text-base' : 'text-lg';
+
   return (
-    <Link href="/" className="brand" aria-label="Pathment home">
-      <Image
-        src="/assets/favicon-32x32.png"
-        alt="Pathment symbol"
-        width={compact ? 18 : 20}
-        height={compact ? 18 : 20}
-        priority
-      />
-      <span className="brand-wordmark">Pathment</span>
+    <Link
+      href={href}
+      aria-label="Pathment home"
+      className={`flex items-center gap-2.5 font-display ${word} font-bold tracking-tight text-zinc-900`}
+    >
+      <span className={`flex ${box} items-center justify-center rounded bg-zinc-900 text-white`}>
+        <span className={`font-display font-black ${glyph}`}>P</span>
+      </span>
+      <span>Pathment</span>
     </Link>
   );
 }

--- a/marketing-site/components/landing/Capabilities.tsx
+++ b/marketing-site/components/landing/Capabilities.tsx
@@ -1,23 +1,118 @@
-import { capabilities } from './content';
+import { GitBranch, Sparkles, Trophy, Users } from 'lucide-react';
 
 export function Capabilities() {
   return (
-    <section id="capabilities" className="container section" aria-labelledby="capabilities-title">
-      <div className="section-head">
-        <p className="eyebrow">Product Capabilities</p>
-        <h2 id="capabilities-title">Operational infrastructure for mentorship at enterprise scale.</h2>
-      </div>
-      <div className="card-grid">
-        {capabilities.map((capability) => (
-          <article key={capability.title} className="card">
-            <h3>{capability.title}</h3>
-            <ul>
-              {capability.bullets.map((bullet) => (
-                <li key={bullet}>{bullet}</li>
+    <section
+      id="capabilities"
+      className="relative border-b border-zinc-200/60 bg-zinc-50 py-24"
+      aria-labelledby="capabilities-title"
+    >
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto mb-16 max-w-3xl text-center">
+          <div className="mb-2 text-xs font-bold uppercase tracking-wider text-brand-600">
+            PRODUCT CAPABILITIES
+          </div>
+          <h2
+            id="capabilities-title"
+            className="font-display text-3xl font-semibold tracking-tight text-zinc-950 sm:text-4xl"
+          >
+            Built for rigorous internal engineering ecosystems
+          </h2>
+        </div>
+
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-3">
+          <div className="flex flex-col justify-between rounded-xl border border-zinc-200 bg-white p-8 shadow-sm-soft md:col-span-2">
+            <div>
+              <span className="mb-6 flex h-9 w-9 items-center justify-center rounded border border-brand-100 bg-brand-50 text-brand-600">
+                <Users className="h-5 w-5" />
+              </span>
+              <h3 className="mb-2 text-lg font-semibold text-zinc-900">Smart Mentor Matching</h3>
+              <p className="mb-6 max-w-xl text-sm leading-relaxed text-zinc-600">
+                Pair mentees with the right mentors based on skills, goals, and availability. Admins
+                review and approve every match, and the full submission-to-review lifecycle stays
+                visible and linked to each mentee&apos;s progression profile.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-4 border-t border-zinc-100 pt-6">
+              <div>
+                <span className="block text-xs font-bold uppercase text-zinc-400">Matching</span>
+                <span className="text-sm font-medium text-zinc-800">
+                  Skill, goal &amp; availability based
+                </span>
+              </div>
+              <div>
+                <span className="block text-xs font-bold uppercase text-zinc-400">Oversight</span>
+                <span className="text-sm font-medium text-zinc-800">
+                  Admin-approved assignments
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-between rounded-xl border border-zinc-200 bg-white p-8 shadow-sm-soft">
+            <div>
+              <span className="mb-6 flex h-9 w-9 items-center justify-center rounded border border-zinc-200 bg-zinc-100 text-zinc-700">
+                <GitBranch className="h-5 w-5" />
+              </span>
+              <h3 className="mb-2 text-lg font-semibold text-zinc-900">AI-Generated Roadmaps</h3>
+              <p className="text-sm leading-relaxed text-zinc-600">
+                AI analyzes each mentee&apos;s goals and skill gaps to generate a structured learning
+                roadmap, broken into actionable tasks and adjusted as they progress.
+              </p>
+            </div>
+            <div className="border-t border-zinc-100 pt-6">
+              <span className="mb-1 block text-xs font-semibold text-zinc-400">Always current:</span>
+              <span className="text-xs text-zinc-600">
+                Milestones and tasks adapt automatically to real progress.
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-between rounded-xl border border-zinc-200 bg-white p-8 shadow-sm-soft">
+            <div>
+              <span className="mb-6 flex h-9 w-9 items-center justify-center rounded border border-zinc-200 bg-zinc-100 text-zinc-700">
+                <Sparkles className="h-5 w-5" />
+              </span>
+              <h3 className="mb-2 text-lg font-semibold text-zinc-900">Outcome Insights</h3>
+              <p className="text-sm leading-relaxed text-zinc-600">
+                Track program wellness in real time, surface mentees who are stalling, and give
+                leaders clear summaries to inform promotion and readiness decisions.
+              </p>
+            </div>
+            <div className="border-t border-zinc-100 pt-6">
+              <span className="mb-1 block text-xs font-semibold text-zinc-400">Real-time view:</span>
+              <span className="text-xs text-zinc-600">
+                Completion health and capability growth at a glance.
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-between rounded-xl border border-zinc-200 bg-white p-8 shadow-sm-soft md:col-span-2">
+            <div>
+              <span className="mb-6 flex h-9 w-9 items-center justify-center rounded border border-zinc-200 bg-zinc-100 text-zinc-700">
+                <Trophy className="h-5 w-5" />
+              </span>
+              <h3 className="mb-2 text-lg font-semibold text-zinc-900">
+                Gamified Progress &amp; Motivation
+              </h3>
+              <p className="mb-4 max-w-xl text-sm leading-relaxed text-zinc-600">
+                Completing tasks earns points, milestones unlock badges, and leaderboards add
+                friendly competition. Mentees stay motivated while their skill growth is tracked over
+                time &mdash; turning learning into measurable momentum.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 border-t border-zinc-100 pt-6">
+              {['Points', 'Badges', 'Leaderboards', 'Streaks'].map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-xs font-medium text-zinc-600"
+                >
+                  {tag}
+                </span>
               ))}
-            </ul>
-          </article>
-        ))}
+            </div>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/marketing-site/components/landing/Capabilities.tsx
+++ b/marketing-site/components/landing/Capabilities.tsx
@@ -21,7 +21,7 @@ export function Capabilities() {
         </div>
 
         <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-3">
-          <div className="flex flex-col justify-between rounded-xl border border-zinc-200 bg-white p-8 shadow-sm-soft md:col-span-2">
+          <div className="flex flex-col justify-between rounded-2xl border border-zinc-200 bg-white p-8 shadow-sm-soft transition-all duration-200 hover:border-zinc-300 hover:shadow-md-soft md:col-span-2">
             <div>
               <span className="mb-6 flex h-9 w-9 items-center justify-center rounded border border-brand-100 bg-brand-50 text-brand-600">
                 <Users className="h-5 w-5" />
@@ -49,7 +49,7 @@ export function Capabilities() {
             </div>
           </div>
 
-          <div className="flex flex-col justify-between rounded-xl border border-zinc-200 bg-white p-8 shadow-sm-soft">
+          <div className="flex flex-col justify-between rounded-2xl border border-zinc-200 bg-white p-8 shadow-sm-soft transition-all duration-200 hover:border-zinc-300 hover:shadow-md-soft">
             <div>
               <span className="mb-6 flex h-9 w-9 items-center justify-center rounded border border-zinc-200 bg-zinc-100 text-zinc-700">
                 <GitBranch className="h-5 w-5" />
@@ -68,7 +68,7 @@ export function Capabilities() {
             </div>
           </div>
 
-          <div className="flex flex-col justify-between rounded-xl border border-zinc-200 bg-white p-8 shadow-sm-soft">
+          <div className="flex flex-col justify-between rounded-2xl border border-zinc-200 bg-white p-8 shadow-sm-soft transition-all duration-200 hover:border-zinc-300 hover:shadow-md-soft">
             <div>
               <span className="mb-6 flex h-9 w-9 items-center justify-center rounded border border-zinc-200 bg-zinc-100 text-zinc-700">
                 <Sparkles className="h-5 w-5" />
@@ -87,7 +87,7 @@ export function Capabilities() {
             </div>
           </div>
 
-          <div className="flex flex-col justify-between rounded-xl border border-zinc-200 bg-white p-8 shadow-sm-soft md:col-span-2">
+          <div className="flex flex-col justify-between rounded-2xl border border-zinc-200 bg-white p-8 shadow-sm-soft transition-all duration-200 hover:border-zinc-300 hover:shadow-md-soft md:col-span-2">
             <div>
               <span className="mb-6 flex h-9 w-9 items-center justify-center rounded border border-zinc-200 bg-zinc-100 text-zinc-700">
                 <Trophy className="h-5 w-5" />

--- a/marketing-site/components/landing/Enterprise.tsx
+++ b/marketing-site/components/landing/Enterprise.tsx
@@ -1,19 +1,55 @@
+import { Building2, Lock, Users } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { enterprisePillars } from './content';
+
+const icons: Record<string, LucideIcon> = {
+  workspace: Building2,
+  roles: Users,
+  auth: Lock,
+};
 
 export function Enterprise() {
   return (
-    <section id="enterprise" className="container section" aria-labelledby="enterprise-title">
-      <div className="section-head">
-        <p className="eyebrow">Enterprise Credibility</p>
-        <h2 id="enterprise-title">Security, scalability, and control built into the core system.</h2>
-      </div>
-      <div className="card-grid">
-        {enterprisePillars.map((pillar) => (
-          <article key={pillar.title} className="card">
-            <h3>{pillar.title}</h3>
-            <p>{pillar.description}</p>
-          </article>
-        ))}
+    <section
+      id="enterprise"
+      className="border-b border-zinc-200/60 bg-white py-24"
+      aria-labelledby="enterprise-title"
+    >
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto mb-16 max-w-3xl text-center">
+          <div className="mb-2 text-xs font-bold uppercase tracking-wider text-brand-600">
+            BUILT FOR ORGANIZATIONS
+          </div>
+          <h2
+            id="enterprise-title"
+            className="font-display text-3xl font-semibold tracking-tight text-zinc-950 sm:text-4xl"
+          >
+            Isolated workspaces, clear roles, secure access
+          </h2>
+          <p className="mt-4 text-base text-zinc-600">
+            Pathment is structured so every organization runs its own mentorship program
+            independently, with the right experience for each role and straightforward, secure
+            sign-in for everyone involved.
+          </p>
+        </div>
+
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-3">
+          {enterprisePillars.map((pillar) => {
+            const Icon = icons[pillar.icon];
+            return (
+              <div
+                key={pillar.title}
+                className="rounded-lg border border-zinc-100 bg-[#fcfcfd] p-6"
+              >
+                <div className="mb-4 flex items-center gap-2">
+                  <Icon className="h-5 w-5 text-zinc-900" />
+                  <h3 className="font-semibold text-zinc-900">{pillar.title}</h3>
+                </div>
+                <p className="text-sm leading-relaxed text-zinc-600">{pillar.description}</p>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </section>
   );

--- a/marketing-site/components/landing/Enterprise.tsx
+++ b/marketing-site/components/landing/Enterprise.tsx
@@ -39,7 +39,7 @@ export function Enterprise() {
             return (
               <div
                 key={pillar.title}
-                className="rounded-lg border border-zinc-100 bg-[#fcfcfd] p-6"
+                className="rounded-2xl border border-zinc-100 bg-[#fcfcfd] p-7 transition-colors duration-200 hover:border-zinc-200 hover:bg-white"
               >
                 <div className="mb-4 flex items-center gap-2">
                   <Icon className="h-5 w-5 text-zinc-900" />

--- a/marketing-site/components/landing/FinalCta.tsx
+++ b/marketing-site/components/landing/FinalCta.tsx
@@ -1,17 +1,48 @@
-import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
 
 export function FinalCta() {
   return (
-    <section className="container section" aria-labelledby="final-cta-title">
-      <div className="cta-panel">
-        <h2 id="final-cta-title">Run mentorship like a serious enterprise system.</h2>
-        <p>
-          Replace fragmented coaching with a measurable infrastructure for capability growth.
-        </p>
-        <div className="cta-row">
-          <Link href="mailto:hello@pathment.me?subject=Pathment%20Request%20Access" className="btn btn-primary">
-            Request Access
-          </Link>
+    <section id="request-access" className="relative overflow-hidden bg-white py-24">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="relative mx-auto max-w-5xl overflow-hidden rounded-2xl border border-zinc-200/80 bg-zinc-50 px-8 py-16 shadow-sm-soft md:p-20">
+          <div className="grid-pattern pointer-events-none absolute inset-0 opacity-40" />
+          <div className="relative mx-auto max-w-2xl text-center">
+            <h2 className="mb-4 font-display text-3xl font-semibold tracking-tight text-zinc-950 sm:text-4xl">
+              Establish precision mentorship at scale
+            </h2>
+            <p className="mb-10 text-base text-zinc-600">
+              See how Pathment aligns continuous personal progression directly to organization
+              metrics. Connect with our solution engineering team to design your workspace setup.
+            </p>
+            <form
+              action="mailto:enterprise@pathment.com"
+              method="post"
+              className="mx-auto flex max-w-md flex-col items-stretch justify-center gap-3 sm:flex-row"
+            >
+              <input
+                type="email"
+                name="email"
+                placeholder="Enter work email"
+                required
+                className="flex-1 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-950"
+              />
+              <button
+                type="submit"
+                className="flex items-center justify-center gap-1.5 rounded-lg bg-zinc-950 px-5 py-2.5 text-sm font-semibold text-white shadow-md-soft transition-all hover:bg-zinc-800"
+              >
+                Request Invite <ArrowRight className="h-4 w-4" />
+              </button>
+            </form>
+            <p className="mt-4 text-xs text-zinc-400">
+              For enterprise security configurations or customized RFP reviews, reach us directly at{' '}
+              <a
+                href="mailto:enterprise@pathment.com"
+                className="text-zinc-600 underline hover:text-zinc-900"
+              >
+                enterprise@pathment.com
+              </a>
+            </p>
+          </div>
         </div>
       </div>
     </section>

--- a/marketing-site/components/landing/FinalCta.tsx
+++ b/marketing-site/components/landing/FinalCta.tsx
@@ -17,20 +17,21 @@ export function FinalCta() {
             <form
               action="mailto:enterprise@pathment.com"
               method="post"
-              className="mx-auto flex max-w-md flex-col items-stretch justify-center gap-3 sm:flex-row"
+              className="mx-auto flex w-full max-w-md flex-col gap-2.5 sm:flex-row"
             >
               <input
                 type="email"
                 name="email"
                 placeholder="Enter work email"
                 required
-                className="flex-1 rounded-lg border border-zinc-300 bg-white px-4 py-2.5 text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-950"
+                className="w-full flex-1 rounded-xl border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 shadow-sm-soft transition-all placeholder:text-zinc-400 focus:border-brand-300 focus:outline-none focus:ring-4 focus:ring-brand-500/10"
               />
               <button
                 type="submit"
-                className="flex items-center justify-center gap-1.5 rounded-lg bg-zinc-950 px-5 py-2.5 text-sm font-semibold text-white shadow-md-soft transition-all hover:bg-zinc-800"
+                className="group inline-flex items-center justify-center gap-1.5 rounded-xl bg-zinc-950 px-6 py-3 text-sm font-semibold text-white shadow-md-soft transition-all duration-200 hover:-translate-y-0.5 hover:bg-zinc-800 hover:shadow-lg-soft"
               >
-                Request Invite <ArrowRight className="h-4 w-4" />
+                Request Invite
+                <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" />
               </button>
             </form>
             <p className="mt-4 text-xs text-zinc-400">

--- a/marketing-site/components/landing/Footer.tsx
+++ b/marketing-site/components/landing/Footer.tsx
@@ -1,11 +1,59 @@
+import { SiGithub, SiX } from 'react-icons/si';
+import { FaLinkedin } from 'react-icons/fa6';
 import { Brand } from './Brand';
+import { footerColumns } from './content';
 
 export function Footer() {
   return (
-    <footer className="footer-shell">
-      <div className="container footer-inner">
-        <Brand compact />
-        <p>Pathment | AI-powered mentorship infrastructure for enterprise teams.</p>
+    <footer className="border-t border-zinc-200 bg-white">
+      <div className="mx-auto max-w-7xl px-6 py-12 lg:px-8">
+        <div className="mb-12 grid grid-cols-2 gap-8 md:grid-cols-4">
+          <div className="col-span-2 space-y-4 md:col-span-1">
+            <Brand compact />
+            <p className="text-xs leading-relaxed text-zinc-500">
+              AI-powered mentorship infrastructure for high-growth enterprise systems. Align
+              development structure to platform performance.
+            </p>
+            <div className="flex items-center gap-3 text-zinc-400">
+              <a href="#" aria-label="GitHub" className="text-base hover:text-zinc-600">
+                <SiGithub />
+              </a>
+              <a href="#" aria-label="LinkedIn" className="text-base hover:text-zinc-600">
+                <FaLinkedin />
+              </a>
+              <a href="#" aria-label="X" className="text-base hover:text-zinc-600">
+                <SiX />
+              </a>
+            </div>
+          </div>
+
+          {footerColumns.map((column) => (
+            <div key={column.title}>
+              <h4 className="mb-4 text-xs font-bold uppercase tracking-wider text-zinc-900">
+                {column.title}
+              </h4>
+              <ul className="space-y-2 text-xs text-zinc-500">
+                {column.links.map((link) => (
+                  <li key={link.label}>
+                    <a href={link.href} className="hover:text-zinc-900">
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-col items-center justify-between gap-4 border-t border-zinc-200/60 pt-8 sm:flex-row">
+          <p className="text-xs text-zinc-400">
+            &copy; 2026 Pathment Technologies, Inc. All rights reserved.
+          </p>
+          <div className="flex items-center gap-1.5 rounded border border-emerald-100 bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-600">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            All services fully operational
+          </div>
+        </div>
       </div>
     </footer>
   );

--- a/marketing-site/components/landing/Hero.tsx
+++ b/marketing-site/components/landing/Hero.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, LayoutDashboard, LineChart, Sparkles, Trophy, Users } from 'lucide-react';
+import { Check, GitBranch, LayoutDashboard, LineChart, Sparkles, Trophy, Users } from 'lucide-react';
 import { heroHighlights } from './content';
 
 export function Hero() {
@@ -39,14 +39,14 @@ export function Hero() {
             </a>
           </div>
 
-          <div className="mx-auto mt-8 flex max-w-md flex-wrap items-center justify-center gap-x-6 gap-y-2 border-t border-zinc-200/60 pt-6 text-xs font-medium text-zinc-400">
-            {heroHighlights.map((item, index) => (
-              <span key={item} className="flex items-center gap-6">
-                {index > 0 && <span className="hidden h-3 w-px bg-zinc-200 sm:block" />}
-                <span className="flex items-center gap-1.5">
-                  <span className="flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                  {item}
-                </span>
+          <div className="mx-auto mt-10 flex max-w-2xl flex-wrap items-center justify-center gap-2.5">
+            {heroHighlights.map((item) => (
+              <span
+                key={item}
+                className="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 shadow-sm-soft"
+              >
+                <Check className="h-3.5 w-3.5 text-brand-600" />
+                {item}
               </span>
             ))}
           </div>

--- a/marketing-site/components/landing/Hero.tsx
+++ b/marketing-site/components/landing/Hero.tsx
@@ -1,21 +1,200 @@
-import Link from 'next/link';
+import { GitBranch, LayoutDashboard, LineChart, Sparkles, Trophy, Users } from 'lucide-react';
+import { heroHighlights } from './content';
 
 export function Hero() {
   return (
-    <section className="container hero" aria-labelledby="hero-title">
-      <p className="eyebrow">AI-Powered Mentorship Infrastructure</p>
-      <h1 id="hero-title">Structured growth, at scale.</h1>
-      <p className="lead">
-        Pathment gives enterprise teams a precise system for capability growth through guided mentorship,
-        measurable progression, and AI-accelerated operational clarity.
-      </p>
-      <div className="cta-row">
-        <Link href="mailto:hello@pathment.me?subject=Pathment%20Get%20Started" className="btn btn-primary">
-          Get Started
-        </Link>
-        <Link href="mailto:hello@pathment.me?subject=Pathment%20Request%20Access" className="btn btn-secondary">
-          Request Access
-        </Link>
+    <section className="relative overflow-hidden border-b border-zinc-200/60 bg-[#fcfcfd] pt-16 pb-24 md:pt-20 md:pb-32">
+      <div className="grid-pattern pointer-events-none absolute inset-0 opacity-45" />
+      <div className="pointer-events-none absolute top-0 left-1/2 h-full w-full max-w-7xl -translate-x-1/2">
+        <div className="h-full w-full border-x border-zinc-100" />
+      </div>
+
+      <div className="relative mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto mb-12 max-w-3xl text-center md:mb-16">
+          <div className="mb-6 inline-flex items-center gap-1.5 rounded-full border border-zinc-200/80 bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-800">
+            <span className="flex h-1.5 w-1.5 rounded-full bg-brand-500" />
+            AI-POWERED MENTORSHIP INFRASTRUCTURE
+          </div>
+          <h1 className="mb-6 text-balance font-display text-4xl leading-[1.08] font-semibold tracking-tight text-zinc-950 sm:text-6xl">
+            Structured growth, <br className="hidden sm:inline" />
+            <span className="font-normal italic text-zinc-500">at enterprise scale.</span>
+          </h1>
+          <p className="mx-auto mb-10 max-w-2xl text-lg leading-relaxed text-zinc-600">
+            Pathment gives engineering &amp; product teams a rigorous system for competency
+            development through smart mentor matching, AI-generated roadmaps, and gamified,
+            verifiable progress.
+          </p>
+          <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <a
+              href="#request-access"
+              className="inline-flex w-full items-center justify-center rounded-lg bg-zinc-950 px-5 py-3 text-sm font-semibold text-white shadow-md-soft transition-all hover:bg-zinc-800 sm:w-auto"
+            >
+              Request Access
+            </a>
+            <a
+              href="#how-it-works"
+              className="inline-flex w-full items-center justify-center rounded-lg border border-zinc-200 bg-white px-5 py-3 text-sm font-semibold text-zinc-700 transition-all hover:bg-zinc-50 hover:text-zinc-950 sm:w-auto"
+            >
+              See How It Works
+            </a>
+          </div>
+
+          <div className="mx-auto mt-8 flex max-w-md flex-wrap items-center justify-center gap-x-6 gap-y-2 border-t border-zinc-200/60 pt-6 text-xs font-medium text-zinc-400">
+            {heroHighlights.map((item, index) => (
+              <span key={item} className="flex items-center gap-6">
+                {index > 0 && <span className="hidden h-3 w-px bg-zinc-200 sm:block" />}
+                <span className="flex items-center gap-1.5">
+                  <span className="flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                  {item}
+                </span>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="relative mx-auto max-w-5xl rounded-xl border border-zinc-200/80 bg-white p-2.5 shadow-lg-soft">
+          <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50">
+            <div className="flex items-center justify-between border-b border-zinc-200/80 bg-white px-4 py-3">
+              <div className="flex items-center gap-1.5">
+                <div className="h-2.5 w-2.5 rounded-full bg-zinc-200" />
+                <div className="h-2.5 w-2.5 rounded-full bg-zinc-200" />
+                <div className="h-2.5 w-2.5 rounded-full bg-zinc-200" />
+                <span className="ml-2 font-mono text-xs text-zinc-400">
+                  acme.pathment.me/analytics
+                </span>
+              </div>
+              <span className="inline-flex items-center gap-1 rounded border border-brand-100 bg-brand-50 px-1.5 py-0.5 text-[10px] font-semibold text-brand-600">
+                <Sparkles className="h-3 w-3" /> AI ACTIVE
+              </span>
+            </div>
+
+            <div className="grid grid-cols-1 divide-y divide-zinc-200 md:grid-cols-4 md:divide-x md:divide-y-0">
+              <div className="space-y-4 bg-white p-4 text-xs font-medium text-zinc-500">
+                <div className="px-2 text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+                  Navigation
+                </div>
+                <div className="space-y-1">
+                  <span className="flex items-center gap-2 rounded bg-zinc-100 px-2 py-1.5 text-zinc-900">
+                    <LayoutDashboard className="h-3.5 w-3.5 text-zinc-600" /> Program Overview
+                  </span>
+                  <span className="flex items-center gap-2 rounded px-2 py-1.5 transition-colors hover:bg-zinc-50 hover:text-zinc-900">
+                    <Users className="h-3.5 w-3.5" /> Active Cohorts
+                  </span>
+                  <span className="flex items-center gap-2 rounded px-2 py-1.5 transition-colors hover:bg-zinc-50 hover:text-zinc-900">
+                    <GitBranch className="h-3.5 w-3.5" /> Skill Blueprints
+                  </span>
+                  <span className="flex items-center gap-2 rounded px-2 py-1.5 transition-colors hover:bg-zinc-50 hover:text-zinc-900">
+                    <LineChart className="h-3.5 w-3.5" /> Progress Analytics
+                  </span>
+                  <span className="flex items-center gap-2 rounded px-2 py-1.5 transition-colors hover:bg-zinc-50 hover:text-zinc-900">
+                    <Trophy className="h-3.5 w-3.5" /> Leaderboard
+                  </span>
+                </div>
+              </div>
+
+              <div className="space-y-6 bg-[#fcfcfd] p-6 md:col-span-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h4 className="text-base font-semibold text-zinc-900">
+                      Engineering Mentorship Cohort 4
+                    </h4>
+                    <p className="text-xs text-zinc-500">
+                      System status: 124 active developer pathways mapped
+                    </p>
+                  </div>
+                  <span className="rounded border border-zinc-200 bg-white px-2.5 py-1 text-xs text-zinc-500">
+                    Q3 Performance Roadmap
+                  </span>
+                </div>
+
+                <div className="grid grid-cols-3 gap-4">
+                  <div className="rounded-lg border border-zinc-200/80 bg-white p-3.5">
+                    <div className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+                      Active Pairs
+                    </div>
+                    <div className="mt-1 text-xl font-semibold text-zinc-900">58 Pairs</div>
+                    <div className="mt-0.5 text-[10px] font-medium text-emerald-600">
+                      &uarr; 12% vs last month
+                    </div>
+                  </div>
+                  <div className="rounded-lg border border-zinc-200/80 bg-white p-3.5">
+                    <div className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+                      Milestone Completion
+                    </div>
+                    <div className="mt-1 text-xl font-semibold text-zinc-900">91.4%</div>
+                    <div className="mt-0.5 text-[10px] text-zinc-500">Target trajectory met</div>
+                  </div>
+                  <div className="rounded-lg border border-zinc-200/80 bg-white p-3.5">
+                    <div className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+                      Avg. Feedback Speed
+                    </div>
+                    <div className="mt-1 text-xl font-semibold text-zinc-900">2.4 Hrs</div>
+                    <div className="mt-0.5 text-[10px] font-medium text-emerald-600">
+                      &darr; 4.2h since setup
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-zinc-200/80 bg-white p-4">
+                  <div className="mb-4 flex items-center justify-between">
+                    <span className="text-xs font-semibold text-zinc-800">
+                      Progression Path: Staff Engineer (L6) Prep
+                    </span>
+                    <span className="text-[11px] text-zinc-400">4 Milestones</span>
+                  </div>
+                  <div className="space-y-3">
+                    <div className="flex items-center gap-3">
+                      <span className="w-8 font-mono text-xs text-zinc-400">M1</span>
+                      <div className="w-32 truncate text-xs font-medium text-zinc-800">
+                        Architecture Blueprint
+                      </div>
+                      <div className="h-2 flex-1 overflow-hidden rounded-full bg-zinc-100">
+                        <div className="h-full rounded-full bg-zinc-800" style={{ width: '100%' }} />
+                      </div>
+                      <span className="w-12 text-right font-mono text-xs font-medium text-emerald-600">
+                        100% Done
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="w-8 font-mono text-xs text-zinc-400">M2</span>
+                      <div className="w-32 truncate text-xs font-medium text-zinc-800">
+                        Cross-team Governance
+                      </div>
+                      <div className="h-2 flex-1 overflow-hidden rounded-full bg-zinc-100">
+                        <div className="h-full rounded-full bg-zinc-800" style={{ width: '78%' }} />
+                      </div>
+                      <span className="w-12 text-right font-mono text-xs font-medium text-zinc-600">
+                        78% Active
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="w-8 font-mono text-xs text-zinc-400">M3</span>
+                      <div className="w-32 truncate text-xs font-medium text-zinc-800">
+                        Strategic Delivery
+                      </div>
+                      <div className="h-2 flex-1 overflow-hidden rounded-full bg-zinc-100">
+                        <div className="h-full rounded-full bg-zinc-300" style={{ width: '30%' }} />
+                      </div>
+                      <span className="w-12 text-right font-mono text-xs text-zinc-400">
+                        30% Active
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-start gap-2.5 rounded-lg border border-indigo-100 bg-indigo-50 p-3">
+                  <Sparkles className="mt-0.5 h-4 w-4 flex-shrink-0 text-indigo-600" />
+                  <div className="text-xs text-indigo-950">
+                    <span className="font-semibold">Pathment AI recommendation:</span> 4 pairs on the
+                    Staff Track have completed &lsquo;Architecture Blueprint&rsquo; ahead of target.
+                    We suggest unlocking M2 (&lsquo;Cross-team Governance&rsquo;) templates
+                    automatically.
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/marketing-site/components/landing/Hero.tsx
+++ b/marketing-site/components/landing/Hero.tsx
@@ -182,13 +182,28 @@ export function Hero() {
                   </div>
                 </div>
 
-                <div className="flex items-start gap-2.5 rounded-lg border border-indigo-100 bg-indigo-50 p-3">
-                  <Sparkles className="mt-0.5 h-4 w-4 flex-shrink-0 text-indigo-600" />
-                  <div className="text-xs text-indigo-950">
-                    <span className="font-semibold">Pathment AI recommendation:</span> 4 pairs on the
-                    Staff Track have completed &lsquo;Architecture Blueprint&rsquo; ahead of target.
-                    We suggest unlocking M2 (&lsquo;Cross-team Governance&rsquo;) templates
-                    automatically.
+                <div className="rounded-lg border border-zinc-200/80 bg-white p-4">
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="inline-flex items-center gap-1.5 text-[11px] font-semibold text-zinc-500">
+                      <Sparkles className="h-3.5 w-3.5 text-brand-600" />
+                      Suggested action
+                    </span>
+                    <span className="font-mono text-[10px] text-zinc-400">2m ago</span>
+                  </div>
+                  <p className="text-xs leading-relaxed text-zinc-600">
+                    4 pairs finished{' '}
+                    <span className="font-medium text-zinc-900">Architecture Blueprint</span> ahead
+                    of schedule. Unlock{' '}
+                    <span className="font-medium text-zinc-900">M2 · Cross-team Governance</span> for
+                    them?
+                  </p>
+                  <div className="mt-3 flex items-center gap-2">
+                    <span className="rounded-md bg-zinc-900 px-2.5 py-1 text-[11px] font-semibold text-white">
+                      Unlock M2
+                    </span>
+                    <span className="rounded-md border border-zinc-200 px-2.5 py-1 text-[11px] font-medium text-zinc-600">
+                      Dismiss
+                    </span>
                   </div>
                 </div>
               </div>

--- a/marketing-site/components/landing/Hero.tsx
+++ b/marketing-site/components/landing/Hero.tsx
@@ -1,4 +1,13 @@
-import { Check, GitBranch, LayoutDashboard, LineChart, Sparkles, Trophy, Users } from 'lucide-react';
+import {
+  ArrowRight,
+  Check,
+  GitBranch,
+  LayoutDashboard,
+  LineChart,
+  Sparkles,
+  Trophy,
+  Users,
+} from 'lucide-react';
 import { heroHighlights } from './content';
 
 export function Hero() {
@@ -15,7 +24,7 @@ export function Hero() {
             <span className="flex h-1.5 w-1.5 rounded-full bg-brand-500" />
             AI-POWERED MENTORSHIP INFRASTRUCTURE
           </div>
-          <h1 className="mb-6 text-balance font-display text-4xl leading-[1.08] font-semibold tracking-tight text-zinc-950 sm:text-6xl">
+          <h1 className="mb-6 text-balance font-display text-[2.75rem] leading-[1.04] font-semibold tracking-tight text-zinc-950 sm:text-6xl">
             Structured growth, <br className="hidden sm:inline" />
             <span className="font-normal italic text-zinc-500">at enterprise scale.</span>
           </h1>
@@ -24,16 +33,17 @@ export function Hero() {
             development through smart mentor matching, AI-generated roadmaps, and gamified,
             verifiable progress.
           </p>
-          <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
             <a
               href="#request-access"
-              className="inline-flex w-full items-center justify-center rounded-lg bg-zinc-950 px-5 py-3 text-sm font-semibold text-white shadow-md-soft transition-all hover:bg-zinc-800 sm:w-auto"
+              className="group inline-flex w-full items-center justify-center gap-1.5 rounded-xl bg-zinc-950 px-6 py-3.5 text-sm font-semibold text-white shadow-md-soft transition-all duration-200 hover:-translate-y-0.5 hover:bg-zinc-800 hover:shadow-lg-soft sm:w-auto"
             >
               Request Access
+              <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" />
             </a>
             <a
               href="#how-it-works"
-              className="inline-flex w-full items-center justify-center rounded-lg border border-zinc-200 bg-white px-5 py-3 text-sm font-semibold text-zinc-700 transition-all hover:bg-zinc-50 hover:text-zinc-950 sm:w-auto"
+              className="inline-flex w-full items-center justify-center rounded-xl border border-zinc-200 bg-white px-6 py-3.5 text-sm font-semibold text-zinc-700 shadow-sm-soft transition-all duration-200 hover:-translate-y-0.5 hover:border-zinc-300 hover:text-zinc-950 sm:w-auto"
             >
               See How It Works
             </a>

--- a/marketing-site/components/landing/Navbar.tsx
+++ b/marketing-site/components/landing/Navbar.tsx
@@ -1,23 +1,33 @@
-import Link from 'next/link';
 import { Brand } from './Brand';
+import { WorkspaceSignIn } from './WorkspaceSignIn';
 import { navItems } from './content';
 
 export function Navbar() {
   return (
-    <header className="nav-shell">
-      <div className="container nav-inner">
-        <Brand />
-        <nav className="nav-items" aria-label="Primary">
-          {navItems.map((item) => (
-            <a key={item.href} href={item.href} className="nav-link">
-              {item.label}
+    <nav className="sticky top-0 z-50 border-b border-zinc-200/80 bg-white/80 backdrop-blur-md">
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between">
+          <div className="flex items-center gap-8">
+            <Brand />
+            <div className="hidden items-center gap-6 text-sm font-medium text-zinc-600 md:flex">
+              {navItems.map((item) => (
+                <a key={item.href} href={item.href} className="transition-colors hover:text-zinc-950">
+                  {item.label}
+                </a>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <WorkspaceSignIn />
+            <a
+              href="#request-access"
+              className="inline-flex items-center justify-center rounded-lg bg-zinc-900 px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm transition-all hover:bg-zinc-800"
+            >
+              Request Access
             </a>
-          ))}
-        </nav>
-        <Link href="mailto:hello@pathment.me?subject=Pathment%20Request%20Access" className="btn btn-secondary">
-          Request Access
-        </Link>
+          </div>
+        </div>
       </div>
-    </header>
+    </nav>
   );
 }

--- a/marketing-site/components/landing/Navbar.tsx
+++ b/marketing-site/components/landing/Navbar.tsx
@@ -21,7 +21,7 @@ export function Navbar() {
             <WorkspaceSignIn />
             <a
               href="#request-access"
-              className="inline-flex items-center justify-center rounded-lg bg-zinc-900 px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm transition-all hover:bg-zinc-800"
+              className="inline-flex items-center justify-center rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white shadow-sm-soft transition-all duration-200 hover:-translate-y-0.5 hover:bg-zinc-800 hover:shadow-md-soft"
             >
               Request Access
             </a>

--- a/marketing-site/components/landing/ProblemSolution.tsx
+++ b/marketing-site/components/landing/ProblemSolution.tsx
@@ -1,25 +1,78 @@
+import { AlertCircle, Check, CheckCircle2, X } from 'lucide-react';
+import { currentStatePoints, pathmentSystemPoints } from './content';
+
 export function ProblemSolution() {
   return (
-    <section id="problem" className="container section" aria-labelledby="problem-title">
-      <div className="split-grid">
-        <article className="panel">
-          <p className="kicker">Current State</p>
-          <h2 id="problem-title">Mentorship is often informal, invisible, and inconsistent.</h2>
-          <ul>
-            <li>Programs depend on individual effort, not system design.</li>
-            <li>Progression lacks measurable structure.</li>
-            <li>Leaders cannot see capability growth in real time.</li>
-          </ul>
-        </article>
-        <article className="panel panel-accent">
-          <p className="kicker">Pathment System</p>
-          <h3>Convert unstructured coaching into measurable progression.</h3>
-          <ul>
-            <li>Define progression pathways by role and outcome.</li>
-            <li>Execute guided mentor workflows with feedback loops.</li>
-            <li>Track capability growth with operational analytics.</li>
-          </ul>
-        </article>
+    <section
+      id="solution"
+      className="relative overflow-hidden border-b border-zinc-200/60 bg-zinc-50 py-24"
+      aria-labelledby="solution-title"
+    >
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto mb-16 max-w-3xl text-center">
+          <h2
+            id="solution-title"
+            className="font-display text-3xl font-semibold tracking-tight text-zinc-950 sm:text-4xl"
+          >
+            Rethinking operational guidance
+          </h2>
+          <p className="mt-4 text-base text-zinc-600">
+            Legacy mentorship is usually informal, invisible, and impossible to measure. Pathment
+            structures engineering development into verifiable system progression.
+          </p>
+        </div>
+
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-2">
+          <div className="relative overflow-hidden rounded-xl border border-zinc-200 bg-white p-8">
+            <div className="pointer-events-none absolute top-0 right-0 h-24 w-24 rounded-bl-3xl bg-linear-to-bl from-red-50/40 to-transparent" />
+            <div className="mb-6 flex items-center gap-3">
+              <span className="flex h-9 w-9 items-center justify-center rounded-lg border border-red-100 bg-red-50 text-red-600">
+                <AlertCircle className="h-5 w-5" />
+              </span>
+              <div>
+                <span className="text-xs font-bold uppercase tracking-wide text-zinc-400">
+                  Current State
+                </span>
+                <h3 className="text-lg font-semibold text-zinc-900">Informal &amp; Invisible</h3>
+              </div>
+            </div>
+            <ul className="space-y-4 text-sm text-zinc-600">
+              {currentStatePoints.map((point) => (
+                <li key={point.label} className="flex items-start gap-2.5">
+                  <X className="mt-1 h-4 w-4 flex-shrink-0 text-red-500" />
+                  <span>
+                    <strong>{point.label}</strong> {point.body}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="relative overflow-hidden rounded-xl border border-zinc-200 bg-white p-8 shadow-sm-soft">
+            <div className="pointer-events-none absolute top-0 right-0 h-24 w-24 rounded-bl-3xl bg-linear-to-bl from-brand-50 to-transparent" />
+            <div className="mb-6 flex items-center gap-3">
+              <span className="flex h-9 w-9 items-center justify-center rounded-lg border border-brand-100 bg-brand-50 text-brand-600">
+                <CheckCircle2 className="h-5 w-5" />
+              </span>
+              <div>
+                <span className="text-xs font-bold uppercase tracking-wide text-brand-600">
+                  Pathment System
+                </span>
+                <h3 className="text-lg font-semibold text-zinc-900">Measurable Progression</h3>
+              </div>
+            </div>
+            <ul className="space-y-4 text-sm text-zinc-600">
+              {pathmentSystemPoints.map((point) => (
+                <li key={point.label} className="flex items-start gap-2.5">
+                  <Check className="mt-1 h-4 w-4 flex-shrink-0 text-emerald-500" />
+                  <span>
+                    <strong>{point.label}</strong> {point.body}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/marketing-site/components/landing/ProblemSolution.tsx
+++ b/marketing-site/components/landing/ProblemSolution.tsx
@@ -1,72 +1,62 @@
-import { AlertCircle, Check, CheckCircle2, X } from 'lucide-react';
+import { Check } from 'lucide-react';
 import { currentStatePoints, pathmentSystemPoints } from './content';
 
 export function ProblemSolution() {
   return (
     <section
       id="solution"
-      className="relative overflow-hidden border-b border-zinc-200/60 bg-zinc-50 py-24"
+      className="border-b border-zinc-200/60 bg-zinc-50 py-24"
       aria-labelledby="solution-title"
     >
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
-        <div className="mx-auto mb-16 max-w-3xl text-center">
+        <div className="mx-auto mb-16 max-w-2xl text-center">
           <h2
             id="solution-title"
             className="font-display text-3xl font-semibold tracking-tight text-zinc-950 sm:text-4xl"
           >
             Rethinking operational guidance
           </h2>
-          <p className="mt-4 text-base text-zinc-600">
+          <p className="mt-4 text-base leading-relaxed text-zinc-600">
             Legacy mentorship is usually informal, invisible, and impossible to measure. Pathment
-            structures engineering development into verifiable system progression.
+            structures engineering development into verifiable progression.
           </p>
         </div>
 
-        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-2">
-          <div className="relative overflow-hidden rounded-xl border border-zinc-200 bg-white p-8">
-            <div className="pointer-events-none absolute top-0 right-0 h-24 w-24 rounded-bl-3xl bg-linear-to-bl from-red-50/40 to-transparent" />
-            <div className="mb-6 flex items-center gap-3">
-              <span className="flex h-9 w-9 items-center justify-center rounded-lg border border-red-100 bg-red-50 text-red-600">
-                <AlertCircle className="h-5 w-5" />
-              </span>
-              <div>
-                <span className="text-xs font-bold uppercase tracking-wide text-zinc-400">
-                  Current State
-                </span>
-                <h3 className="text-lg font-semibold text-zinc-900">Informal &amp; Invisible</h3>
-              </div>
-            </div>
-            <ul className="space-y-4 text-sm text-zinc-600">
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-2">
+          {/* Today */}
+          <div className="rounded-2xl border border-zinc-200 bg-white p-8">
+            <span className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+              Today
+            </span>
+            <h3 className="mt-2 mb-7 text-xl font-semibold text-zinc-900">
+              Informal &amp; invisible
+            </h3>
+            <ul className="space-y-5">
               {currentStatePoints.map((point) => (
-                <li key={point.label} className="flex items-start gap-2.5">
-                  <X className="mt-1 h-4 w-4 flex-shrink-0 text-red-500" />
-                  <span>
-                    <strong>{point.label}</strong> {point.body}
+                <li key={point.label} className="flex gap-3">
+                  <span className="mt-[7px] h-1.5 w-1.5 flex-shrink-0 rounded-full bg-zinc-300" />
+                  <span className="text-sm leading-relaxed text-zinc-600">
+                    <span className="font-medium text-zinc-900">{point.label}</span> {point.body}
                   </span>
                 </li>
               ))}
             </ul>
           </div>
 
-          <div className="relative overflow-hidden rounded-xl border border-zinc-200 bg-white p-8 shadow-sm-soft">
-            <div className="pointer-events-none absolute top-0 right-0 h-24 w-24 rounded-bl-3xl bg-linear-to-bl from-brand-50 to-transparent" />
-            <div className="mb-6 flex items-center gap-3">
-              <span className="flex h-9 w-9 items-center justify-center rounded-lg border border-brand-100 bg-brand-50 text-brand-600">
-                <CheckCircle2 className="h-5 w-5" />
-              </span>
-              <div>
-                <span className="text-xs font-bold uppercase tracking-wide text-brand-600">
-                  Pathment System
-                </span>
-                <h3 className="text-lg font-semibold text-zinc-900">Measurable Progression</h3>
-              </div>
-            </div>
-            <ul className="space-y-4 text-sm text-zinc-600">
+          {/* With Pathment */}
+          <div className="rounded-2xl border border-brand-200 bg-white p-8 shadow-sm-soft ring-1 ring-brand-500/10">
+            <span className="text-xs font-semibold uppercase tracking-wider text-brand-600">
+              With Pathment
+            </span>
+            <h3 className="mt-2 mb-7 text-xl font-semibold text-zinc-900">
+              Measurable progression
+            </h3>
+            <ul className="space-y-5">
               {pathmentSystemPoints.map((point) => (
-                <li key={point.label} className="flex items-start gap-2.5">
-                  <Check className="mt-1 h-4 w-4 flex-shrink-0 text-emerald-500" />
-                  <span>
-                    <strong>{point.label}</strong> {point.body}
+                <li key={point.label} className="flex gap-3">
+                  <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-brand-600" />
+                  <span className="text-sm leading-relaxed text-zinc-600">
+                    <span className="font-medium text-zinc-900">{point.label}</span> {point.body}
                   </span>
                 </li>
               ))}

--- a/marketing-site/components/landing/Workflow.tsx
+++ b/marketing-site/components/landing/Workflow.tsx
@@ -2,19 +2,42 @@ import { workflowSteps } from './content';
 
 export function Workflow() {
   return (
-    <section id="workflow" className="container section" aria-labelledby="workflow-title">
-      <div className="section-head">
-        <p className="eyebrow">How It Works</p>
-        <h2 id="workflow-title">A system built on progression, guidance, and outcomes.</h2>
-      </div>
-      <div className="card-grid">
-        {workflowSteps.map((step) => (
-          <article key={step.step} className="card">
-            <p className="card-step">{step.step}</p>
-            <h3>{step.title}</h3>
-            <p>{step.description}</p>
-          </article>
-        ))}
+    <section
+      id="how-it-works"
+      className="border-b border-zinc-200/60 bg-white py-24"
+      aria-labelledby="how-it-works-title"
+    >
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto mb-20 max-w-3xl text-center">
+          <div className="mb-2 text-xs font-bold uppercase tracking-wider text-brand-600">
+            ENGINEERING PROGRESSION ENGINE
+          </div>
+          <h2
+            id="how-it-works-title"
+            className="font-display text-3xl font-semibold tracking-tight text-zinc-950 sm:text-4xl"
+          >
+            A structured cycle for continuous growth
+          </h2>
+          <p className="mt-4 text-base text-zinc-600">
+            Unlike legacy portals, Pathment functions as structural infrastructure. We orchestrate
+            alignment across three core execution cycles.
+          </p>
+        </div>
+
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-12 md:grid-cols-3">
+          {workflowSteps.map((step) => (
+            <div key={step.step} className="space-y-4">
+              <div className="flex items-center gap-3">
+                <span className="rounded bg-zinc-100 px-2.5 py-1 font-mono text-xs font-bold text-zinc-400">
+                  {step.step}
+                </span>
+                <span className="h-px flex-1 bg-zinc-200" />
+              </div>
+              <h3 className="text-lg font-semibold text-zinc-900">{step.title}</h3>
+              <p className="text-sm leading-relaxed text-zinc-600">{step.description}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/marketing-site/components/landing/WorkspaceSignIn.tsx
+++ b/marketing-site/components/landing/WorkspaceSignIn.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ArrowRight } from 'lucide-react';
+
+const ROOT_DOMAIN = 'pathment.me';
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(new RegExp(`\\.${ROOT_DOMAIN}.*$`), '')
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function WorkspaceSignIn() {
+  const [open, setOpen] = useState(false);
+  const [workspace, setWorkspace] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    function onPointerDown(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
+  const slug = slugify(workspace);
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!slug) return;
+    window.location.href = `https://${slug}.${ROOT_DOMAIN}/login`;
+  }
+
+  return (
+    <div ref={containerRef} className="relative hidden sm:block">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="text-sm font-medium text-zinc-600 transition-colors hover:text-zinc-950"
+      >
+        Sign In
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Sign in to your workspace"
+          className="absolute right-0 top-full z-50 mt-3 w-80 rounded-xl border border-zinc-200 bg-white p-4 shadow-lg-soft"
+        >
+          <p className="mb-1 text-sm font-semibold text-zinc-900">Sign in to your workspace</p>
+          <p className="mb-3 text-xs text-zinc-500">
+            Enter your workspace name to continue to your team&apos;s sign-in page.
+          </p>
+          <form onSubmit={handleSubmit} className="space-y-2.5">
+            <div className="flex items-stretch overflow-hidden rounded-lg border border-zinc-300 focus-within:ring-2 focus-within:ring-zinc-950">
+              <input
+                ref={inputRef}
+                type="text"
+                value={workspace}
+                onChange={(event) => setWorkspace(event.target.value)}
+                placeholder="your-workspace"
+                autoComplete="off"
+                spellCheck={false}
+                className="min-w-0 flex-1 bg-white px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none"
+              />
+              <span className="flex items-center bg-zinc-50 px-2.5 text-xs font-medium text-zinc-500">
+                .{ROOT_DOMAIN}
+              </span>
+            </div>
+            <button
+              type="submit"
+              disabled={!slug}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-zinc-950 px-4 py-2 text-sm font-semibold text-white transition-all hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Continue <ArrowRight className="h-4 w-4" />
+            </button>
+          </form>
+          <p className="mt-3 text-xs text-zinc-500">
+            Don&apos;t have a workspace yet?{' '}
+            <a href="#request-access" onClick={() => setOpen(false)} className="font-medium text-zinc-900 underline">
+              Request access
+            </a>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/marketing-site/components/landing/WorkspaceSignIn.tsx
+++ b/marketing-site/components/landing/WorkspaceSignIn.tsx
@@ -76,7 +76,7 @@ export function WorkspaceSignIn() {
             Enter your workspace name to continue to your team&apos;s sign-in page.
           </p>
           <form onSubmit={handleSubmit} className="space-y-2.5">
-            <div className="flex items-stretch overflow-hidden rounded-lg border border-zinc-300 focus-within:ring-2 focus-within:ring-zinc-950">
+            <div className="flex items-stretch overflow-hidden rounded-xl border border-zinc-200 transition-all focus-within:border-brand-300 focus-within:ring-4 focus-within:ring-brand-500/10">
               <input
                 ref={inputRef}
                 type="text"
@@ -85,16 +85,16 @@ export function WorkspaceSignIn() {
                 placeholder="your-workspace"
                 autoComplete="off"
                 spellCheck={false}
-                className="min-w-0 flex-1 bg-white px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:outline-none"
+                className="min-w-0 flex-1 bg-white px-3.5 py-2.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:outline-none"
               />
-              <span className="flex items-center bg-zinc-50 px-2.5 text-xs font-medium text-zinc-500">
+              <span className="flex items-center bg-zinc-50 px-3 text-xs font-medium text-zinc-500">
                 .{ROOT_DOMAIN}
               </span>
             </div>
             <button
               type="submit"
               disabled={!slug}
-              className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-zinc-950 px-4 py-2 text-sm font-semibold text-white transition-all hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-40"
+              className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-zinc-950 px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200 hover:bg-zinc-800 enabled:hover:-translate-y-0.5 enabled:hover:shadow-md-soft disabled:cursor-not-allowed disabled:opacity-40"
             >
               Continue <ArrowRight className="h-4 w-4" />
             </button>

--- a/marketing-site/components/landing/content.ts
+++ b/marketing-site/components/landing/content.ts
@@ -1,8 +1,15 @@
 export const navItems = [
-  { href: '#problem', label: 'Problem and Solution' },
-  { href: '#workflow', label: 'How It Works' },
+  { href: '#solution', label: 'Problem & Solution' },
+  { href: '#how-it-works', label: 'How It Works' },
   { href: '#capabilities', label: 'Capabilities' },
   { href: '#enterprise', label: 'Enterprise' },
+] as const;
+
+export const heroHighlights = [
+  'Built for 800+ engineers',
+  'AI-generated roadmaps',
+  'Smart mentor matching',
+  'Gamified progress',
 ] as const;
 
 export const workflowSteps = [
@@ -10,63 +17,97 @@ export const workflowSteps = [
     step: '01',
     title: 'Progression Blueprint',
     description:
-      'Define capability pathways with measurable milestones and role-specific targets.',
+      'Define precise technical and operational career pathways with measurable milestones, system dependencies, and role-specific target competencies built directly into your program config.',
   },
   {
     step: '02',
-    title: 'Guided Mentorship Execution',
+    title: 'Guided Execution',
     description:
-      'Run mentor-mentee workflows with structured submissions, reviews, and accountability.',
+      'Execute seamless mentor-mentee operations through program templates, structured check-ins, AI-generated tasks, and concrete, async progression checkpoints.',
   },
   {
     step: '03',
     title: 'Outcome Intelligence',
     description:
-      'Track progression health and identify intervention points through AI-assisted signals.',
+      'Gain direct insights into program wellness, detect mentorship blockages or stumbles instantly, and generate actionable strategic feedback to inform promotion review processes.',
   },
 ] as const;
 
-export const capabilities = [
+export const currentStatePoints = [
   {
-    title: 'Mentorship Tracking',
-    bullets: [
-      'Role-aware assignment and oversight',
-      'Submission and feedback lifecycle visibility',
-      'Program-level progress transparency',
-    ],
+    label: 'Ad-hoc matching:',
+    body: 'Programs depend heavily on accidental personal connections and individual efforts, leading to unequal opportunity.',
   },
   {
-    title: 'Progress Systems',
-    bullets: [
-      'Milestone and competency progression',
-      'Pathway standardization across teams',
-      'Measurable capability advancement',
-    ],
+    label: 'No progression blueprint:',
+    body: 'Milestones are generic, non-standardized, and untracked. Mentees lack definitive skill targets.',
   },
   {
-    title: 'AI-Assisted Insights',
-    bullets: [
-      'Early detection of mentorship stalls',
-      'Roadmap acceleration recommendations',
-      'Leader-ready decision summaries',
-    ],
+    label: 'Blind engineering leaders:',
+    body: 'Executive teams cannot see capability growth in real-time, resulting in promotion misalignment and talent churn.',
+  },
+] as const;
+
+export const pathmentSystemPoints = [
+  {
+    label: 'Smart matching:',
+    body: 'Mentees are paired with the right mentors based on skills, goals, and availability, with admin approval.',
+  },
+  {
+    label: 'AI-generated pathways:',
+    body: 'Personalized roadmaps break goals into milestones and actionable tasks, adjusting as progress is made.',
+  },
+  {
+    label: 'Gamified progress:',
+    body: 'Points, badges, and leaderboards keep mentees motivated while leaders see capability growth in real time.',
   },
 ] as const;
 
 export const enterprisePillars = [
   {
-    title: 'Security',
+    icon: 'workspace',
+    title: 'Isolated Workspaces',
     description:
-      'Enterprise-grade controls with isolated deployment patterns and governed access.',
+      'Every company runs in its own dedicated, isolated workspace on a private subdomain, so each organization’s programs, members, and data stay fully separated.',
   },
   {
-    title: 'Scalability',
+    icon: 'roles',
+    title: 'Role-Based Programs',
     description:
-      'Operate mentorship systems across business units without losing process integrity.',
+      'Purpose-built admin, mentor, and mentee experiences with permissions scoped to each role, so the right people see the right tools and information.',
   },
   {
-    title: 'Team-Level Control',
+    icon: 'auth',
+    title: 'Secure Sign-In',
     description:
-      'Program leaders can configure standards, progression rules, and reporting boundaries.',
+      'Straightforward email and password authentication with email verification and secure password reset — scoped to each tenant, with no SSO setup required to get started.',
+  },
+] as const;
+
+export const footerColumns = [
+  {
+    title: 'Product',
+    links: [
+      { href: '#solution', label: 'Problem & Solution' },
+      { href: '#how-it-works', label: 'How It Works' },
+      { href: '#capabilities', label: 'Capabilities' },
+      { href: '#enterprise', label: 'Enterprise Scope' },
+    ],
+  },
+  {
+    title: 'Resources',
+    links: [
+      { href: '#', label: 'Documentation' },
+      { href: '#request-access', label: 'Request Access' },
+      { href: 'mailto:hello@pathment.me', label: 'Contact Support' },
+    ],
+  },
+  {
+    title: 'Company',
+    links: [
+      { href: '#', label: 'About Us' },
+      { href: '#', label: 'Careers' },
+      { href: '#', label: 'Privacy Policy' },
+    ],
   },
 ] as const;

--- a/marketing-site/package-lock.json
+++ b/marketing-site/package-lock.json
@@ -8,17 +8,34 @@
       "name": "marketing-site",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^1.17.0",
         "next": "^16.2.2",
         "react": "19.2.0",
-        "react-dom": "19.2.0"
+        "react-dom": "19.2.0",
+        "react-icons": "^5.6.0"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.3.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.0.1",
+        "tailwindcss": "^4.3.0",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -52,7 +69,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1242,6 +1258,306 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "postcss": "^8.5.10",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/postcss/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1290,7 +1606,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1350,7 +1665,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -1876,7 +2190,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2220,7 +2533,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2520,8 +2832,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2567,6 +2879,20 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
+      "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -2774,7 +3100,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2960,7 +3285,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3503,6 +3827,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4114,6 +4445,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4241,6 +4582,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4285,6 +4887,25 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4352,9 +4973,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -4817,7 +5438,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4827,12 +5447,20 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {
@@ -5457,6 +6085,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwindcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -5498,7 +6147,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5661,7 +6309,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5937,7 +6584,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/marketing-site/package.json
+++ b/marketing-site/package.json
@@ -9,16 +9,20 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "lucide-react": "^1.17.0",
     "next": "^16.2.2",
     "react": "19.2.0",
-    "react-dom": "19.2.0"
+    "react-dom": "19.2.0",
+    "react-icons": "^5.6.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.3.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.0.1",
+    "tailwindcss": "^4.3.0",
     "typescript": "^5"
   }
 }

--- a/marketing-site/postcss.config.mjs
+++ b/marketing-site/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+
+export default config;


### PR DESCRIPTION
## Summary

Rebuilds the `marketing-site` landing page into a light, YC-style design and rewrites the copy so every claim reflects what Pathment actually does.

## Design / stack
- Adds **Tailwind CSS v4** (`@tailwindcss/postcss`), `lucide-react`, and `react-icons` — mirroring the `client-interface` setup.
- New light theme in `globals.css` (brand color tokens, soft shadows, grid-pattern background); fonts switched to **Inter + Instrument Sans**.
- Rebuilt sections: Navbar, Hero (with product dashboard mockup), Problem & Solution, How It Works, Capabilities, Enterprise, Final CTA, Footer.

## Functionality
- **Sign In** now opens a workspace prompt that redirects to `https://<workspace>.pathment.me/login` — there's no global login, tenants sign in on their own subdomain.

## Honest copy (removed fabricated claims)
- ❌ Removed: SOC2, "14,000+ engineers", "94% retention", fake customer logo cloud, fake testimonial, and non-existent integrations (Slack/Teams/Okta/Workday/Notion/GitHub).
- ✅ Replaced with real capabilities (cross-checked against `server/src` models): **smart mentor matching, AI-generated roadmaps, outcome insights, gamified progress** (points/badges/leaderboards/streaks).
- Hero highlights: **built for 800+ engineers** + real product facts.
- Enterprise section limited to true claims: **isolated per-tenant workspaces, role-based access, basic secure sign-in** (no SSO/SOC2 overclaim).

## Notes
- Engineering-focused framing retained (Staff Engineer L6 etc.); can broaden to general roles if desired.
- No testimonial section currently; a founder quote can be added back on request.

## Verification
- `npm run build` passes (TypeScript + static generation green).
- Served output verified: new content present, all fabricated claims absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)