### PR TITLE
Feature/ Add markdown support for task descriptions

### DIFF
--- a/client-interface/app/mentee/feedback/[id]/page.tsx
+++ b/client-interface/app/mentee/feedback/[id]/page.tsx
@@ -20,6 +20,7 @@ import {
   User,
 } from 'lucide-react';
 import { useTaskDetail } from '@/lib/hooks/mentee';
+import RichTextEditor from '@/components/shared/RichTextEditor';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -105,7 +106,9 @@ export default function FeedbackView({ params }: PageProps) {
               </span>
             </div>
             {taskDescription && (
-              <p className="text-slate-600 text-sm">{taskDescription}</p>
+              <div className="prose prose-slate max-w-none text-slate-600 text-sm mt-2">
+                <RichTextEditor content={taskDescription} readOnly />
+              </div>
             )}
           </div>
         </div>

--- a/client-interface/app/mentee/tasks/[id]/page.tsx
+++ b/client-interface/app/mentee/tasks/[id]/page.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { useTaskDetail } from '@/lib/hooks/mentee';
 import { PageHeader, StatusBadge } from '@/components/admin/ui';
+import RichTextEditor from '@/components/shared/RichTextEditor';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -79,7 +80,9 @@ export default function TaskDetailsPage({ params }: PageProps) {
                 </span>
               )}
             </div>
-            <p className="text-slate-600">{taskDescription}</p>
+            <div className="prose prose-slate max-w-none text-slate-600">
+              <RichTextEditor content={taskDescription} readOnly />
+            </div>
           </div>
           <StatusBadge status={task.status} />
         </div>

