### PR TITLE
Feat/reusable task templates

### DIFF
--- a/client-interface/app/mentor/tasks/page.tsx
+++ b/client-interface/app/mentor/tasks/page.tsx
@@ -2,13 +2,27 @@
 
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { useState } from 'react';
 import {
   Search, ClipboardList, Clock, CheckCircle2, AlertCircle, Plus,
-  Loader2, FileText, Star, XCircle, AlertTriangle, BookOpen, CalendarClock
+  Loader2, FileText, Star, XCircle, AlertTriangle, BookOpen, CalendarClock,
+  Copy, Pencil, Trash2, Send, X, Clock1,
+  StarIcon
 } from 'lucide-react';
 import { useMentorTasks } from '@/lib/hooks/mentor';
 import { StatsCard, TabBar, StatusBadge } from '@/components/admin/ui';
 import type { Tab } from '@/components/admin/ui';
+import { MultiSelectMentee } from '@/components/ui/MultiSelectMentee';
+
+function TabLoader() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <Loader2 className="w-8 h-8 animate-spin text-indigo-600" />
+    </div>
+  );
+}
+
+
 
 export default function MentorTasks() {
   const router = useRouter();
@@ -47,7 +61,23 @@ export default function MentorTasks() {
     setCancellingTask,
     setCancelReason,
     handleCancelTask,
+    templates,
+    templatesLoading,
+    handleCreateTemplate,
+    handleUpdateTemplate,
+    handleDeleteTemplate,
+    handleAssignTemplate,
+    handleSaveAndAssign,
+    handleSaveTemplateOnly,
+    mentees: hookMentees,
   } = useMentorTasks();
+
+  const [assigningTemplateId, setAssigningTemplateId] = useState<string | null>(null);
+  const [assignMenteeIds, setAssignMenteeIds] = useState<string[]>([]);
+  const [assignDueDate, setAssignDueDate] = useState('');
+  const [editingTemplate, setEditingTemplate] = useState<any | null>(null);
+  const [editForm, setEditForm] = useState({ title: '', description: '', type: 'custom', difficulty: 'medium', deliverable: '', pointsBase: 10, estimatedHours: 2 });
+  const [deletingTemplateId, setDeletingTemplateId] = useState<string | null>(null);
 
   // ─── UI helpers ──────────────────────────────────────────────────────────
 
@@ -107,12 +137,6 @@ export default function MentorTasks() {
     );
   };
 
-  const TabLoader = () => (
-    <div className="flex items-center justify-center py-12">
-      <Loader2 className="w-8 h-8 animate-spin text-indigo-600" />
-    </div>
-  );
-
   // ─── Render ───────────────────────────────────────────────────────────────
 
   return (
@@ -139,6 +163,7 @@ export default function MentorTasks() {
             { id: 'all',        label: 'All Tasks',          icon: ClipboardList },
             { id: 'roadmap',    label: 'Program Roadmap',    icon: FileText },
             { id: 'create',     label: 'Create Custom Task', icon: Plus },
+            { id: 'templates',  label: 'Templates',          icon: Copy,         count: templates.length > 0 ? templates.length : undefined },
           ] as Tab[]}
           activeTab={activeTab}
           onChange={(id) => handleTabSwitch(id as any)}
