### PR TITLE
file-upload-support-in-task-for-admin-mentor

### DIFF
--- a/client-interface/app/admin/programs/[id]/roadmap/page.tsx
+++ b/client-interface/app/admin/programs/[id]/roadmap/page.tsx
@@ -20,6 +20,7 @@ import {
 import { useProgramRoadmap } from '@/lib/hooks/admin';
 import { GenerateConfirmModal } from '@/components/admin/programs';
 import { ConfirmDialog } from '@/components/admin/ui';
+import FileUploader from '@/components/shared/FileUploader';
 
 export default function RoadmapGenerator() {
   const router = useRouter();
@@ -518,6 +519,25 @@ export default function RoadmapGenerator() {
                   </select>
                 </div>
               </div>
+              {taskModal.mode === 'add' && (
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1.5">
+                    Requirement Files
+                  </label>
+                  <FileUploader
+                    files={taskForm.files}
+                    onFilesAdded={(newFiles) =>
+                      setTaskForm({ ...taskForm, files: [...taskForm.files, ...newFiles] })
+                    }
+                    onFileRemoved={(index) =>
+                      setTaskForm({
+                        ...taskForm,
+                        files: taskForm.files.filter((_, i) => i !== index),
+                      })
+                    }
+                  />
+                </div>
+              )}
             </div>
 
             {/* Modal Footer */}

--- a/client-interface/app/mentee/tasks/[id]/page.tsx
+++ b/client-interface/app/mentee/tasks/[id]/page.tsx
@@ -60,11 +60,12 @@ export default function TaskDetailsPage({ params }: PageProps) {
     );
   }
 
-  const taskTitle = task.roadmapTask?.title || task.title || 'Untitled Task';
+   const taskTitle = task.roadmapTask?.title || task.title || 'Untitled Task';
   const taskDescription = task.roadmapTask?.description || task.description || '';
   const taskDeliverable = task.roadmapTask?.deliverable || task.deliverable;
   const acceptanceCriteria = task.roadmapTask?.acceptanceCriteria || task.acceptanceCriteria || [];
   const resources = task.roadmapTask?.resources || [];
+  const taskFiles = task.roadmapTask?.taskFiles || [];
   const latestSubmission = task.submissions?.[task.submissions.length - 1] || null;
   const feedback = latestSubmission?.feedback || [];
 
@@ -216,6 +217,27 @@ export default function TaskDetailsPage({ params }: PageProps) {
                   >
                     <LinkIcon className="w-4 h-4" />
                     {resource.title}
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+                {taskFiles.length > 0 && (
+          <div>
+            <h3 className="text-sm font-medium text-slate-700 mb-3">Task Files</h3>
+            <ul className="space-y-2">
+              {taskFiles.map((file: any) => (
+                <li key={file.id}>
+                  <a
+                    href={file.fileUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-indigo-600 hover:text-indigo-800 hover:underline flex items-center gap-2"
+                  >
+                    <FileText className="w-4 h-4" />
+                    {file.fileName}
                     <ExternalLink className="w-3 h-3" />
                   </a>
                 </li>

--- a/client-interface/app/mentor/tasks/[id]/page.tsx
+++ b/client-interface/app/mentor/tasks/[id]/page.tsx
@@ -66,11 +66,12 @@ export default function MentorTaskDetailsPage({ params }: PageProps) {
     );
   }
 
-  const taskTitle = task.roadmapTask?.title || task.title || 'Untitled Task';
+    const taskTitle = task.roadmapTask?.title || task.title || 'Untitled Task';
   const taskDescription = task.roadmapTask?.description || task.description || '';
   const taskDeliverable = task.roadmapTask?.deliverable || task.deliverable;
   const acceptanceCriteria = task.roadmapTask?.acceptanceCriteria || task.acceptanceCriteria || [];
   const resources = task.roadmapTask?.resources || [];
+  const taskFiles = task.roadmapTask?.taskFiles || [];
   const latestSubmission = task.submissions?.[task.submissions.length - 1] || null;
   const feedback = latestSubmission?.feedback || [];
 
@@ -239,6 +240,27 @@ export default function MentorTaskDetailsPage({ params }: PageProps) {
                   >
                     <LinkIcon className="w-4 h-4" />
                     {resource.title}
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+                {taskFiles.length > 0 && (
+          <div>
+            <h3 className="text-sm font-medium text-slate-700 mb-3">Task Files</h3>
+            <ul className="space-y-2">
+              {taskFiles.map((file: any) => (
+                <li key={file.id}>
+                  <a
+                    href={file.fileUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-indigo-600 hover:text-indigo-800 hover:underline flex items-center gap-2"
+                  >
+                    <FileText className="w-4 h-4" />
+                    {file.fileName}
                     <ExternalLink className="w-3 h-3" />
                   </a>
                 </li>

--- a/client-interface/app/mentor/tasks/page.tsx
+++ b/client-interface/app/mentor/tasks/page.tsx
@@ -6,6 +6,7 @@ import {
   Search, ClipboardList, Clock, CheckCircle2, AlertCircle, Plus,
   Loader2, FileText, Star, XCircle, AlertTriangle, BookOpen, CalendarClock
 } from 'lucide-react';
+import FileUploader from '@/components/shared/FileUploader';
 import { useMentorTasks } from '@/lib/hooks/mentor';
 import { StatsCard, TabBar, StatusBadge } from '@/components/admin/ui';
 import type { Tab } from '@/components/admin/ui';
@@ -773,6 +774,21 @@ export default function MentorTasks() {
                         className="w-full px-4 py-3 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
                       />
                     </div>
+                  </div>
+                  <div>
+                    <label className="block text-slate-700 text-sm mb-2">Requirement Files</label>
+                    <FileUploader
+                      files={formData.files}
+                      onFilesAdded={(newFiles) =>
+                        setFormData({ ...formData, files: [...formData.files, ...newFiles] })
+                      }
+                      onFileRemoved={(index) =>
+                        setFormData({
+                          ...formData,
+                          files: formData.files.filter((_, i) => i !== index),
+                        })
+                      }
+                    />
                   </div>
 
                   <div className="flex gap-4">

--- a/client-interface/lib/hooks/admin/useProgramRoadmap.ts
+++ b/client-interface/lib/hooks/admin/useProgramRoadmap.ts
@@ -40,6 +40,7 @@ export interface TaskForm {
   type: string;
   difficulty: string;
   weekId: string;
+  files: File[];
 }
 
 export interface WeekForm {
@@ -117,8 +118,8 @@ export function useProgramRoadmap(): UseProgramRoadmapReturn {
   const [selectedLevelId, setSelectedLevelIdRaw] = useState<string>(levelParam || '');
   const [editingWeek, setEditingWeek] = useState<number | null>(null);
   const [taskModal, setTaskModal] = useState<TaskModalState | null>(null);
-  const [taskForm, setTaskForm] = useState<TaskForm>({
-    title: '', description: '', deliverable: '', taskOrder: 1, type: 'exercise', difficulty: 'medium', weekId: '',
+    const [taskForm, setTaskForm] = useState<TaskForm>({
+    title: '', description: '', deliverable: '', taskOrder: 1, type: 'exercise', difficulty: 'medium', weekId: '', files: [],
   });
   const [savingTask, setSavingTask] = useState(false);
   const [weekModal, setWeekModal] = useState<WeekModalState | null>(null);
@@ -280,14 +281,14 @@ export function useProgramRoadmap(): UseProgramRoadmapReturn {
   }, [weekForm, weekModal, roadmapId, roadmap.length, fetchRoadmap, selectedLevelId]);
 
   const openAddTask = useCallback((weekId: string, weekNumber: number, taskCount: number) => {
-    setTaskForm({ title: '', description: '', deliverable: '', taskOrder: taskCount + 1, type: 'exercise', difficulty: 'medium', weekId });
+        setTaskForm({ title: '', description: '', deliverable: '', taskOrder: taskCount + 1, type: 'exercise', difficulty: 'medium', weekId, files: [] });
     setTaskModal({ mode: 'add', weekId, weekNumber });
   }, []);
 
   const openEditTask = useCallback((task: RoadmapWeekTask, weekId: string, weekNumber: number) => {
-    setTaskForm({
+        setTaskForm({
       title: task.title, description: task.description, deliverable: task.deliverable ?? '',
-      taskOrder: task.taskOrder ?? 1, type: task.type ?? 'exercise', difficulty: task.difficulty ?? 'medium', weekId,
+      taskOrder: task.taskOrder ?? 1, type: task.type ?? 'exercise', difficulty: task.difficulty ?? 'medium', weekId, files: [],
     });
     setTaskModal({ mode: 'edit', weekId, weekNumber, task });
   }, []);
@@ -298,10 +299,11 @@ export function useProgramRoadmap(): UseProgramRoadmapReturn {
     }
     setSavingTask(true);
     try {
-      const payload = {
+                  const payload = {
         title: taskForm.title.trim(), description: taskForm.description.trim(),
-        deliverable: taskForm.deliverable.trim(), taskOrder: taskForm.taskOrder,
+        deliverable: taskForm.deliverable.trim(), orderIndex: taskForm.taskOrder,
         type: taskForm.type, difficulty: taskForm.difficulty,
+        files: taskForm.files,
       };
       if (taskModal?.mode === 'add') {
         await programManagementApi.roadmaps.addTask(taskForm.weekId, payload);

--- a/client-interface/lib/hooks/mentor/useMentorTasks.ts
+++ b/client-interface/lib/hooks/mentor/useMentorTasks.ts
@@ -22,6 +22,7 @@ export interface CustomTaskFormData {
   pointsBase: number;
   deliverable: string;
   acceptanceCriteria: string[];
+  files: File[];
 }
 
 const EMPTY_FORM: CustomTaskFormData = {
@@ -35,6 +36,7 @@ const EMPTY_FORM: CustomTaskFormData = {
   pointsBase: 10,
   deliverable: '',
   acceptanceCriteria: [],
+  files: [],
 };
 
 export interface UseMentorTasksReturn {

--- a/client-interface/lib/services/program-api.ts
+++ b/client-interface/lib/services/program-api.ts
@@ -147,8 +147,25 @@ export const roadmapsApi = {
   },
 
   // Task operations
-  addTask: async (weekId: string, data: any) => {
-    const response = await apiClient.post<any>(`/weeks/${weekId}/tasks`, data);
+   addTask: async (weekId: string, data: any) => {
+    const formData = new FormData();
+
+    Object.entries(data).forEach(([key, value]) => {
+      if (key === 'files') return;
+      if (value !== undefined && value !== null) {
+        formData.append(key, String(value));
+      }
+    });
+
+    data.files?.forEach((file: File) => {
+      formData.append('files', file);
+    });
+
+        const response = await apiClient.post<any>(`/weeks/${weekId}/tasks`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
     return response.data;
   },
 

--- a/client-interface/lib/services/task-api.ts
+++ b/client-interface/lib/services/task-api.ts
@@ -29,10 +29,10 @@ export const taskApi = {
   getMentorTaskStats: (mentorId: string) =>
     apiClient.get(`/tasks/mentor/${mentorId}/stats`),
 
-  createCustomTask: (data: {
+   createCustomTask: (data: {
     menteeId: string;
     enrollmentId: string;
-    roadmapTaskId?: string; // Optional: assign existing roadmap task
+    roadmapTaskId?: string;
     title?: string;
     description?: string;
     type?: string;
@@ -41,8 +41,29 @@ export const taskApi = {
     pointsBase?: number;
     deliverable?: string;
     acceptanceCriteria?: string[];
-  }) =>
-    apiClient.post('/tasks/custom', data),
+    files?: File[];
+  }) => {
+    const formData = new FormData();
+
+    Object.entries(data).forEach(([key, value]) => {
+      if (key === 'files') return;
+      if (Array.isArray(value)) {
+        value.forEach((item) => formData.append(key, String(item)));
+      } else if (value !== undefined && value !== null) {
+        formData.append(key, String(value));
+      }
+    });
+
+       data.files?.forEach((file) => {
+      formData.append('files', file);
+    });
+
+    return apiClient.post('/tasks/custom', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+  },
 
   reviewTask: (taskId: string, data: {
     rating: number;

--- a/server/scripts/migrations/007_add_task_files.js
+++ b/server/scripts/migrations/007_add_task_files.js
@@ -1,0 +1,81 @@
+const { Sequelize } = require('sequelize');
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
+
+const sequelize = new Sequelize(process.env.DATABASE_URL, { logging: false });
+
+async function up() {
+  const qi = sequelize.getQueryInterface();
+
+  await qi.createTable('task_files', {
+    id: {
+      type: Sequelize.UUID,
+      defaultValue: Sequelize.literal('gen_random_uuid()'),
+      primaryKey: true
+    },
+    roadmap_task_id: {
+      type: Sequelize.UUID,
+      allowNull: false,
+      references: {
+        model: 'roadmap_tasks',
+        key: 'id'
+      },
+      onDelete: 'CASCADE'
+    },
+    file_name: {
+      type: Sequelize.STRING(255),
+      allowNull: false
+    },
+    file_url: {
+      type: Sequelize.TEXT,
+      allowNull: false
+    },
+    file_type: {
+      type: Sequelize.STRING(100),
+      allowNull: true
+    },
+    file_size_bytes: {
+      type: Sequelize.BIGINT,
+      allowNull: true
+    },
+    uploaded_by: {
+      type: Sequelize.UUID,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'id'
+      }
+    },
+    uploaded_at: {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.fn('NOW')
+    }
+  });
+
+  await qi.addIndex('task_files', ['roadmap_task_id']);
+  await qi.addIndex('task_files', ['uploaded_by']);
+}
+
+async function down() {
+  const qi = sequelize.getQueryInterface();
+  await qi.dropTable('task_files');
+}
+
+const run = async () => {
+  try {
+    if (process.argv.includes('--rollback')) {
+      await down();
+      console.log('Rolled back migration 007_add_task_files');
+    } else {
+      await up();
+      console.log('Ran migration 007_add_task_files');
+    }
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+};
+
+run();

--- a/server/src/controllers/roadmapController.js
+++ b/server/src/controllers/roadmapController.js
@@ -70,7 +70,7 @@ exports.deleteWeek = catchAsync(async (req, res) => {
 
 exports.addTask = catchAsync(async (req, res) => {
   const { weekId } = req.params;
-  const task = await roadmapService.addTask(weekId, req.body, req.user.id, req.user.role);
+  const task = await roadmapService.addTask(weekId, req.body, req.user.id, req.user.role, req.files || []);
   res.status(201).json(successResponse('Task added successfully', { task }, 201));
 });
 

--- a/server/src/controllers/taskController.js
+++ b/server/src/controllers/taskController.js
@@ -20,7 +20,7 @@ exports.autoAssignWeekTasks = catchAsync(async (req, res) => {
 exports.createCustomTask = catchAsync(async (req, res) => {
   const mentorId = req.user.id;
   
-  const task = await taskService.createCustomTask(req.body, mentorId);
+  const task = await taskService.createCustomTask(req.body, mentorId, req.files || []);
   res.status(201).json(successResponse('Custom task created successfully', { task }, 201));
 });
 

--- a/server/src/models/tasks/RoadmapTask.js
+++ b/server/src/models/tasks/RoadmapTask.js
@@ -75,9 +75,10 @@ module.exports = (sequelize, DataTypes) => {
     ]
   });
 
-  RoadmapTask.associate = (models) => {
+   RoadmapTask.associate = (models) => {
     RoadmapTask.belongsTo(models.RoadmapWeek, { foreignKey: 'roadmap_week_id', as: 'week' });
     RoadmapTask.hasMany(models.TaskResource, { foreignKey: 'roadmap_task_id', as: 'resources' });
+    RoadmapTask.hasMany(models.TaskFile, { foreignKey: 'roadmap_task_id', as: 'taskFiles' });
     RoadmapTask.hasMany(models.TaskSkill, { foreignKey: 'roadmap_task_id', as: 'taskSkills' });
     RoadmapTask.hasMany(models.AssignedTask, { foreignKey: 'roadmap_task_id', as: 'assignments' });
     RoadmapTask.hasMany(models.TaskAnalytics, { foreignKey: 'roadmap_task_id', as: 'analytics' });

--- a/server/src/models/tasks/TaskFile.js
+++ b/server/src/models/tasks/TaskFile.js
@@ -1,0 +1,57 @@
+module.exports = (sequelize, DataTypes) => {
+  const TaskFile = sequelize.define('TaskFile', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true
+    },
+    roadmapTaskId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'roadmap_task_id'
+    },
+    fileName: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      field: 'file_name'
+    },
+    fileUrl: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      field: 'file_url'
+    },
+    fileType: {
+      type: DataTypes.STRING(100),
+      field: 'file_type'
+    },
+    fileSizeBytes: {
+      type: DataTypes.BIGINT,
+      field: 'file_size_bytes'
+    },
+    uploadedBy: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'uploaded_by'
+    },
+    uploadedAt: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      field: 'uploaded_at'
+    }
+  }, {
+    tableName: 'task_files',
+    underscored: true,
+    timestamps: false,
+    indexes: [
+      { fields: ['roadmap_task_id'] },
+      { fields: ['uploaded_by'] }
+    ]
+  });
+
+  TaskFile.associate = (models) => {
+    TaskFile.belongsTo(models.RoadmapTask, { foreignKey: 'roadmap_task_id', as: 'roadmapTask' });
+    TaskFile.belongsTo(models.User, { foreignKey: 'uploaded_by', as: 'uploader' });
+  };
+
+  return TaskFile;
+};

--- a/server/src/routes/roadmaps.js
+++ b/server/src/routes/roadmaps.js
@@ -4,6 +4,7 @@ const roadmapController = require('../controllers/roadmapController');
 const { authenticate, authorize } = require('../middlewares/auth');
 const { validate } = require('../middlewares/validate');
 const roadmapValidation = require('../validations/roadmapValidation');
+const upload = require('../middlewares/upload');
 
 /**
  * @route   POST /api/programs/:programId/levels/:levelId/roadmap/generate
@@ -123,6 +124,7 @@ router.post(
   '/weeks/:weekId/tasks',
   authenticate,
   authorize('admin', 'mentor'),
+  upload.array('files', 5),
   validate(roadmapValidation.addTask),
   roadmapController.addTask
 );

--- a/server/src/routes/tasks.js
+++ b/server/src/routes/tasks.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const taskController = require('../controllers/taskController');
 const { authenticate, authorize } = require('../middlewares/auth');
+const upload = require('../middlewares/upload');
 
 /**
  * @route   POST /api/tasks/auto-assign
@@ -24,6 +25,7 @@ router.post(
   '/custom',
   authenticate,
   authorize(['mentor']),
+  upload.array('files', 5),
   taskController.createCustomTask
 );
 

--- a/server/src/services/roadmapService.js
+++ b/server/src/services/roadmapService.js
@@ -1,6 +1,7 @@
 const { models } = require('../db');
 const { NotFoundError, ForbiddenError, ValidationError } = require('../utils/errors/errorTypes');
 const groqService = require('./groqService');
+const { uploadTaskFiles } = require('../utils/taskFileUpload');
 
 class RoadmapService {
   /**
@@ -632,7 +633,7 @@ class RoadmapService {
   /**
    * Add task to week
    */
-  async addTask(weekId, data, userId, userRole) {
+   async addTask(weekId, data, userId, userRole, files = []) {
     const week = await models.RoadmapWeek.findByPk(weekId, {
       include: [
         {
@@ -652,15 +653,20 @@ class RoadmapService {
       throw new ForbiddenError('You do not have permission to add tasks');
     }
 
+         const maxTaskOrder = await models.RoadmapTask.max('taskOrder', {
+      where: { roadmapWeekId: weekId }
+    });
+
     const task = await models.RoadmapTask.create({
       roadmapWeekId: weekId,
       ...data,
-      // Map orderIndex → taskOrder (model field), auto-assign if missing
-      taskOrder: data.taskOrder || data.orderIndex ||
-        ((await models.RoadmapTask.count({ where: { roadmapWeekId: weekId } })) + 1),
-      // deliverable is NOT NULL in the model, provide default if omitted
+      taskOrder: (maxTaskOrder || 0) + 1,
       deliverable: data.deliverable || 'Complete the assigned task',
     });
+
+    if (files.length > 0) {
+      await uploadTaskFiles(task.id, userId, files);
+    }
 
     // Add resources if provided
     if (data.resources && Array.isArray(data.resources)) {

--- a/server/src/services/taskService.js
+++ b/server/src/services/taskService.js
@@ -3,6 +3,7 @@ const { NotFoundError, ForbiddenError, ValidationError } = require('../utils/err
 const { Op } = require('sequelize');
 const notificationOrchestrator = require('./notificationOrchestrator');
 const { NOTIFICATION_EVENTS } = require('../config/notificationMatrix');
+const { uploadTaskFiles } = require('../utils/taskFileUpload');
 
 class TaskService {
   /**
@@ -125,7 +126,7 @@ class TaskService {
   /**
    * Create custom task (mentor creates for specific mentee)
    */
-  async createCustomTask(data, mentorId) {
+    async createCustomTask(data, mentorId, files = []) {
     const {
       menteeId,
       enrollmentId,
@@ -178,6 +179,9 @@ class TaskService {
         isCustomTask: true,
         pointsBase: pointsBase || 10
       });
+            if (files.length > 0) {
+        await uploadTaskFiles(roadmapTask.id, mentorId, files);
+      }
     }
 
     // Create assigned task
@@ -354,7 +358,7 @@ class TaskService {
         {
           model: models.RoadmapTask,
           as: 'roadmapTask',
-          include: [
+         include: [
             {
               model: models.RoadmapWeek,
               as: 'week'
@@ -362,6 +366,10 @@ class TaskService {
             {
               model: models.TaskResource,
               as: 'resources'
+            },
+            {
+              model: models.TaskFile,
+              as: 'taskFiles'
             }
           ]
         },

--- a/server/src/utils/taskFileUpload.js
+++ b/server/src/utils/taskFileUpload.js
@@ -1,0 +1,38 @@
+const { models } = require('../db');
+const { uploadToCloudinary } = require('./cloudinaryUpload');
+const { ValidationError } = require('./errors/errorTypes');
+
+const getCloudinaryResourceType = (mimetype) => {
+  if (mimetype.startsWith('video/')) return 'video';
+  if (mimetype.startsWith('image/')) return 'image';
+  return 'raw';
+};
+
+async function uploadTaskFiles(roadmapTaskId, uploadedBy, files = []) {
+  for (const file of files) {
+    try {
+      const resourceType = getCloudinaryResourceType(file.mimetype);
+      const result = await uploadToCloudinary(
+        file.buffer,
+        `pathment/tasks/${roadmapTaskId}`,
+        resourceType
+      );
+
+      await models.TaskFile.create({
+        roadmapTaskId,
+        uploadedBy,
+        fileName: file.originalname,
+        fileUrl: result.secure_url,
+        fileType: file.mimetype,
+        fileSizeBytes: file.size
+      });
+    } catch (error) {
+      console.error('Error uploading task file:', error);
+      throw new ValidationError(`Failed to upload file: ${file.originalname}`);
+    }
+  }
+}
+
+module.exports = {
+  uploadTaskFiles
+};


### PR DESCRIPTION
### Description

This PR adds optional file upload support for manually created tasks. Admins can now attach requirement files when adding roadmap tasks manually, and mentors can attach files when creating custom tasks for mentees. Uploaded files are shown dynamically in task details only when a task has files.

### Problem

Admins and mentors could create custom/manual tasks, but they could not upload supporting files such as screenshots, PDFs, starter files, specs, or requirement documents.

This made custom tasks less clear for mentees, even though mentees already had file upload support when submitting their work.

## Solution / Enhancement

- Added task-level file attachment support using a new `task_files` table.
- Reused the existing file upload flow with Multer and Cloudinary.
- Added optional file upload UI to mentor custom task creation.
- Added optional file upload UI to admin roadmap task creation.
- Updated mentor and mentee task detail pages to show uploaded task files only when files exist.


### Files Changed

- `server/src/models/tasks/TaskFile.js`
- `server/scripts/migrations/007_add_task_files.js`
- `server/src/models/tasks/RoadmapTask.js`
- `server/src/utils/taskFileUpload.js`
- `server/src/routes/tasks.js`
- `server/src/controllers/taskController.js`
- `server/src/services/taskService.js`
- `server/src/routes/roadmaps.js`
- `server/src/controllers/roadmapController.js`
- `server/src/services/roadmapService.js`
- `client-interface/lib/services/task-api.ts`
- `client-interface/lib/services/program-api.ts`
- `client-interface/lib/hooks/mentor/useMentorTasks.ts`
- `client-interface/app/mentor/tasks/page.tsx`
- `client-interface/lib/hooks/admin/useProgramRoadmap.ts`
- `client-interface/app/admin/programs/[id]/roadmap/page.tsx`
- `client-interface/app/mentor/tasks/[id]/page.tsx`
- `client-interface/app/mentee/tasks/[id]/page.tsx`

### Testing Checklist

- [x] Mentor can create a custom task without uploading files.
- [x] Mentor can create a custom task with uploaded files.
- [x] Uploaded mentor task files are saved in `task_files`.
- [x] Mentee can see uploaded mentor task files in task details.
- [x] Mentor can see uploaded mentor task files in task details.
- [x] Admin can add a roadmap task without uploading files.
- [x] Admin can add a roadmap task with uploaded files.
- [x] Uploaded admin roadmap task files are saved in `task_files`.
- [x] Task details hide the file section when no files exist.



Closes #123

### Screnshoot

## Mentor creating tasks with File Upload

https://github.com/user-attachments/assets/906020f1-31d4-48fe-87b3-6f472ec96d89

## Admin creating tasks with File Upload


https://github.com/user-attachments/assets/11a2c556-36f3-4b5d-8b7c-783056a4b795