--- a/client-interface/app/mentee/tasks/[id]/submit/page.tsx
+++ b/client-interface/app/mentee/tasks/[id]/submit/page.tsx
@@ -193,7 +193,9 @@ export default function TaskSubmission({ params }: PageProps) {
                 {task.difficulty}
               </span>
             </div>
-            <p className="text-slate-600">{taskDescription}</p>
+            <div className="prose prose-slate max-w-none text-slate-600 mt-2">
+              <RichTextEditor content={taskDescription || ''} readOnly />
+            </div>
             {taskDeliverable && (
               <div className="mt-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
                 <p className="text-sm text-blue-900"><strong>Deliverable:</strong> {taskDeliverable}</p>
@@ -218,7 +220,7 @@ export default function TaskSubmission({ params }: PageProps) {
           <div className="mt-6">
             <h3 className="text-sm font-medium text-slate-900 mb-3">Acceptance Criteria</h3>
             <ul className="space-y-2">
-              {acceptanceCriteria.map((criterion, index) => (
+              {acceptanceCriteria.map((criterion: string, index: number) => (
                 <li key={index} className="flex items-start gap-2 text-slate-700">
                   <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0 mt-0.5" />
                   <span className="text-sm">{criterion}</span>
@@ -232,7 +234,7 @@ export default function TaskSubmission({ params }: PageProps) {
           <div className="mt-6">
             <h3 className="text-sm font-medium text-slate-900 mb-3">Learning Resources</h3>
             <ul className="space-y-2">
-              {resources.map((resource) => (
+              {resources.map((resource: any) => (
                 <li key={resource.id}>
                   <a 
                     href={resource.url}

--- a/client-interface/app/mentee/tasks/page.tsx
+++ b/client-interface/app/mentee/tasks/page.tsx
@@ -5,6 +5,11 @@ import { Clock, CheckCircle2, AlertCircle, FileText, Loader2, Star, Calendar, XC
 import { useMenteeTasks } from '@/lib/hooks/mentee';
 import { StatsCard, SearchAndFilterBar, StatusBadge } from '@/components/admin/ui';
 
+const stripHtml = (html: string) => {
+  if (!html) return '';
+  return html.replace(/<[^>]*>/g, '');
+};
+
 export default function MenteeTasks() {
   const router = useRouter();
   const {
@@ -180,7 +185,7 @@ export default function MenteeTasks() {
                       )}
                       
                       <p className="text-slate-600 text-sm line-clamp-2 mb-3">
-                        {task.roadmapTask?.description}
+                        {stripHtml(task.roadmapTask?.description || task.description || '')}
                       </p>
                       
                       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-slate-600">

--- a/client-interface/app/mentor/tasks/[id]/feedback/page.tsx
+++ b/client-interface/app/mentor/tasks/[id]/feedback/page.tsx
@@ -149,7 +149,9 @@ export default function FeedbackProvision({ params }: PageProps) {
               {task.difficulty}
             </span>
           </div>
-          <p className="text-slate-600 text-sm mb-4">{taskDescription}</p>
+          <div className="prose prose-slate max-w-none text-slate-600 text-sm mb-4">
+            <RichTextEditor content={taskDescription || ''} readOnly />
+          </div>
           
           {taskDeliverable && (
             <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
@@ -161,7 +163,7 @@ export default function FeedbackProvision({ params }: PageProps) {
             <div className="mb-4">
               <h4 className="text-sm text-slate-700 mb-2">Acceptance Criteria</h4>
               <ul className="space-y-1">
-                {acceptanceCriteria.map((criterion, index) => (
+                {acceptanceCriteria.map((criterion: string, index: number) => (
                   <li key={index} className="flex items-start gap-2 text-sm text-slate-600">
                     <CheckCircle2 className="w-4 h-4 text-green-600 shrink-0 mt-0.5" />
                     {criterion}
@@ -198,7 +200,7 @@ export default function FeedbackProvision({ params }: PageProps) {
           <div className="mb-6">
             <h4 className="text-sm text-slate-700 mb-3">Project Links</h4>
             <div className="space-y-2">
-              {submission.submissionUrls.map((url, index) => (
+              {submission.submissionUrls.map((url: string, index: number) => (
                 <a
                   key={index}
                   href={url}
@@ -219,7 +221,7 @@ export default function FeedbackProvision({ params }: PageProps) {
           <div>
             <h4 className="text-sm text-slate-700 mb-3">File Attachments</h4>
             <div className="space-y-2">
-              {submission.files.map((file) => (
+              {submission.files.map((file: any) => (
                 <div
                   key={file.id}
                   className="flex items-center justify-between p-3 bg-slate-50 border border-slate-200 rounded-lg"

--- a/client-interface/app/mentor/tasks/[id]/page.tsx
+++ b/client-interface/app/mentor/tasks/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
 } from 'lucide-react';
 import { useMentorTaskDetail } from '@/lib/hooks/mentor';
 import { PageHeader, StatusBadge } from '@/components/admin/ui';
+import RichTextEditor from '@/components/shared/RichTextEditor';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -98,7 +99,9 @@ export default function MentorTaskDetailsPage({ params }: PageProps) {
                 </span>
               )}
             </div>
-            <p className="text-slate-600">{taskDescription}</p>
+            <div className="prose prose-slate max-w-none text-slate-600">
+              <RichTextEditor content={taskDescription} readOnly />
+            </div>
           </div>
               <StatusBadge status={task.status} />
         </div>

--- a/client-interface/app/mentor/tasks/page.tsx
+++ b/client-interface/app/mentor/tasks/page.tsx
@@ -9,6 +9,7 @@ import {
 import { useMentorTasks } from '@/lib/hooks/mentor';
 import { StatsCard, TabBar, StatusBadge } from '@/components/admin/ui';
 import type { Tab } from '@/components/admin/ui';
+import RichTextEditor from '@/components/shared/RichTextEditor';
 
 export default function MentorTasks() {
   const router = useRouter();
@@ -711,13 +712,11 @@ export default function MentorTasks() {
                     <label className="block text-slate-700 text-sm mb-2">
                       Description <span className="text-red-500">*</span>
                     </label>
-                    <textarea
-                      rows={6}
-                      value={formData.description}
-                      onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                    <RichTextEditor
+                      content={formData.description}
+                      onChange={(html) => setFormData({ ...formData, description: html })}
                       placeholder="Provide detailed instructions for the task..."
-                      required
-                      className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                      minHeight="150px"
                     />
                   </div>
 

--- a/client-interface/components/shared/RichTextEditor.tsx
+++ b/client-interface/components/shared/RichTextEditor.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
@@ -19,23 +20,26 @@ import {
 
 interface RichTextEditorProps {
   content: string;
-  onChange: (content: string) => void;
+  onChange?: (content: string) => void;
   placeholder?: string;
   minHeight?: string;
+  readOnly?: boolean;
 }
 
 export default function RichTextEditor({
   content,
   onChange,
   placeholder = 'Start typing...',
-  minHeight = '200px'
+  minHeight = '200px',
+  readOnly = false
 }: RichTextEditorProps) {
   const editor = useEditor({
     immediatelyRender: false,
+    editable: !readOnly,
     extensions: [
       StarterKit,
       Link.configure({
-        openOnClick: false,
+        openOnClick: readOnly,
         HTMLAttributes: {
           class: 'text-blue-600 underline'
         }
@@ -46,7 +50,7 @@ export default function RichTextEditor({
     ],
     content,
     onUpdate: ({ editor }) => {
-      onChange(editor.getHTML());
+      onChange?.(editor.getHTML());
     },
     editorProps: {
       attributes: {
@@ -55,8 +59,24 @@ export default function RichTextEditor({
     }
   });
 
+  useEffect(() => {
+    if (editor && editor.getHTML() !== content) {
+      editor.commands.setContent(content);
+    }
+  }, [content, editor]);
+
+  useEffect(() => {
+    if (editor) {
+      editor.setEditable(!readOnly);
+    }
+  }, [readOnly, editor]);
+
   if (!editor) {
     return null;
+  }
+
+  if (readOnly) {
+    return <EditorContent editor={editor} />;
   }
 
   const setLink = () => {


### PR DESCRIPTION

## Description

This PR implements rich Markdown formatting support for custom task descriptions across the Pathment client interface, ensuring high security (no `dangerouslySetInnerHTML`), consistent rendering, and a polished user experience.
RichTextEditor component was reused to safely support markdown.


Key changes:
1. **Safe Rich Text Editor Component**:
   * Enhanced the existing TipTap-based `RichTextEditor` with a `readOnly` configuration to safely parse and display HTML/Markdown without using dangerouslysethtml.
2. **Seamless Lifecycle Integration**:
   * Integrated the editor in write mode on the custom task creation page.
   * Migrated all display and interaction screens to use the read-only editor, including:
     * **Mentor Task Details Page** (`app/mentor/tasks/[id]/page.tsx`)
     * **Mentee Task Details Page** (`app/mentee/tasks/[id]/page.tsx`)
     * **Mentee Task Submission Page** (`app/mentee/tasks/[id]/submit/page.tsx`)
     * **Mentee Feedback Details Page** (`app/mentee/feedback/[id]/page.tsx`)
     * **Mentor Review / Grading Page** (`app/mentor/tasks/[id]/feedback/page.tsx`)
     
3. **List View Preview Sanitization**:
   * Added a `stripHtml` to the **Mentee Tasks List Page** (`app/mentee/tasks/page.tsx`) to show clean, plain-text descriptions instead of rendering raw HTML tags inside list card containers.
  


## Related Issue
Closes #106 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

<img width="1872" height="888" alt="Screenshot From 2026-05-31 22-18-38" src="https://github.com/user-attachments/assets/c91e8d9b-21d1-4163-9df1-3d0d9ea16677" />
<img width="1872" height="888" alt="Screenshot From 2026-05-31 22-24-15" src="https://github.com/user-attachments/assets/44b00110-4dd3-4475-9490-585c7eb3fc4a" />
<img width="1500" height="179" alt="image" src="https://github.com/user-attachments/assets/efd8dcb7-c504-4de2-884b-5091fa9fd4f8" />



<!-- Add before/after screenshots or a short screen recording for frontend changes -->
```