@@ -617,8 +642,8 @@ export default function MentorTasks() {
                                       </div>
                                       <p className="text-slate-600 text-sm mb-2">{task.description}</p>
                                       <div className="flex items-center gap-4 text-xs text-slate-500">
-                                        <span>⏱️ {task.estimatedHours}h</span>
-                                        <span>⭐ {task.pointsBase} points</span>
+                                        <span><Clock1 className="w-3.5 h-3.5 inline mr-1" />{task.estimatedHours}h</span>
+                                        <span><Star className="w-3.5 h-3.5 inline mr-1" />{task.pointsBase} points</span>
                                         {task.isMandatory && <span className="text-red-600">● Mandatory</span>}
                                       </div>
                                     </div>
@@ -678,19 +703,15 @@ export default function MentorTasks() {
                     <label className="block text-slate-700 text-sm mb-2">
                       Select Mentee <span className="text-red-500">*</span>
                     </label>
-                    <select
-                      value={formData.menteeId}
-                      onChange={(e) => handleMenteeChange(e.target.value)}
-                      required
-                      className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-                    >
-                      <option value="">Choose a mentee...</option>
-                      {mentees.map((match) => (
-                        <option key={`${match.menteeId}-${match.enrollment?.programId ?? match.enrollment?.program?.name}`} value={match.menteeId}>
-                          {match.mentee?.firstName} {match.mentee?.lastName} - {match.enrollment?.program?.name}
-                        </option>
-                      ))}
-                    </select>
+                    <MultiSelectMentee
+                      options={mentees.map(match => ({
+                        value: match.menteeId,
+                        label: `${match.mentee?.firstName} ${match.mentee?.lastName} - ${match.enrollment?.program?.name}`
+                      }))}
+                      selectedIds={formData.mentees.map(m => m.menteeId)}
+                      onChange={handleMenteeChange}
+                      placeholder="Choose assignees..."
+                    />
                   </div>
 
                   <div>
@@ -774,16 +795,45 @@ export default function MentorTasks() {
                     </div>
                   </div>
 
-                  <div className="flex gap-4">
-                    <button type="submit" className="px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl transition-colors">
-                      Assign Task
+                  <div className="grid md:grid-cols-2 gap-6">
+                    <div>
+                      <label className="block text-slate-700 text-sm mb-2">Estimated Hours</label>
+                      <input
+                        type="number"
+                        value={formData.estimatedHours}
+                        onChange={(e) => setFormData({ ...formData, estimatedHours: parseInt(e.target.value) || 0 })}
+                        placeholder="e.g., 2"
+                        min="1"
+                        className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-4 mt-8 pt-6 border-t border-slate-100">
+                    <button type="submit" className="w-full flex justify-center items-center gap-2 px-6 py-3.5 bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-xl transition-all shadow-sm shadow-indigo-200 hover:shadow-md">
+                      <Send className="w-4 h-4" />Assign Task
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleSaveAndAssign}
+                      className="w-full flex justify-center items-center gap-2 px-6 py-3.5  bg-purple-600 hover:bg-purple-700 text-white font-medium rounded-xl transition-all shadow-sm shadow-purple-200 hover:shadow-md"
+                    >
+                      <Copy className="w-4 h-4" />Save & Assign
+                    </button>
+                    
+                    <button
+                      type="button"
+                      onClick={handleSaveTemplateOnly}
+                      className="w-full flex justify-center items-center gap-2 px-6 py-3 bg-indigo-50 hover:bg-indigo-100 text-indigo-700 font-medium rounded-xl transition-colors"
+                    >
+                      <BookOpen className="w-4 h-4" />Save as Template Only
                     </button>
                     <button
                       type="button"
                       onClick={() => handleTabSwitch('all')}
-                      className="px-6 py-3 bg-white hover:bg-slate-50 border border-slate-200 text-slate-700 rounded-xl transition-colors"
+                      className="w-full flex justify-center items-center gap-2 px-6 py-3 bg-white hover:bg-slate-50 border border-slate-200 text-slate-700 font-medium rounded-xl transition-colors"
                     >
-                      Cancel
+                      <X className="w-4 h-4" />Cancel
                     </button>
                   </div>
                 </form>
@@ -804,6 +854,262 @@ export default function MentorTasks() {
                   </div>
                 </div>
               </div>
+            </div>
+          )}
+
+          {activeTab === 'templates' && (
+            <div>
+              <div className="flex items-center justify-between mb-6">
+                <h3 className="text-slate-900">Saved Templates</h3>
+                <button
+                  onClick={() => handleTabSwitch('create')}
+                  className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl text-sm font-medium transition-colors flex items-center gap-2"
+                >
+                  <Plus className="w-4 h-4" />Create Task
+                </button>
+              </div>
+
+              {templatesLoading ? (
+                <TabLoader />
+              ) : templates.length === 0 ? (
+                <div className="text-center py-12">
+                  <Copy className="w-12 h-12 text-slate-300 mx-auto mb-3" />
+                  <p className="text-slate-600 mb-2">No templates yet</p>
+                  <p className="text-slate-500 text-sm">When you create a custom task, use &quot;Save as Template &amp; Assign&quot; to save it here for reuse.</p>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {templates.map((tpl: any) => (
+                    <div key={tpl.id} className="p-5 bg-white rounded-xl border border-slate-200 hover:border-indigo-200 transition-colors">
+                      <div className="flex items-start justify-between mb-3">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <h4 className="text-slate-900 font-medium">{tpl.title}</h4>
+                            <span className={`px-2 py-0.5 rounded text-xs font-medium ${
+                              tpl.difficulty === 'easy' ? 'bg-green-100 text-green-700' :
+                              tpl.difficulty === 'medium' ? 'bg-yellow-100 text-yellow-700' :
+                              tpl.difficulty === 'hard' ? 'bg-orange-100 text-orange-700' :
+                              'bg-red-100 text-red-700'
+                            }`}>{tpl.difficulty}</span>
+                            <span className="px-2 py-0.5 bg-blue-100 text-blue-700 rounded text-xs font-medium">{tpl.type}</span>
+                          </div>
+                          <p className="text-slate-600 text-sm line-clamp-2">{tpl.description}</p>
+                          <div className="flex items-center gap-4 text-xs text-slate-500 mt-2">
+                            <span><StarIcon className="w-3.5 h-3.5 inline mr-1" />{tpl.pointsBase} points</span>
+                            {tpl.estimatedHours && <span><Clock1 className="w-3.5 h-3.5 inline mr-1" />{tpl.estimatedHours}h</span>}
+                            <span>Created {new Date(tpl.createdAt).toLocaleDateString()}</span>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <button
+                            onClick={() => setAssigningTemplateId(tpl.id)}
+                            className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5"
+                          >
+                            <Send className="w-3.5 h-3.5" />Assign
+                          </button>
+                          <button
+                            onClick={() => {
+                              setEditingTemplate(tpl);
+                              setEditForm({
+                                title: tpl.title,
+                                description: tpl.description,
+                                type: tpl.type,
+                                difficulty: tpl.difficulty,
+                                deliverable: tpl.deliverable || '',
+                                pointsBase: tpl.pointsBase,
+                                estimatedHours: tpl.estimatedHours || 2,
+                              });
+                            }}
+                            className="p-2 text-slate-500 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors"
+                            title="Edit template"
+                          >
+                            <Pencil className="w-4 h-4" />
+                          </button>
+                          <button
+                            onClick={() => setDeletingTemplateId(tpl.id)}
+                            className="p-2 text-slate-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                            title="Delete template"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </button>
+                        </div>
+                      </div>
+
+                      {assigningTemplateId === tpl.id && (
+                        <div className="mt-3 p-4 bg-indigo-50 border border-indigo-200 rounded-lg">
+                          <p className="text-indigo-900 font-medium text-sm mb-3">Assign this template to a mentee</p>
+                          <div className="grid sm:grid-cols-2 gap-3 mb-3">
+                            <MultiSelectMentee
+                              options={hookMentees.map((match: any) => ({
+                                value: `${match.menteeId}::${match.enrollmentId}`,
+                                label: `${match.mentee?.firstName} ${match.mentee?.lastName} - ${match.enrollment?.program?.name}`
+                              }))}
+                              selectedIds={assignMenteeIds}
+                              onChange={setAssignMenteeIds}
+                              placeholder="Choose assignees..."
+                            />
+                            <input
+                              type="date"
+                              value={assignDueDate}
+                              onChange={(e) => setAssignDueDate(e.target.value)}
+                              min={new Date().toISOString().split('T')[0]}
+                              className="w-full px-3 py-2 border border-indigo-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm bg-white"
+                              placeholder="Due date (optional)"
+                            />
+                          </div>
+                          <div className="flex gap-2">
+                            <button
+                              onClick={async () => {
+                                if (assignMenteeIds.length === 0) return;
+                                const menteesData = assignMenteeIds.map(idStr => {
+                                  const [mId, eId] = idStr.split('::');
+                                  return { menteeId: mId, enrollmentId: eId };
+                                });
+                                await handleAssignTemplate(tpl.id, menteesData, assignDueDate || undefined);
+                                setAssigningTemplateId(null);
+                                setAssignMenteeIds([]);
+                                setAssignDueDate('');
+                              }}
+                              disabled={assignMenteeIds.length === 0}
+                              className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 disabled:cursor-not-allowed text-white rounded-lg text-sm transition-colors"
+                            >
+                              Assign
+                            </button>
+                            <button
+                              onClick={() => { setAssigningTemplateId(null); setAssignMenteeIds([]); setAssignDueDate(''); }}
+                              className="px-4 py-2 bg-white hover:bg-slate-50 text-slate-700 rounded-lg text-sm transition-colors border border-slate-200"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      )}
+
+                      {editingTemplate?.id === tpl.id && (
+                        <div className="mt-3 p-4 bg-slate-50 border border-slate-200 rounded-lg">
+                          <div className="flex items-center justify-between mb-3">
+                            <p className="text-slate-900 font-medium text-sm">Edit Template</p>
+                            <button onClick={() => setEditingTemplate(null)} className="text-slate-400 hover:text-slate-600">
+                              <X className="w-4 h-4" />
+                            </button>
+                          </div>
+                          <div className="space-y-4">
+                            <div>
+                              <label className="block text-slate-700 text-xs font-medium mb-1.5">Title <span className="text-red-500">*</span></label>
+                              <input
+                                value={editForm.title}
+                                onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
+                                className="w-full px-3 py-2.5 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                                placeholder="Template Title"
+                              />
+                            </div>
+                            <div>
+                              <label className="block text-slate-700 text-xs font-medium mb-1.5">Description <span className="text-red-500">*</span></label>
+                              <textarea
+                                value={editForm.description}
+                                onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
+                                className="w-full px-3 py-2.5 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                                rows={3}
+                                placeholder="Detailed description..."
+                              />
+                            </div>
+                            <div className="grid grid-cols-2 gap-4">
+                              <div>
+                                <label className="block text-slate-700 text-xs font-medium mb-1.5">Task Type</label>
+                                <select value={editForm.type} onChange={(e) => setEditForm({ ...editForm, type: e.target.value })} className="w-full px-3 py-2.5 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm">
+                                  <option value="custom">Custom</option>
+                                  <option value="exercise">Exercise</option>
+                                  <option value="project">Project</option>
+                                  <option value="practical">Practical</option>
+                                </select>
+                              </div>
+                              <div>
+                                <label className="block text-slate-700 text-xs font-medium mb-1.5">Difficulty</label>
+                                <select value={editForm.difficulty} onChange={(e) => setEditForm({ ...editForm, difficulty: e.target.value })} className="w-full px-3 py-2.5 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm">
+                                  <option value="easy">Easy</option>
+                                  <option value="medium">Medium</option>
+                                  <option value="hard">Hard</option>
+                                  <option value="expert">Expert</option>
+                                </select>
+                              </div>
+                            </div>
+                            <div className="grid grid-cols-2 gap-4">
+                              <div>
+                                <label className="block text-slate-700 text-xs font-medium mb-1.5">Points Base</label>
+                                <input
+                                  type="number"
+                                  value={editForm.pointsBase}
+                                  onChange={(e) => setEditForm({ ...editForm, pointsBase: parseInt(e.target.value) || 0 })}
+                                  className="w-full px-3 py-2.5 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                                  placeholder="e.g., 100"
+                                  min="0"
+                                />
+                              </div>
+                              <div>
+                                <label className="block text-slate-700 text-xs font-medium mb-1.5">Estimated Hours</label>
+                                <input
+                                  type="number"
+                                  value={editForm.estimatedHours}
+                                  onChange={(e) => setEditForm({ ...editForm, estimatedHours: parseInt(e.target.value) || 0 })}
+                                  className="w-full px-3 py-2.5 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                                  placeholder="e.g., 2"
+                                  min="0"
+                                />
+                              </div>
+                            </div>
+                            <div className="flex gap-2">
+                              <button
+                                onClick={async () => {
+                                  await handleUpdateTemplate(tpl.id, editForm);
+                                  setEditingTemplate(null);
+                                }}
+                                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-sm transition-colors"
+                              >
+                                Save Changes
+                              </button>
+                              <button
+                                onClick={() => setEditingTemplate(null)}
+                                className="px-4 py-2 bg-white hover:bg-slate-50 text-slate-700 rounded-lg text-sm transition-colors border border-slate-200"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+
+                      {deletingTemplateId === tpl.id && (
+                        <div className="mt-3 p-4 bg-red-50 border border-red-200 rounded-lg">
+                          <div className="flex items-start gap-3">
+                            <AlertTriangle className="w-5 h-5 text-red-600 mt-0.5" />
+                            <div className="flex-1">
+                              <p className="text-red-900 font-medium mb-1">Delete this template?</p>
+                              <p className="text-red-700 text-sm mb-3">This won't affect tasks already assigned from this template.</p>
+                              <div className="flex gap-2">
+                                <button
+                                  onClick={async () => {
+                                    await handleDeleteTemplate(tpl.id);
+                                    setDeletingTemplateId(null);
+                                  }}
+                                  className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm transition-colors"
+                                >
+                                  Delete
+                                </button>
+                                <button
+                                  onClick={() => setDeletingTemplateId(null)}
+                                  className="px-4 py-2 bg-white hover:bg-slate-50 text-slate-700 rounded-lg text-sm transition-colors border border-slate-200"
+                                >
+                                  Keep
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           )}
 

--- a/client-interface/components/ui/MultiSelectMentee.tsx
+++ b/client-interface/components/ui/MultiSelectMentee.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { ChevronDown, Check } from 'lucide-react';
+
+interface MultiSelectMenteeProps {
+  options: { value: string; label: string }[];
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+  placeholder?: string;
+}
+
+export function MultiSelectMentee({ 
+  options, 
+  selectedIds, 
+  onChange, 
+  placeholder = "Choose mentees..." 
+}: MultiSelectMenteeProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const toggleOption = (id: string) => {
+    if (selectedIds.includes(id)) {
+      onChange(selectedIds.filter(i => i !== id));
+    } else {
+      onChange([...selectedIds, id]);
+    }
+  };
+
+  const selectedText = selectedIds.length === 0 
+    ? placeholder 
+    : selectedIds.length === 1 
+      ? options.find(o => o.value === selectedIds[0])?.label 
+      : `${selectedIds.length} mentees selected`;
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <div 
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent flex justify-between items-center bg-white cursor-pointer transition-colors hover:border-slate-300"
+      >
+        <span className={selectedIds.length === 0 ? "text-slate-500" : "text-slate-900"}>{selectedText}</span>
+        <ChevronDown className={`w-5 h-5 text-slate-400 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} />
+      </div>
+      
+      {isOpen && (
+        <div className="absolute z-10 w-full mt-1 bg-white border border-slate-200 rounded-xl shadow-lg max-h-60 overflow-y-auto outline-none">
+          {options.length === 0 ? (
+            <div className="px-4 py-3 text-slate-500 text-sm">No mentees available</div>
+          ) : (
+            options.map(option => {
+              const isSelected = selectedIds.includes(option.value);
+              return (
+                <div 
+                  key={option.value}
+                  onClick={() => toggleOption(option.value)}
+                  className={`flex items-center justify-between px-4 py-3 cursor-pointer transition-colors ${
+                    isSelected 
+                      ? 'bg-green-50 text-green-700' 
+                      : 'hover:bg-slate-50 text-slate-700'
+                  }`}
+                >
+                  <span className="text-sm font-medium">{option.label}</span>
+                  {isSelected && <Check className="w-4 h-4 text-green-600" />}
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client-interface/lib/hooks/mentor/useMentorTasks.ts
+++ b/client-interface/lib/hooks/mentor/useMentorTasks.ts
@@ -9,30 +9,30 @@ import { useAuth } from '@/lib/context/AuthContext';
 import { extractApiErrorMessage } from '@/lib/utils/api-error';
 import { toast } from 'sonner';
 
-export type MentorTaskTab = 'pending' | 'extensions' | 'all' | 'roadmap' | 'create';
+export type MentorTaskTab = 'pending' | 'extensions' | 'all' | 'roadmap' | 'create' | 'templates';
 
 export interface CustomTaskFormData {
-  menteeId: string;
-  enrollmentId: string;
+  mentees: { menteeId: string; enrollmentId: string }[];
   title: string;
   description: string;
   type: string;
   difficulty: string;
   dueDate: string;
   pointsBase: number;
+  estimatedHours: number;
   deliverable: string;
   acceptanceCriteria: string[];
 }
 
 const EMPTY_FORM: CustomTaskFormData = {
-  menteeId: '',
-  enrollmentId: '',
+  mentees: [],
   title: '',
   description: '',
   type: 'custom',
   difficulty: 'medium',
   dueDate: '',
   pointsBase: 10,
+  estimatedHours: 2,
   deliverable: '',
   acceptanceCriteria: [],
 };
@@ -79,19 +79,31 @@ export interface UseMentorTasksReturn {
   // create form
   formData: CustomTaskFormData;
   setFormData: React.Dispatch<React.SetStateAction<CustomTaskFormData>>;
-  handleMenteeChange: (menteeId: string) => void;
+  handleMenteeChange: (menteeIds: string[]) => void;
   handleCreateCustomTask: (e: React.FormEvent) => Promise<void>;
+  handleSaveAndAssign: (e: React.FormEvent) => Promise<void>;
+  handleSaveTemplateOnly: (e: React.FormEvent) => Promise<void>;
 
   // cancel
   cancellingTask: string | null;
   cancelReason: string;
   setCancellingTask: (id: string | null) => void;
   setCancelReason: (v: string) => void;
+
+  // templates
+  templates: any[];
+  templatesLoading: boolean;
+  fetchTemplates: () => Promise<void>;
+  handleCreateTemplate: (data: any) => Promise<void>;
+  handleUpdateTemplate: (id: string, data: any) => Promise<void>;
+  handleDeleteTemplate: (id: string) => Promise<void>;
+  handleAssignTemplate: (templateId: string, menteesData: { menteeId: string; enrollmentId: string }[], dueDate?: string) => Promise<void>;
   handleCancelTask: (taskId: string) => Promise<void>;
 }
 
 export function useMentorTasks(): UseMentorTasksReturn {
   const { user } = useAuth();
+  const userId = user?.id;
   const searchParams = useSearchParams();
 
   const [activeTab, setActiveTab] = useState<MentorTaskTab>('pending');
@@ -125,39 +137,43 @@ export function useMentorTasks(): UseMentorTasksReturn {
   const [cancelReason, setCancelReason] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
 
+  const [templates, setTemplates] = useState<any[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(false);
+  const [templatesLoaded, setTemplatesLoaded] = useState(false);
+
   // ─── Fetchers ─────────────────────────────────────────────────────────────
 
   const fetchStats = useCallback(async () => {
-    if (!user?.id) return;
+    if (!userId) return;
     try {
       setStatsLoading(true);
-      const res = await taskApi.getMentorTaskStats(user.id);
+      const res = await taskApi.getMentorTaskStats(userId);
       setStats(res?.data?.stats);
     } catch {
       // non-critical
     } finally {
       setStatsLoading(false);
     }
-  }, [user?.id]);
+  }, [userId]);
 
   const fetchPendingTasks = useCallback(async () => {
-    if (!user?.id) return;
+    if (!userId) return;
     try {
       setPendingLoading(true);
-      const res = await taskApi.getMentorTasks(user.id, { pendingReview: true });
+      const res = await taskApi.getMentorTasks(userId, { pendingReview: true });
       setPendingTasks(res?.data?.tasks || []);
     } catch {
       toast.error('Failed to load pending tasks');
     } finally {
       setPendingLoading(false);
     }
-  }, [user?.id]);
+  }, [userId]);
 
   const fetchAllTasks = useCallback(async () => {
-    if (!user?.id) return;
+    if (!userId) return;
     try {
       setAllTasksLoading(true);
-      const res = await taskApi.getMentorTasks(user.id);
+      const res = await taskApi.getMentorTasks(userId);
       setAllTasks(res?.data?.tasks || []);
       setAllTasksLoaded(true);
     } catch {
@@ -165,13 +181,13 @@ export function useMentorTasks(): UseMentorTasksReturn {
     } finally {
       setAllTasksLoading(false);
     }
-  }, [user?.id]);
+  }, [userId]);
 
   const fetchMentees = useCallback(async (): Promise<any[]> => {
-    if (!user?.id) return [];
+    if (!userId) return [];
     try {
       setMenteesLoading(true);
-      const res = await matchingApi.getMatches({ mentorId: user.id, status: 'active' });
+      const res = await matchingApi.getMatches({ mentorId: userId, status: 'active' });
       const list = res?.data?.matches || res?.matches || [];
       setMentees(list);
       setMenteesLoaded(true);
@@ -182,7 +198,7 @@ export function useMentorTasks(): UseMentorTasksReturn {
     } finally {
       setMenteesLoading(false);
     }
-  }, [user?.id]);
+  }, [userId]);
 
   const fetchMentorLevelAssignments = useCallback(async (): Promise<any[]> => {
     try {
@@ -209,10 +225,23 @@ export function useMentorTasks(): UseMentorTasksReturn {
     }
   }, []);
 
+  const fetchTemplates = useCallback(async () => {
+    try {
+      setTemplatesLoading(true);
+      const res = await taskApi.getTemplates();
+      setTemplates(res?.data?.templates || []);
+      setTemplatesLoaded(true);
+    } catch {
+      toast.error('Failed to load templates');
+    } finally {
+      setTemplatesLoading(false);
+    }
+  }, []);
+
   // ─── Initial boot ─────────────────────────────────────────────────────────
 
   useEffect(() => {
-    if (!user?.id) return;
+    if (!userId) return;
 
     const paramTab = searchParams.get('tab') as MentorTaskTab | null;
     const paramMenteeId = searchParams.get('menteeId');
@@ -234,8 +263,7 @@ export function useMentorTasks(): UseMentorTasksReturn {
             const levelId = match.levelId || '';
             setFormData((prev) => ({
               ...prev,
-              menteeId: paramMenteeId,
-              enrollmentId: match.enrollmentId || '',
+              mentees: [{ menteeId: paramMenteeId, enrollmentId: match.enrollmentId || '' }],
             }));
             setSelectedMenteeForAssign(paramMenteeId);
             if (programId) setSelectedProgram(programId);
@@ -253,7 +281,7 @@ export function useMentorTasks(): UseMentorTasksReturn {
       if (paramTab) setActiveTab(paramTab);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.id]);
+  }, [userId]);
 
   // ─── Tab switch ───────────────────────────────────────────────────────────
 
@@ -269,6 +297,10 @@ export function useMentorTasks(): UseMentorTasksReturn {
       if ((tab === 'roadmap' || tab === 'create') && !mentorLevelsLoaded && !mentorLevelsLoading) {
         fetchMentorLevelAssignments();
       }
+      if (tab === 'templates' && !templatesLoaded && !templatesLoading) {
+        fetchTemplates();
+        if (!menteesLoaded && !menteesLoading) fetchMentees();
+      }
     },
     [
       allTasksLoaded,
@@ -280,6 +312,9 @@ export function useMentorTasks(): UseMentorTasksReturn {
       mentorLevelsLoaded,
       mentorLevelsLoading,
       fetchMentorLevelAssignments,
+      templatesLoaded,
+      templatesLoading,
+      fetchTemplates,
     ]
   );
 
@@ -337,8 +372,8 @@ export function useMentorTasks(): UseMentorTasksReturn {
   const handleCreateCustomTask = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
-      if (!formData.menteeId || !formData.title || !formData.description) {
-        toast.error('Please fill in all required fields');
+      if (formData.mentees.length === 0 || !formData.title || !formData.description) {
+        toast.error('Please fill in all required fields and select at least one mentee');
         return;
       }
       try {
@@ -378,10 +413,127 @@ export function useMentorTasks(): UseMentorTasksReturn {
     [cancelReason, fetchStats, fetchPendingTasks, allTasksLoaded, fetchAllTasks]
   );
 
+  const handleCreateTemplate = useCallback(async (data: any) => {
+    try {
+      await taskApi.createTemplate(data);
+      toast.success('Template saved');
+      fetchTemplates();
+    } catch (error: any) {
+      toast.error(extractApiErrorMessage(error, 'Failed to save template'));
+    }
+  }, [fetchTemplates]);
+
+  const handleUpdateTemplate = useCallback(async (id: string, data: any) => {
+    try {
+      await taskApi.updateTemplate(id, data);
+      toast.success('Template updated');
+      fetchTemplates();
+    } catch (error: any) {
+      toast.error(extractApiErrorMessage(error, 'Failed to update template'));
+    }
+  }, [fetchTemplates]);
+
+  const handleDeleteTemplate = useCallback(async (id: string) => {
+    try {
+      await taskApi.deleteTemplate(id);
+      toast.success('Template deleted');
+      fetchTemplates();
+    } catch (error: any) {
+      toast.error(extractApiErrorMessage(error, 'Failed to delete template'));
+    }
+  }, [fetchTemplates]);
+
+  const handleAssignTemplate = useCallback(async (templateId: string, menteesData: { menteeId: string, enrollmentId: string }[], dueDate?: string) => {
+    try {
+      await taskApi.assignTemplate(templateId, { mentees: menteesData, dueDate });
+      toast.success('Template assigned to mentees');
+      fetchStats();
+      setAllTasksLoaded(false);
+    } catch (error: any) {
+      toast.error(extractApiErrorMessage(error, 'Failed to assign template'));
+    }
+  }, [fetchStats]);
+
+  const handleSaveAndAssign = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (formData.mentees.length === 0 || !formData.title || !formData.description) {
+        toast.error('Please fill in all required fields and select at least one mentee');
+        return;
+      }
+      try {
+        const templatePayload = {
+          title: formData.title,
+          description: formData.description,
+          type: formData.type,
+          difficulty: formData.difficulty,
+          deliverable: formData.deliverable,
+          acceptanceCriteria: formData.acceptanceCriteria,
+          pointsBase: formData.pointsBase,
+          estimatedHours: formData.estimatedHours,
+        };
+        await taskApi.createTemplate(templatePayload);
+
+        await taskApi.createCustomTask(formData);
+        toast.success('Task assigned and saved as template');
+        setFormData(EMPTY_FORM);
+        fetchStats();
+        fetchPendingTasks();
+        setAllTasksLoaded(false);
+        setTemplatesLoaded(false);
+        setActiveTab('all');
+        fetchAllTasks();
+      } catch (error: any) {
+        toast.error(extractApiErrorMessage(error, 'Failed to save and assign'));
+      }
+    },
+    [formData, fetchStats, fetchPendingTasks, fetchAllTasks]
+  );
+
+  const handleSaveTemplateOnly = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!formData.title || !formData.description) {
+        toast.error('Please provide a title and description to save as a template');
+        return;
+      }
+      
+      const templatePayload = {
+        title: formData.title,
+        description: formData.description,
+        type: formData.type,
+        difficulty: formData.difficulty,
+        deliverable: formData.deliverable,
+        acceptanceCriteria: formData.acceptanceCriteria,
+        pointsBase: formData.pointsBase,
+        estimatedHours: formData.estimatedHours,
+      };
+
+      try {
+        await taskApi.createTemplate(templatePayload);
+
+
+        toast.success('Template saved successfully');
+        setFormData(EMPTY_FORM);
+        setTemplatesLoaded(false);
+        setActiveTab('templates');
+      } catch (error: any) {
+        toast.error(extractApiErrorMessage(error, 'Failed to save template'));
+      }
+    },
+    [formData]
+  );
+
   const handleMenteeChange = useCallback(
-    (menteeId: string) => {
-      const match = mentees.find((m) => m.menteeId === menteeId);
-      setFormData((prev) => ({ ...prev, menteeId, enrollmentId: match?.enrollmentId || '' }));
+    (menteeIds: string[]) => {
+      const selectedMentees = menteeIds.map(id => {
+        const match = mentees.find((m) => m.menteeId === id);
+        return {
+          menteeId: id,
+          enrollmentId: match?.enrollmentId || ''
+        };
+      });
+      setFormData((prev) => ({ ...prev, mentees: selectedMentees }));
     },
     [mentees]
   );
@@ -438,10 +590,19 @@ export function useMentorTasks(): UseMentorTasksReturn {
     setFormData,
     handleMenteeChange,
     handleCreateCustomTask,
+    handleSaveAndAssign,
+    handleSaveTemplateOnly,
     cancellingTask,
     cancelReason,
     setCancellingTask,
     setCancelReason,
     handleCancelTask,
+    templates,
+    templatesLoading,
+    fetchTemplates,
+    handleCreateTemplate,
+    handleUpdateTemplate,
+    handleDeleteTemplate,
+    handleAssignTemplate,
   };
 }

--- a/client-interface/lib/services/task-api.ts
+++ b/client-interface/lib/services/task-api.ts
@@ -66,7 +66,43 @@ export const taskApi = {
 
   // Admin APIs
   autoAssignWeekTasks: (enrollmentId: string, weekNumber: number) =>
-    apiClient.post('/tasks/auto-assign', { enrollmentId, weekNumber })
+    apiClient.post('/tasks/auto-assign', { enrollmentId, weekNumber }),
+
+  getTemplates: () =>
+    apiClient.get('/tasks/templates'),
+
+  createTemplate: (data: {
+    title: string;
+    description: string;
+    type?: string;
+    difficulty?: string;
+    deliverable?: string;
+    acceptanceCriteria?: string[];
+    estimatedHours?: number;
+    pointsBase?: number;
+  }) =>
+    apiClient.post('/tasks/templates', data),
+
+  updateTemplate: (templateId: string, data: {
+    title?: string;
+    description?: string;
+    type?: string;
+    difficulty?: string;
+    deliverable?: string;
+    acceptanceCriteria?: string[];
+    estimatedHours?: number;
+    pointsBase?: number;
+  }) =>
+    apiClient.put(`/tasks/templates/${templateId}`, data),
+
+  deleteTemplate: (templateId: string) =>
+    apiClient.delete(`/tasks/templates/${templateId}`),
+
+  assignTemplate: (templateId: string, data: {
+    mentees: { menteeId: string; enrollmentId: string }[];
+    dueDate?: string;
+  }) =>
+    apiClient.post(`/tasks/templates/${templateId}/assign`, data),
 };
 
 export default taskApi;

--- a/server/scripts/migrations/007_add_task_templates.js
+++ b/server/scripts/migrations/007_add_task_templates.js
@@ -1,0 +1,69 @@
+require('dotenv').config({ path: require('path').join(__dirname, '../../.env') });
+const { sequelize } = require('../../src/db');
+
+async function up() {
+  console.log('Running migration: Create task_templates table...');
+
+  try {
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS task_templates (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        mentor_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        title VARCHAR(255) NOT NULL,
+        description TEXT NOT NULL,
+        type VARCHAR(20) NOT NULL DEFAULT 'custom',
+        difficulty VARCHAR(20) NOT NULL DEFAULT 'medium',
+        deliverable TEXT,
+        acceptance_criteria TEXT[] DEFAULT '{}',
+        estimated_hours INTEGER DEFAULT 5,
+        points_base INTEGER DEFAULT 10,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+    `);
+
+    await sequelize.query(`
+      CREATE INDEX IF NOT EXISTS idx_task_templates_mentor_id ON task_templates(mentor_id);
+    `);
+
+    console.log('Migration completed successfully!');
+    console.log('   - Created task_templates table');
+    console.log('   - Added mentor_id index');
+  } catch (error) {
+    console.error('Migration failed:', error.message);
+    throw error;
+  }
+}
+
+async function down() {
+  console.log('Rolling back migration: Drop task_templates table...');
+
+  try {
+    await sequelize.query(`DROP TABLE IF EXISTS task_templates CASCADE;`);
+    console.log('Rollback completed successfully!');
+  } catch (error) {
+    console.error('Rollback failed:', error.message);
+    throw error;
+  }
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const isRollback = args.includes('--rollback') || args.includes('-r');
+
+  (async () => {
+    try {
+      if (isRollback) {
+        await down();
+      } else {
+        await up();
+      }
+      process.exit(0);
+    } catch (error) {
+      console.error(error);
+      process.exit(1);
+    }
+  })();
+}
+
+module.exports = { up, down };

--- a/server/src/controllers/taskController.js
+++ b/server/src/controllers/taskController.js
@@ -20,8 +20,28 @@ exports.autoAssignWeekTasks = catchAsync(async (req, res) => {
 exports.createCustomTask = catchAsync(async (req, res) => {
   const mentorId = req.user.id;
   
-  const task = await taskService.createCustomTask(req.body, mentorId);
-  res.status(201).json(successResponse('Custom task created successfully', { task }, 201));
+  if (req.body.mentees && Array.isArray(req.body.mentees) && req.body.mentees.length > 0) {
+    const results = {
+      successful: [],
+      failed: []
+    };
+    for (const mentee of req.body.mentees) {
+      try {
+        const task = await taskService.createCustomTask({
+          ...req.body,
+          menteeId: mentee.menteeId,
+          enrollmentId: mentee.enrollmentId
+        }, mentorId);
+        results.successful.push({ menteeId: mentee.menteeId, taskId: task.assignedTasks?.[0]?.id });
+      } catch (error) {
+        results.failed.push({ menteeId: mentee.menteeId, reason: error.message });
+      }
+    }
+    return res.status(201).json(successResponse('Custom tasks creation completed', results, 201));
+  } else {
+    const task = await taskService.createCustomTask(req.body, mentorId);
+    return res.status(201).json(successResponse('Custom task created successfully', { task }, 201));
+  }
 });
 
 /**

--- a/server/src/controllers/taskTemplateController.js
+++ b/server/src/controllers/taskTemplateController.js
@@ -1,0 +1,65 @@
+const taskTemplateService = require('../services/taskTemplateService');
+const taskService = require('../services/taskService');
+const { successResponse } = require('../utils/responses');
+const { catchAsync } = require('../middlewares/errorHandler');
+const { ValidationError } = require('../utils/errors/errorTypes');
+
+exports.createTemplate = catchAsync(async (req, res) => {
+  const template = await taskTemplateService.createTemplate(req.user.id, req.body);
+  res.status(201).json(successResponse('Template created', { template }, 201));
+});
+
+exports.getTemplates = catchAsync(async (req, res) => {
+  const templates = await taskTemplateService.getTemplatesByMentor(req.user.id);
+  res.status(200).json(successResponse('Templates retrieved', { templates }));
+});
+
+exports.updateTemplate = catchAsync(async (req, res) => {
+  const template = await taskTemplateService.updateTemplate(req.params.id, req.user.id, req.body);
+  res.status(200).json(successResponse('Template updated', { template }));
+});
+
+exports.deleteTemplate = catchAsync(async (req, res) => {
+  const result = await taskTemplateService.deleteTemplate(req.params.id, req.user.id);
+  res.status(200).json(successResponse(result.message, {}));
+});
+
+exports.assignTemplate = catchAsync(async (req, res) => {
+  const { mentees, dueDate } = req.body;
+
+  if (!mentees || !Array.isArray(mentees) || mentees.length === 0) {
+    throw new ValidationError('No mentees provided');
+  }
+
+  const template = await taskTemplateService.getTemplateById(req.params.id, req.user.id);
+
+  const results = {
+    successful: [],
+    failed: []
+  };
+
+  for (const mentee of mentees) {
+    try {
+      const task = await taskService.createCustomTask({
+        menteeId: mentee.menteeId,
+        enrollmentId: mentee.enrollmentId,
+        title: template.title,
+        description: template.description,
+        type: template.type,
+        difficulty: template.difficulty,
+        deliverable: template.deliverable,
+        acceptanceCriteria: template.acceptanceCriteria,
+        pointsBase: template.pointsBase,
+        estimatedHours: template.estimatedHours,
+        dueDate
+      }, req.user.id);
+      results.successful.push({ menteeId: mentee.menteeId, taskId: task.assignedTasks?.[0]?.id });
+    } catch (error) {
+      results.failed.push({ menteeId: mentee.menteeId, reason: error.message });
+    }
+  }
+
+  res.status(201).json(successResponse('Template assignment completed', results, 201));
+});
+
+module.exports = exports;

--- a/server/src/models/tasks/TaskTemplate.js
+++ b/server/src/models/tasks/TaskTemplate.js
@@ -1,0 +1,69 @@
+module.exports = (sequelize, DataTypes) => {
+  const TaskTemplate = sequelize.define('TaskTemplate', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true
+    },
+    mentorId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'mentor_id'
+    },
+    title: {
+      type: DataTypes.STRING(255),
+      allowNull: false
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: false
+    },
+    type: {
+      type: DataTypes.STRING(20),
+      allowNull: false,
+      defaultValue: 'custom',
+      validate: {
+        isIn: [['reading', 'video', 'exercise', 'project', 'quiz', 'discussion', 'practical', 'assessment', 'custom']]
+      }
+    },
+    difficulty: {
+      type: DataTypes.STRING(20),
+      allowNull: false,
+      defaultValue: 'medium',
+      validate: {
+        isIn: [['easy', 'medium', 'hard', 'expert']]
+      }
+    },
+    deliverable: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    acceptanceCriteria: {
+      type: DataTypes.ARRAY(DataTypes.TEXT),
+      defaultValue: [],
+      field: 'acceptance_criteria'
+    },
+    estimatedHours: {
+      type: DataTypes.INTEGER,
+      defaultValue: 5,
+      field: 'estimated_hours'
+    },
+    pointsBase: {
+      type: DataTypes.INTEGER,
+      defaultValue: 10,
+      field: 'points_base'
+    }
+  }, {
+    tableName: 'task_templates',
+    underscored: true,
+    indexes: [
+      { fields: ['mentor_id'] }
+    ]
+  });
+
+  TaskTemplate.associate = (models) => {
+    TaskTemplate.belongsTo(models.User, { foreignKey: 'mentor_id', as: 'mentor' });
+  };
+
+  return TaskTemplate;
+};

--- a/server/src/routes/tasks.js
+++ b/server/src/routes/tasks.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const taskController = require('../controllers/taskController');
+const taskTemplateController = require('../controllers/taskTemplateController');
 const { authenticate, authorize } = require('../middlewares/auth');
 
 /**
@@ -25,6 +26,41 @@ router.post(
   authenticate,
   authorize(['mentor']),
   taskController.createCustomTask
+);
+
+router.post(
+  '/templates',
+  authenticate,
+  authorize(['mentor']),
+  taskTemplateController.createTemplate
+);
+
+router.get(
+  '/templates',
+  authenticate,
+  authorize(['mentor']),
+  taskTemplateController.getTemplates
+);
+
+router.put(
+  '/templates/:id',
+  authenticate,
+  authorize(['mentor']),
+  taskTemplateController.updateTemplate
+);
+
+router.delete(
+  '/templates/:id',
+  authenticate,
+  authorize(['mentor']),
+  taskTemplateController.deleteTemplate
+);
+
+router.post(
+  '/templates/:id/assign',
+  authenticate,
+  authorize(['mentor']),
+  taskTemplateController.assignTemplate
 );
 
 /**

--- a/server/src/services/taskService.js
+++ b/server/src/services/taskService.js
@@ -136,6 +136,7 @@ class TaskService {
       difficulty,
       dueDate,
       pointsBase,
+      estimatedHours,
       deliverable,
       acceptanceCriteria
     } = data;
@@ -173,7 +174,7 @@ class TaskService {
         taskOrder: 0,
         deliverable: deliverable || 'Complete the assigned task',
         acceptanceCriteria: acceptanceCriteria || [],
-        estimatedHours: 5,
+        estimatedHours: estimatedHours || 5,
         isMandatory: false,
         isCustomTask: true,
         pointsBase: pointsBase || 10

--- a/server/src/services/taskTemplateService.js
+++ b/server/src/services/taskTemplateService.js
@@ -1,0 +1,64 @@
+const { models } = require('../db');
+const { NotFoundError, ForbiddenError } = require('../utils/errors/errorTypes');
+
+class TaskTemplateService {
+  async createTemplate(mentorId, data) {
+    const template = await models.TaskTemplate.create({
+      mentorId,
+      title: data.title,
+      description: data.description,
+      type: data.type || 'custom',
+      difficulty: data.difficulty || 'medium',
+      deliverable: data.deliverable || '',
+      acceptanceCriteria: data.acceptanceCriteria || [],
+      estimatedHours: data.estimatedHours || 5,
+      pointsBase: data.pointsBase || 10
+    });
+
+    return template;
+  }
+
+  async getTemplatesByMentor(mentorId) {
+    return models.TaskTemplate.findAll({
+      where: { mentorId },
+      order: [['createdAt', 'DESC']]
+    });
+  }
+
+  async getTemplateById(templateId, mentorId) {
+    const template = await models.TaskTemplate.findByPk(templateId);
+
+    if (!template) {
+      throw new NotFoundError('Template not found');
+    }
+
+    if (template.mentorId !== mentorId) {
+      throw new ForbiddenError('You do not own this template');
+    }
+
+    return template;
+  }
+
+  async updateTemplate(templateId, mentorId, updateData) {
+    const template = await this.getTemplateById(templateId, mentorId);
+
+    const allowed = ['title', 'description', 'type', 'difficulty', 'deliverable', 'acceptanceCriteria', 'estimatedHours', 'pointsBase'];
+    const filtered = {};
+    for (const key of allowed) {
+      if (updateData[key] !== undefined) {
+        filtered[key] = updateData[key];
+      }
+    }
+
+    await template.update(filtered);
+    return template;
+  }
+
+  async deleteTemplate(templateId, mentorId) {
+    const template = await this.getTemplateById(templateId, mentorId);
+    await template.destroy();
+    return { message: 'Template deleted' };
+  }
+}
+
+module.exports = new TaskTemplateService();


### PR DESCRIPTION
## Related Issue

Closes: #105 

## Description

This PR introduces the **Reusable Task Templates** feature, allowing mentors to save custom tasks as templates and easily assign them to multiple mentees. This significantly reduces repetitive work for mentors when managing standard workflows.

**Key Backend Architecture:**
- Created a new `TaskTemplate` database model and migration script to safely persist templates.
- Added full CRUD REST endpoints for templates along with specialized assignment logic via `taskTemplateController` and `taskTemplateService`.
- Refactored `taskController` and `taskService` to support bulk task assignment to multiple mentees atomically. The system now gracefully tracks partial successes/failures instead of throwing server errors if one mentee assignment fails.
- Replaced hardcoded time estimates by introducing a configurable `estimatedHours` field for custom tasks and templates.

**Key Frontend UI/UX Changes:**
- Added a dedicated "Templates" tab in the mentor dashboard to view, inline-edit, and assign saved templates.
- Enhanced the "Create Custom Task" form with premium-looking "Save & Assign" and "Save as Template Only" action buttons.
- Abstracted a highly reusable, polished `MultiSelectMentee` dropdown component for selecting multiple mentees with great visual feedback.
- Cleaned up form inputs by adding distinct labels and modern grid layouts.
- Refactored the `useMentorTasks.ts` custom hook to cleanly map API interactions, handle form validations, and manage state with full TypeScript safety.

**⚠️ Database Migration Required!**
Before testing or deploying this PR, you MUST run the new database migration script to generate the `task_templates` table in your database. Run the following command from the `server` directory:
```bash
node scripts/migrations/007_add_task_templates.js


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Recording
https://www.loom.com/share/38b6804365024f90b03a6d2931436880
