### PR TITLE
Fix: Add Missing Notifications for Extension Requests and Auto-Update Due Date

### DIFF
--- a/server/src/config/notificationMatrix.js
+++ b/server/src/config/notificationMatrix.js
@@ -11,7 +11,9 @@ const NOTIFICATION_EVENTS = {
   SUBMISSION_DEADLINE_PASSED: 'submission_deadline_passed',
   ACCOUNT_CREATED_WELCOME: 'account_created_welcome',
   PASSWORD_RESET: 'password_reset',
-  WEEKLY_PROGRESS_REPORT: 'weekly_progress_report'
+  WEEKLY_PROGRESS_REPORT: 'weekly_progress_report',
+  EXTENSION_REQUESTED: 'extension_requested',
+EXTENSION_HANDLED: 'extension_handled'
 };
 
 const NOTIFICATION_MATRIX = {
@@ -79,7 +81,17 @@ const NOTIFICATION_MATRIX = {
     type: 'system',
     preferenceKey: 'weekly_progress_report',
     channels: { inApp: false, email: true, chat: false }
-  }
+  },
+  [NOTIFICATION_EVENTS.EXTENSION_REQUESTED]: {
+  type: 'task',
+  preferenceKey: 'extension_requested',
+  channels: { inApp: true, email: true, chat: false }
+},
+[NOTIFICATION_EVENTS.EXTENSION_HANDLED]: {
+  type: 'task',
+  preferenceKey: 'extension_handled',
+  channels: { inApp: true, email: true, chat: false }
+}
 };
 
 module.exports = {

--- a/server/src/services/submissionService.js
+++ b/server/src/services/submissionService.js
@@ -154,9 +154,29 @@ class SubmissionService {
       extensionStatus: 'pending'
     });
 
-    return this.getSubmissionById(submission.id);
-  }
+    const fullSubmission = await this.getSubmissionById(submission.id);
 
+    //  ADD: Send notification to mentor
+    await notificationOrchestrator.dispatch({
+      eventKey: NOTIFICATION_EVENTS.EXTENSION_REQUESTED,
+      recipients: [{ userId: task.mentorId }],
+      payload: {
+        title: 'Extension request received',
+        message: `${fullSubmission.assignedTask?.mentee?.firstName || 'Mentee'} requested an extension for "${fullSubmission.assignedTask?.roadmapTask?.title || 'a task'}" for ${extensionData.days || 'additional'} days.`,
+        actionUrl: `/mentor/tasks/${task.id}`,
+        actionLabel: 'Review Request',
+        relatedEntityType: 'task_submission',
+        relatedEntityId: submission.id,
+        emailSubject: 'Pathment: Extension request from mentee'
+      },
+      dedupe: {
+        relatedEntityType: 'extension_requested',
+        relatedEntityId: submission.id
+      }
+    });
+
+    return fullSubmission;
+  }
   /**
    * Approve or reject extension request
    */
@@ -189,13 +209,43 @@ class SubmissionService {
       reviewedAt: new Date()
     });
 
