### PR TITLE
Implement 15-minute editing window for custom tasks

### DIFF
--- a/client-interface/app/mentor/tasks/[id]/page.tsx
+++ b/client-interface/app/mentor/tasks/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use } from 'react';
+import { use, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   CheckCircle2,
@@ -20,6 +20,8 @@ import {
   Loader2,
   Send,
   AlertTriangle,
+  Pencil,
+  ArrowLeft,
 } from 'lucide-react';
 import { useMentorTaskDetail } from '@/lib/hooks/mentor';
 import { PageHeader, StatusBadge } from '@/components/admin/ui';
@@ -47,7 +49,90 @@ export default function MentorTaskDetailsPage({ params }: PageProps) {
     setNewDueDate,
     handleExtension,
     handleCancelTask,
+    handleUpdateCustomTask,
+    isUpdating,
   } = useMentorTaskDetail(resolvedParams.id);
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editFormData, setEditFormData] = useState({
+    title: '',
+    description: '',
+    type: 'custom',
+    difficulty: 'medium',
+    dueDate: '',
+    pointsBase: 10,
+    deliverable: '',
+    acceptanceCriteriaText: '',
+  });
+
+  const startEditing = () => {
+    if (!task) return;
+    const roadmapTask = task.roadmapTask || {};
+    setEditFormData({
+      title: roadmapTask.title || task.title || '',
+      description: roadmapTask.description || task.description || '',
+      type: roadmapTask.type || task.type || 'custom',
+      difficulty: roadmapTask.difficulty || task.difficulty || 'medium',
+      dueDate: task.dueDate ? new Date(task.dueDate).toISOString().split('T')[0] : '',
+      pointsBase: roadmapTask.pointsBase || 10,
+      deliverable: roadmapTask.deliverable || '',
+      acceptanceCriteriaText: (roadmapTask.acceptanceCriteria || []).join('\n'),
+    });
+    setIsEditing(true);
+  };
+
+  const saveEdit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await handleUpdateCustomTask({
+        title: editFormData.title,
+        description: editFormData.description,
+        type: editFormData.type,
+        difficulty: editFormData.difficulty,
+        dueDate: editFormData.dueDate || undefined,
+        pointsBase: editFormData.pointsBase,
+        deliverable: editFormData.deliverable,
+        acceptanceCriteria: editFormData.acceptanceCriteriaText
+          .split('\n')
+          .map((c) => c.trim())
+          .filter((c) => c.length > 0),
+      });
+      setIsEditing(false);
+    } catch {
+      // toast shown by hook
+    }
+  };
+
+  const [isEditable, setIsEditable] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    if (task && task.isCustomTask && ['assigned', 'in_progress'].includes(task.status)) {
+      const assignedTime = new Date(task.assignedAt).getTime();
+      const timeRemaining = 15 * 60 * 1000 - (Date.now() - assignedTime);
+
+      Promise.resolve().then(() => {
+        if (active) setIsEditable(timeRemaining > 0);
+      });
+
+      if (timeRemaining > 0) {
+        const timer = setTimeout(() => {
+          if (active) setIsEditable(false);
+        }, timeRemaining);
+        return () => {
+          active = false;
+          clearTimeout(timer);
+        };
+      }
+    } else {
+      Promise.resolve().then(() => {
+        if (active) setIsEditable(false);
+      });
+    }
+    return () => {
+      active = false;
+    };
+  }, [task]);
 
   if (loading) {
     return (
@@ -62,6 +147,149 @@ export default function MentorTaskDetailsPage({ params }: PageProps) {
       <div className="p-4 bg-red-50 border border-red-200 rounded-xl flex items-center gap-3">
         <AlertCircle className="w-5 h-5 text-red-600 shrink-0" />
         <p className="text-red-900">{error || 'Task not found'}</p>
+      </div>
+    );
+  }
+
+  if (isEditing) {
+    return (
+      <div className="space-y-6 max-w-4xl">
+        <div className="mb-4">
+          <button
+            onClick={() => setIsEditing(false)}
+            className="inline-flex items-center gap-2 text-slate-500 hover:text-slate-900 text-sm mb-3 transition-colors font-medium"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Cancel Editing
+          </button>
+        </div>
+        
+        <form onSubmit={saveEdit} className="bg-white rounded-2xl border border-slate-200 p-6 space-y-6">
+          <h2 className="text-xl font-semibold text-slate-900">Edit Custom Task</h2>
+          
+          <div className="space-y-4">
+            <div>
+              <label className="block text-slate-700 text-sm font-medium mb-1">
+                Task Title <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={editFormData.title}
+                onChange={(e) => setEditFormData({ ...editFormData, title: e.target.value })}
+                required
+                className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 text-slate-900"
+              />
+            </div>
+
+            <div>
+              <label className="block text-slate-700 text-sm font-medium mb-1">
+                Description <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                rows={5}
+                value={editFormData.description}
+                onChange={(e) => setEditFormData({ ...editFormData, description: e.target.value })}
+                required
+                className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 text-slate-900"
+              />
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-slate-700 text-sm font-medium mb-1">Task Type</label>
+                <select
+                  value={editFormData.type}
+                  onChange={(e) => setEditFormData({ ...editFormData, type: e.target.value })}
+                  className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 text-slate-900"
+                >
+                  <option value="custom">Custom</option>
+                  <option value="exercise">Extra Practice</option>
+                  <option value="project">Project</option>
+                  <option value="practical">Practical</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-slate-700 text-sm font-medium mb-1">Difficulty</label>
+                <select
+                  value={editFormData.difficulty}
+                  onChange={(e) => setEditFormData({ ...editFormData, difficulty: e.target.value })}
+                  className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 text-slate-900"
+                >
+                  <option value="easy">Easy</option>
+                  <option value="medium">Medium</option>
+                  <option value="hard">Hard</option>
+                  <option value="expert">Expert</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-slate-700 text-sm font-medium mb-1">Due Date</label>
+                <input
+                  type="date"
+                  value={editFormData.dueDate}
+                  onChange={(e) => setEditFormData({ ...editFormData, dueDate: e.target.value })}
+                  min={new Date().toISOString().split('T')[0]}
+                  className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 text-slate-900"
+                />
+              </div>
+
+              <div>
+                <label className="block text-slate-700 text-sm font-medium mb-1">Points</label>
+                <input
+                  type="number"
+                  value={editFormData.pointsBase}
+                  onChange={(e) => setEditFormData({ ...editFormData, pointsBase: parseInt(e.target.value) || 0 })}
+                  min="0"
+                  className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 text-slate-900"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-slate-700 text-sm font-medium mb-1">Deliverable</label>
+              <input
+                type="text"
+                value={editFormData.deliverable}
+                onChange={(e) => setEditFormData({ ...editFormData, deliverable: e.target.value })}
+                className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 text-slate-900"
+              />
+            </div>
+
+            <div>
+              <label className="block text-slate-700 text-sm font-medium mb-1">
+                Acceptance Criteria <span className="text-slate-500 text-xs">(one per line)</span>
+              </label>
+              <textarea
+                rows={4}
+                value={editFormData.acceptanceCriteriaText}
+                onChange={(e) => setEditFormData({ ...editFormData, acceptanceCriteriaText: e.target.value })}
+                placeholder="e.g. Code builds without errors&#10;Includes unit tests"
+                className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 text-slate-900"
+              />
+            </div>
+          </div>
+
+          <div className="flex gap-3 pt-4 border-t border-slate-100">
+            <button
+              type="submit"
+              disabled={isUpdating}
+              className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl font-medium transition-colors disabled:opacity-50 flex items-center gap-2"
+            >
+              {isUpdating ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+              {isUpdating ? 'Saving...' : 'Save Changes'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsEditing(false)}
+              className="px-5 py-2.5 bg-white border border-slate-200 text-slate-700 rounded-xl hover:bg-slate-50 transition-colors font-medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
       </div>
     );
   }
@@ -483,14 +711,26 @@ export default function MentorTaskDetailsPage({ params }: PageProps) {
 
       {/* Actions */}
       <div className="flex items-center justify-between gap-4">
-        {canCancel && !cancellingTask && (
-          <button
-            onClick={() => setCancellingTask(true)}
-            className="px-5 py-2.5 bg-red-50 hover:bg-red-100 text-red-700 rounded-xl border border-red-200 font-medium transition-colors text-sm"
-          >
-            Cancel Task
-          </button>
-        )}
+        <div className="flex items-center gap-3">
+          {canCancel && !cancellingTask && (
+            <button
+              onClick={() => setCancellingTask(true)}
+              className="px-5 py-2.5 bg-red-50 hover:bg-red-100 text-red-700 rounded-xl border border-red-200 font-medium transition-colors text-sm"
+            >
+              Cancel Task
+            </button>
+          )}
+
+          {isEditable && !cancellingTask && (
+            <button
+              onClick={startEditing}
+              className="px-5 py-2.5 bg-indigo-50 hover:bg-indigo-100 text-indigo-700 rounded-xl border border-indigo-200 font-medium transition-colors text-sm flex items-center gap-2"
+            >
+              <Pencil className="w-4 h-4" />
+              Edit Task
+            </button>
+          )}
+        </div>
 
         {canReview && !cancellingTask && (
           <button

--- a/client-interface/lib/hooks/mentor/useMentorTaskDetail.ts
+++ b/client-interface/lib/hooks/mentor/useMentorTaskDetail.ts
@@ -23,6 +23,17 @@ export interface UseMentorTaskDetailReturn {
   setNewDueDate: (v: string) => void;
   handleExtension: (approved: boolean, submissionId: string) => Promise<void>;
   handleCancelTask: () => Promise<void>;
+  handleUpdateCustomTask: (data: {
+    title?: string;
+    description?: string;
+    type?: string;
+    difficulty?: string;
+    dueDate?: string;
+    pointsBase?: number;
+    deliverable?: string;
+    acceptanceCriteria?: string[];
+  }) => Promise<void>;
+  isUpdating: boolean;
   refetch: () => Promise<void>;
 }
 
@@ -36,6 +47,7 @@ export function useMentorTaskDetail(taskId: string): UseMentorTaskDetailReturn {
   const [extensionDecision, setExtensionDecision] = useState<'approve' | 'reject' | null>(null);
   const [newDueDate, setNewDueDate] = useState('');
   const [isHandlingExtension, setIsHandlingExtension] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
 
   const fetchTask = useCallback(async () => {
     if (!taskId) return;
@@ -96,6 +108,23 @@ export function useMentorTaskDetail(taskId: string): UseMentorTaskDetailReturn {
     }
   }, [taskId, cancelReason, fetchTask]);
 
+  const handleUpdateCustomTask = useCallback(
+    async (data: any) => {
+      setIsUpdating(true);
+      try {
+        await taskApi.updateCustomTask(taskId, data);
+        toast.success('Custom task updated successfully!');
+        await fetchTask();
+      } catch (err: unknown) {
+        toast.error(extractApiErrorMessage(err, 'Failed to update custom task'));
+        throw err;
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [taskId, fetchTask]
+  );
+
   return {
     task,
     loading,
@@ -112,6 +141,8 @@ export function useMentorTaskDetail(taskId: string): UseMentorTaskDetailReturn {
     setNewDueDate,
     handleExtension,
     handleCancelTask,
+    handleUpdateCustomTask,
+    isUpdating,
     refetch: fetchTask,
   };
 }

--- a/client-interface/lib/services/task-api.ts
+++ b/client-interface/lib/services/task-api.ts
@@ -55,6 +55,18 @@ export const taskApi = {
   cancelTask: (taskId: string, reason?: string) =>
     apiClient.post(`/tasks/${taskId}/cancel`, { reason }),
 
+  updateCustomTask: (taskId: string, data: {
+    title?: string;
+    description?: string;
+    type?: string;
+    difficulty?: string;
+    dueDate?: string;
+    pointsBase?: number;
+    deliverable?: string;
+    acceptanceCriteria?: string[];
+  }) =>
+    apiClient.put(`/tasks/${taskId}`, data),
+
   deleteCustomTask: (taskId: string) =>
     apiClient.delete(`/tasks/${taskId}`),
 

--- a/server/src/controllers/taskController.js
+++ b/server/src/controllers/taskController.js
@@ -187,6 +187,18 @@ exports.getRoadmapTasks = catchAsync(async (req, res) => {
 });
 
 /**
+ * Update custom task
+ * PUT /api/tasks/:taskId
+ */
+exports.updateCustomTask = catchAsync(async (req, res) => {
+  const { taskId } = req.params;
+  const mentorId = req.user.id;
+  
+  const task = await taskService.updateCustomTask(taskId, mentorId, req.body);
+  res.status(200).json(successResponse('Custom task updated successfully', { task }));
+});
+
+/**
  * Delete custom task
  * DELETE /api/tasks/:taskId
  */

--- a/server/src/routes/tasks.js
+++ b/server/src/routes/tasks.js
@@ -148,6 +148,18 @@ router.patch(
 );
 
 /**
+ * @route   PUT /api/tasks/:taskId
+ * @desc    Update a custom task within 15-minute editing window
+ * @access  Mentor
+ */
+router.put(
+  '/:taskId',
+  authenticate,
+  authorize(['mentor']),
+  taskController.updateCustomTask
+);
+
+/**
  * @route   DELETE /api/tasks/:taskId
  * @desc    Delete custom task
  * @access  Mentor

--- a/server/src/services/taskService.js
+++ b/server/src/services/taskService.js
@@ -851,6 +851,74 @@ class TaskService {
   }
 
   /**
+   * Update custom task (mentor only, within 15 minutes of creation)
+   */
+  async updateCustomTask(taskId, mentorId, data) {
+    const {
+      title,
+      description,
+      type,
+      difficulty,
+      dueDate,
+      pointsBase,
+      deliverable,
+      acceptanceCriteria
+    } = data;
+
+    const task = await models.AssignedTask.findByPk(taskId, {
+      include: [{ model: models.RoadmapTask, as: 'roadmapTask' }]
+    });
+
+    if (!task) {
+      throw new NotFoundError('Task not found');
+    }
+
+    if (!task.isCustomTask) {
+      throw new ValidationError('Only custom tasks can be updated');
+    }
+
+    if (task.mentorId !== mentorId) {
+      throw new ForbiddenError('You can only update your own custom tasks');
+    }
+
+    if (task.status === 'completed' || task.status === 'submitted') {
+      throw new ValidationError('Cannot update submitted or completed tasks');
+    }
+
+    // Calculate 15-minute editing window from assignedAt
+    const assignedTime = new Date(task.assignedAt).getTime();
+    const timeDiffMinutes = (Date.now() - assignedTime) / 60000;
+    if (timeDiffMinutes > 15) {
+      throw new ValidationError('The 15-minute editing window has expired');
+    }
+
+    // Update AssignedTask
+    if (dueDate !== undefined) {
+      task.dueDate = dueDate || null;
+      await task.save();
+    }
+
+    // Update RoadmapTask
+    if (task.roadmapTask) {
+      const roadmapTask = task.roadmapTask;
+      if (title !== undefined) roadmapTask.title = title;
+      if (description !== undefined) roadmapTask.description = description;
+      if (type !== undefined) roadmapTask.type = type || 'custom';
+      if (difficulty !== undefined) roadmapTask.difficulty = difficulty || 'medium';
+      if (pointsBase !== undefined) roadmapTask.pointsBase = pointsBase || 10;
+      if (deliverable !== undefined) roadmapTask.deliverable = deliverable;
+      if (acceptanceCriteria !== undefined) roadmapTask.acceptanceCriteria = acceptanceCriteria || [];
+      await roadmapTask.save();
+    }
+
+    // Update enrollment task stats (in case pointsBase or other fields changed)
+    await this.updateEnrollmentTaskStats(task.enrollmentId);
+
+    // Return the updated task
+    return this.getAssignedTaskById(taskId);
+  }
+
+  /**
    * Delete custom task (mentor only)
    */
   async deleteCustomTask(taskId, mentorId) {


### PR DESCRIPTION
closes #117 


## Problem Statement

When mentors assign a custom task to a mentee, any typos, incorrect deadlines, or wrong point values cannot be corrected. Currently, the only workaround is to delete the task entirely and recreate it, which disrupts the mentee's workflow and causes unnecessary database clutter.

## Proposed Solution

Implement a 15-minute editing window immediately after a custom task is created.

* Mentors can update key details (title, description, difficulty, due date, deliverable, and base points) directly from the task detail page.
* To prevent grading disputes or confusion, editing is restricted to tasks that have not yet been submitted, completed, or cancelled, and automatically locks after 15 minutes.

## Alternatives Considered

* **Unlimited/Permanent Editing**: Rejected because editing a task while a mentee is actively working on it or after it is submitted leads to bad user experience.

## Scope

- App area: server & client-interface
- Breaking change: no
- Requires migration/config changes: no

## Acceptance Criteria

- [x] "Edit Task" button is displayed on the mentor task details page for custom tasks under 15 minutes old.
- [x] Edits update the task details (title, description, points, due date, etc.) successfully in both AssignedTask and RoadmapTask models.
- [x] Restricts editing requests on the backend if the task status is not active (e.g. submitted, completed, cancelled) or if the 15-minute window has passed.

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [x] I updated documentation where needed

## Additional Context

A timer runs in the frontend using the `assignedAt` timestamp of the task, automatically locking edit actions once the 15-minute window passes.
<img width="1898" height="893" alt="Screenshot From 2026-06-01 19-10-46" src="https://github.com/user-attachments/assets/fc083a9c-9298-4429-aec7-e90ac1dbbf42" />
<img width="1898" height="893" alt="Screenshot From 2026-06-01 19-11-21" src="https://github.com/user-attachments/assets/c986a3b5-3131-4d3b-93de-75cd0aea200b" />
