### PR TITLE
fix/mentees can only view their mentors

### DIFF
--- a/client-interface/components/shared/messages/UserSearchCombobox.tsx
+++ b/client-interface/components/shared/messages/UserSearchCombobox.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 
 import { messagingApi } from '@/lib/services/messaging-api';
 import type { SearchableUser } from '@/lib/types/messaging';
+import { useAuth } from '@/lib/context/AuthContext';
 
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
@@ -30,6 +31,7 @@ interface UserSearchComboboxProps {
 }
 
 export default function UserSearchCombobox({ onSelect }: UserSearchComboboxProps) {
+  const { user } = useAuth();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [roleFilter, setRoleFilter] = useState<string | undefined>();
@@ -107,21 +109,23 @@ export default function UserSearchCombobox({ onSelect }: UserSearchComboboxProps
           />
 
           {/* Role filter tabs */}
-          <div className="flex items-center gap-1 px-2 py-2 border-b border-slate-100">
-            {roleOptions.map((option) => (
-              <button
-                key={option.label}
-                onClick={() => setRoleFilter(option.value)}
-                className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
-                  roleFilter === option.value
-                    ? 'bg-indigo-600 text-white'
-                    : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
-                }`}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
+          {user?.role !== 'mentee' && (
+            <div className="flex items-center gap-1 px-2 py-2 border-b border-slate-100">
+              {roleOptions.map((option) => (
+                <button
+                  key={option.label}
+                  onClick={() => setRoleFilter(option.value)}
+                  className={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
+                    roleFilter === option.value
+                      ? 'bg-indigo-600 text-white'
+                      : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          )}
 
           <CommandList>
             {isLoading ? (

--- a/server/src/services/messagingService.js
+++ b/server/src/services/messagingService.js
@@ -553,11 +553,27 @@ class MessagingService {
     const limit = Math.min(Math.max(Number(options.limit || 10), 1), 25);
     const roleFilter = options.role;
 
+    const currentUser = await models.User.findByPk(currentUserId, { attributes: ['id', 'role'] });
+    if (!currentUser) return [];
+
     const where = {
       id: { [Op.ne]: currentUserId },
       status: 'active',
       deletedAt: null
     };
+
+    if (currentUser.role === 'mentee') {
+      const matches = await models.MentorMenteeMatch.findAll({
+        where: { menteeId: currentUserId, status: 'active' },
+        attributes: ['mentorId']
+      });
+      const assignedMentorIds = matches.map((m) => m.mentorId);
+
+      if (assignedMentorIds.length === 0) {
+        return [];
+      }
+      where.id = { [Op.in]: assignedMentorIds };
+    }
 
     if (roleFilter && ['admin', 'mentor', 'mentee'].includes(roleFilter)) {
       where.role = roleFilter;


### PR DESCRIPTION
## Description

This PR fixes a bug where mentees could view and search for all mentors and admins across the platform in the message chat. Mentees are now strictly isolated so they can only view and message their assigned mentors.

**Changes made:**
- **Backend Restriction (`messagingService.js`):** Updated the `searchUsers` method to verify the current user's role. If the user is a mentee, the query fetches their active matches from `MentorMenteeMatch` and strictly restricts the search parameters to only those assigned mentor IDs.
- **Frontend UI Update (`UserSearchCombobox.tsx`):** Leveraged the `useAuth` hook to check the user's role on the client side. The role filter tabs ("All", "Mentor", "Mentee", "Admin") are now completely hidden from mentees to prevent UI confusion. 
- **Code hygiene:** All existing comments were preserved.

## Related Issue

Closes #101 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