-    if (approved && newDueDate) {
+   let finalDueDate = newDueDate;
+    if (approved) {
+      if (!newDueDate) {
+        // Auto-calculate 3 days from the TASK'S CURRENT DUE DATE 
+        const currentDueDate = new Date(submission.assignedTask.dueDate);
+        currentDueDate.setDate(currentDueDate.getDate() + 3);
+        finalDueDate = currentDueDate.toISOString().split('T')[0];
+      }
       await submission.assignedTask.update({
-        dueDate: newDueDate
+        dueDate: finalDueDate
       });
     }
 
-    return this.getSubmissionById(submissionId);
+    //  ADD: Send notification to mentee
+    const updatedSubmission = await this.getSubmissionById(submissionId);
+    
+    await notificationOrchestrator.dispatch({
+      eventKey: NOTIFICATION_EVENTS.EXTENSION_HANDLED,
+      recipients: [{ userId: submission.assignedTask.menteeId }],
+      payload: {
+        title: approved ? 'Extension approved' : 'Extension request rejected',
+        message: approved
+          ? `Your extension request for "${updatedSubmission.assignedTask?.roadmapTask?.title || 'task'}" was approved. New due date: ${finalDueDate}`
+          : `Your extension request for "${updatedSubmission.assignedTask?.roadmapTask?.title || 'task'}" was rejected.`,
+        actionUrl: `/mentee/tasks/${submission.assignedTask.id}`,
+        actionLabel: 'View Task',
+        relatedEntityType: 'task_submission',
+        relatedEntityId: submission.id,
+        emailSubject: `Pathment: Extension ${approved ? 'approved' : 'rejected'}`
+      },
+      dedupe: {
+        relatedEntityType: 'extension_handled',
+        relatedEntityId: submission.id
+      }
+    });
+
+    return updatedSubmission;
   }
 
   /**


### PR DESCRIPTION
###  Description

This PR fixes two critical issues with the task extension request system:

**Issue 1: Missing Notifications**
- When a mentee sends an extension request → Mentor receives no notification
- When a mentor approves/rejects extension → Mentee receives no notification
- Currently, the notification orchestrator is never called in extension methods

**Issue 2: Auto-Extension Date Not Applied**
- When mentor approves extension without selecting a date → System should auto-set to 3 days
- Currently, due date only updates if a date is explicitly provided
- Result: Task shows old due date in both portals after approval

---

##  Current Behavior (Broken)

### Issue #1: No Notifications

Mentee requests extension
→ mentee calls: submissionService.requestExtension()
→ backend creates submission with extensionStatus='pending'
→  NO notification dispatcher call
→ Mentor never sees notification

Mentor approves extension
→ mentor calls: submissionService.handleExtension(true)
→ backend updates extensionStatus='approved'
→  NO notification dispatcher call
→ Mentee never sees notification

### Issue #2: Old Due Date Still Showing

Timeline:

Original task due date: May 20, 2026

Mentor approves extension (NO date selected):
→ Should auto-set to: May 23, 2026 (current + 3 days)
→ Backend checks: if (approved && newDueDate) {...}
→ newDueDate = undefined (not selected)
→ Update skipped 
→ Due date remains: May 20, 2026 

## Result
 - Mentee sees: "Due: May 20, 2026" (WRONG - should be May 23)
 - Mentor sees: "Due: May 20, 2026" (WRONG - should be May 23)
 - Confusion: Extension approved but deadline didn't change!

---

##  Expected Behavior (Fixed)

### Fix #1: Notifications Sent

Mentee requests extension
→ Creates submission with extensionStatus='pending'
→  Sends notification to MENTOR
→ Mentor sees: "New extension request from [Student Name]"

Mentor approves extension
→ Updates extensionStatus='approved'
→  Sends notification to MENTEE
→ Mentee sees: "Your extension request was approved!"

Mentor rejects extension
→ Updates extensionStatus='rejected'
→  Sends notification to MENTEE
→ Mentee sees: "Your extension request was rejected"


### Fix #2: Auto-Date Applied

Timeline:

Original task due date: May 20, 2026

Mentor approves extension (NO date selected):
→ System calculates: duedate + 3 days = May 23, 2026
→ Backend updates: dueDate = May 23, 2026
→  Due date changed

## Result
- Mentee sees: "Due: May 23, 2026" 
- Mentor sees: "Due: May 23, 2026" 
- Clear: Extension applied with new deadline!
---

##  Files to Change

1. **Backend Service:** `server/src/services/submissionService.js`
2. **Backend Config:** `server/src/config/notificationMatrix.js`

###  Testing Checklist

- [x] Test extension request notification appears for mentor
- [x] Test extension approval notification appears for mentee
- [x] Test extension rejection notification appears for mentee
- [x] Test auto-date calculation (today +3 days)
- [x] Test manual date selection (uses provided date, not auto)
- [x] Test due date updates in both portals immediately
- [x] Test notifications don't duplicate on page refresh
- [x] Test existing task submission workflow still works

###  Type of Change

- [x]  Bug fix
- [ ]  New feature
- [ ]  Documentation

Closes #112

## Screenshoot

https://github.com/user-attachments/assets/8e1e6160-5b4f-4c15-888b-968f5d5ecb40

