### PR TITLE
fix: add space between mentor name and hasn't in 1:1 empty state

### DIFF
--- a/client-interface/app/mentee/meetings/page.tsx
+++ b/client-interface/app/mentee/meetings/page.tsx
@@ -104,7 +104,7 @@ export default function MenteeMeetings() {
 
                           {b.slots.length === 0 ? (
                             <p className="mt-3 text-sm text-slate-400 rounded-xl bg-slate-50 border border-slate-100 px-3.5 py-2.5">
-                              {b.mentor.name.split(' ')[0]} hasn&apos;t opened any 1:1 times yet - message them to set some up.
+                              {b.mentor.name.split(' ')[0]}{" "}hasn&apos;t opened any 1:1 times yet - message them to set some up.
                             </p>
                           ) : open && (
                             <div className="mt-4 rounded-xl border border-slate-200 p-3">


### PR DESCRIPTION
## Description

The mentor's first name was being rendered directly next to the static text "hasn't" with no space in between, resulting in broken text like "Talhahasn't opened any 1:1 times yet". Fixed by adding {" "} between the JSX expression and the static string in app/mentee/meetings/page.tsx.

##Type of Change

 Bug fix


Before: 
Talhahasn't opened any 1:1 times yet 
<img width="960" height="527" alt="Screenshot 2026-06-15 224435" src="https://github.com/user-attachments/assets/38f6f445-2a39-48e8-a3a0-06d4709b1be7" />


After: 
Talha hasn't opened any 1:1 times yet

After screenshot not included as full backend setup (PostgreSQL, Cloudinary, Resend) is required just to reach the page, which is disproportionate for a one-character space fix.