### PR TITLE
fix/Long descriptions handled in a user-friendly way

### DIFF
--- a/client-interface/app/admin/programs/[id]/page.tsx
+++ b/client-interface/app/admin/programs/[id]/page.tsx
@@ -127,6 +127,7 @@ export default function ProgramDetails() {
   } = useProgramDetail();
 
   const [activeTab, setActiveTab] = useState<'overview' | 'levels' | 'mentors' | 'enrollments'>('overview');
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
 
   useEffect(() => {
     if (activeTab === 'levels' && selectedLevelId) {
@@ -159,6 +160,13 @@ export default function ProgramDetails() {
     );
   }
 
+  const description = program.description || 'No description available';
+  const DESCRIPTION_LIMIT = 250;
+  const isLongDescription = description.length > DESCRIPTION_LIMIT;
+  const displayDescription = isLongDescription && !isDescriptionExpanded
+    ? description.slice(0, DESCRIPTION_LIMIT) + '...'
+    : description;
+
   return (
     <>
       {/* Header */}
@@ -181,7 +189,19 @@ export default function ProgramDetails() {
                 updating={updatingStatus}
               />
             </div>
-            <p className="text-slate-600 mb-4">{program.description || 'No description available'}</p>
+            <div className="mb-4">
+              <p className="text-slate-600 inline">
+                {displayDescription}
+              </p>
+              {isLongDescription && (
+                <button
+                  onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
+                  className="ml-2 text-indigo-600 hover:text-indigo-700 text-sm font-medium focus:outline-none"
+                >
+                  {isDescriptionExpanded ? 'Read Less' : 'Read More'}
+                </button>
+              )}
+            </div>
             {program.tags && program.tags.length > 0 && (
               <div className="flex flex-wrap gap-2">
                 {program.tags.map((tag: string, idx: number) => (

--- a/server/src/validations/programValidation.js
+++ b/server/src/validations/programValidation.js
@@ -1,5 +1,14 @@
 const Joi = require('joi');
 
+const wordLimit = (limit) => (value, helpers) => {
+  if (!value) return value;
+  const wordCount = value.trim().split(/\s+/).filter(Boolean).length;
+  if (wordCount > limit) {
+    return helpers.message(`Description cannot exceed ${limit} words`);
+  }
+  return value;
+};
+
 const programValidation = {
   // Create program validation
   createProgram: Joi.object({
@@ -15,6 +24,7 @@ const programValidation = {
 
     description: Joi.string()
       .min(10)
+      .custom(wordLimit(1000))
       .required()
       .messages({
         'string.empty': 'Program description is required',
@@ -136,6 +146,7 @@ const programValidation = {
 
     description: Joi.string()
       .min(10)
+      .custom(wordLimit(1000))
       .optional()
       .messages({
         'string.min': 'Description must be at least 10 characters'
@@ -243,6 +254,7 @@ const programValidation = {
 
     description: Joi.string()
       .min(10)
+      .custom(wordLimit(1000))
       .optional(),
 
     startDate: Joi.date()


### PR DESCRIPTION
## Description

This PR addresses the issue where extremely long program descriptions negatively impact the page layout and user experience on the `/admin/programs/[id]` page. 

**Changes made:**
- **UI Enhancements:** Implemented a truncation preview (at 250 characters) with an inline "Read More / Read Less" interactive toggle to handle large descriptions gracefully without breaking the layout.
- **Backend Validation:** Added strict Joi validation to the `description` field for creating, updating, and cloning programs to enforce a maximum limit of 1000 words. 
- **Code hygiene:** Ensured all existing codebase comments remained perfectly intact while adding these UX and API improvements.

## Related Issue #121 

<!-- Update this with your specific issue number if you have one, e.g., Closes #123 -->
Fixes the issue: "Long descriptions displayed without any restriction or truncation"

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

