### PR TITLE
Allow co-mentors to add mentees with a toggleable permission.

### DIFF
--- a/client-interface/app/admin/access/page.tsx
+++ b/client-interface/app/admin/access/page.tsx
@@ -23,7 +23,7 @@ import { useConfirm } from '@/lib/context/ConfirmContext';
 const PERMISSION_GROUPS = [
   { label: 'Programs & curriculum', perms: ['program.create', 'program.manage', 'program.publish', 'cohort.manage', 'roadmap.author', 'roadmap.publish_local'] },
   { label: 'Intake', perms: ['intake.manage', 'assessment.author', 'invite.create'] },
-  { label: 'People & clans', perms: ['clan.create', 'clan.manage_members', 'mentee.view', 'mentee.manage', 'user.manage'] },
+  { label: 'People & clans', perms: ['clan.create', 'clan.manage_members', 'mentee.view', 'mentee.manage', 'mentee.add', 'user.manage'] },
   { label: 'Work', perms: ['task.assign', 'task.review', 'library.manage'] },
   { label: 'Community & rewards', perms: ['community.post', 'community.moderate', 'announcement.post', 'gamification.manage'] },
   { label: 'Platform', perms: ['analytics.view', 'access.manage', 'system.settings'] },

--- a/client-interface/app/mentor/clan-team/page.tsx
+++ b/client-interface/app/mentor/clan-team/page.tsx
@@ -78,16 +78,30 @@ function ClanTeamCard({ clanId, myRole }: { clanId: string; myRole: string }) {
   const [adding, setAdding] = useState(false);
   const [addingMentees, setAddingMentees] = useState(false);
   const [permMember, setPermMember] = useState<Member | null>(null);
+  const [canManageTeam, setCanManageTeam] = useState(myRole === 'lead_mentor');
+  const [canAddMentees, setCanAddMentees] = useState(myRole === 'lead_mentor');
   const confirm = useConfirm();
-  const canManage = myRole === 'lead_mentor';
 
   const load = useCallback(() => {
     setLoading(true);
-    clanApi.get(clanId)
-      .then((r: any) => setClan(r.data?.clan || r.data))
+    Promise.all([
+      clanApi.get(clanId),
+      clanApi.myClanAccess(clanId).catch(() => null),
+    ])
+      .then(([clanRes, accessRes]: any[]) => {
+        setClan(clanRes.data?.clan || clanRes.data);
+        const access = accessRes?.data;
+        if (access) {
+          setCanManageTeam(Boolean(access.canManageTeam));
+          setCanAddMentees(Boolean(access.canAddMentees));
+        } else {
+          setCanManageTeam(myRole === 'lead_mentor');
+          setCanAddMentees(myRole === 'lead_mentor');
+        }
+      })
       .catch(() => toast.error('Could not load clan'))
       .finally(() => setLoading(false));
-  }, [clanId]);
+  }, [clanId, myRole]);
   useEffect(load, [load]);
 
   const remove = async (userId: string, label: string) => {
@@ -118,10 +132,10 @@ function ClanTeamCard({ clanId, myRole }: { clanId: string; myRole: string }) {
         </div>
       </div>
       <div className="flex items-center gap-1 shrink-0">
-        {managePerms && canManage && (
+        {managePerms && canManageTeam && (
           <button onClick={() => setPermMember(m)} className="p-1.5 rounded-md text-slate-400 hover:text-brand-600 hover:bg-brand-50" aria-label="Edit permissions" title="Edit permissions"><SlidersHorizontal className="w-4 h-4" /></button>
         )}
-        {removable && canManage && (
+        {removable && canManageTeam && (
           <button onClick={() => remove(m.user.id, name(m.user))} className="p-1.5 rounded-md text-rose-500 hover:bg-rose-50" aria-label="Remove"><Trash2 className="w-4 h-4" /></button>
         )}
       </div>
@@ -144,7 +158,7 @@ function ClanTeamCard({ clanId, myRole }: { clanId: string; myRole: string }) {
           <h2 className="font-semibold text-slate-900">{clan.name}</h2>
           <p className="text-sm text-slate-500">{clan.program?.name} · {menteeCount} mentee{menteeCount === 1 ? '' : 's'}</p>
         </div>
-        {canManage ? (
+        {canManageTeam ? (
           <div className="flex items-center gap-2 shrink-0">
             <button onClick={() => setAddingMentees(true)} className="inline-flex items-center gap-1.5 rounded-lg border border-brand-200 bg-brand-50 dark:bg-brand-500/15 px-3 py-2 text-sm font-medium text-brand-700 hover:bg-brand-100">
               <Users2 className="w-4 h-4" /> Add mentees
@@ -153,6 +167,10 @@ function ClanTeamCard({ clanId, myRole }: { clanId: string; myRole: string }) {
               <UserPlus className="w-4 h-4" /> Add to team
             </button>
           </div>
+        ) : canAddMentees ? (
+          <button onClick={() => setAddingMentees(true)} className="inline-flex items-center gap-1.5 rounded-lg border border-brand-200 bg-brand-50 dark:bg-brand-500/15 px-3 py-2 text-sm font-medium text-brand-700 hover:bg-brand-100 shrink-0">
+            <Users2 className="w-4 h-4" /> Add mentees
+          </button>
         ) : (
           <span className="text-xs text-slate-400 shrink-0">View only (co-mentor)</span>
         )}
@@ -168,11 +186,11 @@ function ClanTeamCard({ clanId, myRole }: { clanId: string; myRole: string }) {
         )}
       </div>
 
-      {canManage && <CrossClanSection clanId={clanId} clanName={clan.name} />}
+      {canManageTeam && <CrossClanSection clanId={clanId} clanName={clan.name} />}
 
-      {adding && <AddTeamMemberDrawer clanId={clanId} onClose={() => setAdding(false)} onAdded={() => { setAdding(false); load(); }} />}
-      {addingMentees && <AddMenteesDrawer clanId={clanId} clanName={clan.name} onClose={() => setAddingMentees(false)} onChanged={() => load()} />}
-      {permMember && <CoMentorPermissionsDrawer clanId={clanId} userId={permMember.user.id} name={name(permMember.user)} onClose={() => setPermMember(null)} onSaved={load} />}
+      {canManageTeam && adding && <AddTeamMemberDrawer clanId={clanId} onClose={() => setAdding(false)} onAdded={() => { setAdding(false); load(); }} />}
+      {canAddMentees && addingMentees && <AddMenteesDrawer clanId={clanId} clanName={clan.name} onClose={() => setAddingMentees(false)} onChanged={() => load()} />}
+      {canManageTeam && permMember && <CoMentorPermissionsDrawer clanId={clanId} userId={permMember.user.id} name={name(permMember.user)} onClose={() => setPermMember(null)} onSaved={load} />}
     </div>
   );
 }

--- a/client-interface/lib/config/permissions.ts
+++ b/client-interface/lib/config/permissions.ts
@@ -18,6 +18,7 @@ export const PERMISSIONS = {
   CLAN_MANAGE_MEMBERS: 'clan.manage_members',
   MENTEE_VIEW: 'mentee.view',
   MENTEE_MANAGE: 'mentee.manage',
+  MENTEE_ADD: 'mentee.add',
   USER_MANAGE: 'user.manage',
   TASK_ASSIGN: 'task.assign',
   TASK_REVIEW: 'task.review',
@@ -42,6 +43,7 @@ export type Permission = (typeof PERMISSIONS)[keyof typeof PERMISSIONS];
 export const CO_MENTOR_PERMISSIONS: { key: Permission; label: string; description: string }[] = [
   { key: PERMISSIONS.MENTEE_VIEW, label: 'View mentees', description: 'See mentee profiles, progress, and submissions.' },
   { key: PERMISSIONS.MENTEE_MANAGE, label: 'Manage mentees', description: 'Add notes, manage placement, and act on insights.' },
+  { key: PERMISSIONS.MENTEE_ADD, label: 'Add mentees', description: 'Bring new mentees into the clan or invite them by email.' },
   { key: PERMISSIONS.TASK_ASSIGN, label: 'Assign tasks', description: 'Create and assign tasks to mentees.' },
   { key: PERMISSIONS.TASK_REVIEW, label: 'Review work', description: 'Mark tasks complete and leave feedback.' },
   { key: PERMISSIONS.ROADMAP_PUBLISH_LOCAL, label: 'Publish roadmaps', description: "Build and publish the clan's roadmap." },

--- a/client-interface/lib/services/clan-api.ts
+++ b/client-interface/lib/services/clan-api.ts
@@ -27,6 +27,8 @@ export const clanApi = {
   update: (id: string, data: Record<string, unknown>) => apiClient.patch(`/clans/${id}`, data),
   addMember: (id: string, userId: string, role: 'lead_mentor' | 'co_mentor' | 'mentee' | 'core_team') =>
     apiClient.post(`/clans/${id}/members`, { userId, role }),
+  /** Clan-scoped mentor capabilities for the current user (matches server guards). */
+  myClanAccess: (id: string) => apiClient.get(`/clans/${id}/members/me/access`),
   removeMember: (id: string, userId: string) => apiClient.delete(`/clans/${id}/members/${userId}`),
   /** A co-mentor's current toggle state: { keys, denied }. Works for co-mentors
    *  from any source (team membership / cross-clan cover / IAM grant). */

--- a/server/scripts/test-rbac.js
+++ b/server/scripts/test-rbac.js
@@ -128,6 +128,14 @@ async function mkUser(role, n) {
   ok('MENTEE_ADD: lead mentor via clan.manage_members', await authzService.can(fLead, P.CLAN_MANAGE_MEMBERS, clanARes));
   ok('MENTEE_ADD: plain mentee NO', !(await authzService.can(fPlain, P.MENTEE_ADD, clanARes)));
 
+  // Toggle path: a lead/admin disabling mentee.add for THIS co-mentor blocks it
+  // (and leaves their other permissions intact), then re-enabling restores it.
+  await clanService.setMemberPermissions(clan.id, fCo.id, [P.MENTEE_ADD], fLead.id);
+  ok('MENTEE_ADD: co-mentor BLOCKED after lead disables it', !(await authzService.can(fCo, P.MENTEE_ADD, clanARes)));
+  ok('MENTEE_ADD: other perms intact (task.assign still yes)', await authzService.can(fCo, P.TASK_ASSIGN, clanARes));
+  await clanService.setMemberPermissions(clan.id, fCo.id, [], fLead.id);
+  ok('MENTEE_ADD: co-mentor restored after re-enable', await authzService.can(fCo, P.MENTEE_ADD, clanARes));
+
   ok('completion (TASK_REVIEW): lead mentor yes', await authzService.can(fLead, P.TASK_REVIEW, clanARes));
   ok('completion (TASK_REVIEW): co-mentor yes (preserved)', await authzService.can(fCo, P.TASK_REVIEW, clanARes));
   ok('completion (TASK_REVIEW): plain mentee NO', !(await authzService.can(fPlain, P.TASK_REVIEW, clanARes)));

--- a/server/scripts/test-rbac.js
+++ b/server/scripts/test-rbac.js
@@ -123,6 +123,11 @@ async function mkUser(role, n) {
   ok('TASK_ASSIGN: plain mentee BLOCKED', !(await authzService.can(fPlain, P.TASK_ASSIGN, clanARes)));
   ok('TASK_ASSIGN: admin anywhere', await authzService.can(fAdmin, P.TASK_ASSIGN, clanBRes));
 
+  ok('MENTEE_ADD: co-mentor in own clan', await authzService.can(fCo, P.MENTEE_ADD, clanARes));
+  ok('MENTEE_ADD: co-mentor BLOCKED in another clan', !(await authzService.can(fCo, P.MENTEE_ADD, clanBRes)));
+  ok('MENTEE_ADD: lead mentor via clan.manage_members', await authzService.can(fLead, P.CLAN_MANAGE_MEMBERS, clanARes));
+  ok('MENTEE_ADD: plain mentee NO', !(await authzService.can(fPlain, P.MENTEE_ADD, clanARes)));
+
   ok('completion (TASK_REVIEW): lead mentor yes', await authzService.can(fLead, P.TASK_REVIEW, clanARes));
   ok('completion (TASK_REVIEW): co-mentor yes (preserved)', await authzService.can(fCo, P.TASK_REVIEW, clanARes));
   ok('completion (TASK_REVIEW): plain mentee NO', !(await authzService.can(fPlain, P.TASK_REVIEW, clanARes)));

--- a/server/src/config/permissions.js
+++ b/server/src/config/permissions.js
@@ -25,6 +25,7 @@ const PERMISSIONS = {
   CLAN_MANAGE_MEMBERS: 'clan.manage_members',
   MENTEE_VIEW: 'mentee.view',                // see mentees' profiles/progress
   MENTEE_MANAGE: 'mentee.manage',            // notes, insights, placement actions
+  MENTEE_ADD: 'mentee.add',                  // add mentees to a clan (co-mentor toggle)
   USER_MANAGE: 'user.manage',               // org user directory / status
 
   // Work

--- a/server/src/config/roles.js
+++ b/server/src/config/roles.js
@@ -62,7 +62,7 @@ const ROLES = {
     scope: 'clan',
     description: 'Leads a clan - full mentoring plus member management.',
     permissions: [
-      P.TASK_ASSIGN, P.TASK_REVIEW, P.MENTEE_VIEW, P.MENTEE_MANAGE,
+      P.TASK_ASSIGN, P.TASK_REVIEW, P.MENTEE_VIEW, P.MENTEE_MANAGE, P.MENTEE_ADD,
       P.CLAN_MANAGE_MEMBERS, P.ROADMAP_PUBLISH_LOCAL, P.LIBRARY_MANAGE,
       P.ANNOUNCEMENT_POST, P.ANALYTICS_VIEW, P.COMMUNITY_POST
     ]
@@ -72,11 +72,12 @@ const ROLES = {
     scope: 'clan',
     description: 'Full mentoring access by default; the lead mentor and admins manage the team and can fine-tune each co-mentor.',
     // Co-mentors default to the SAME power as a lead mentor, EXCEPT
-    // clan.manage_members (managing the team + editing permissions stays with
-    // the lead mentor + admins). A lead/admin can then revoke any of these for
-    // an individual co-mentor via clan_memberships.permission_overrides.
+    // clan.manage_members (managing co-mentors/core team + editing permissions
+    // stays with the lead mentor + admins). mentee.add is toggleable here so a
+    // lead can revoke it per co-mentor. A lead/admin can fine-tune via
+    // clan_memberships.permission_overrides.
     permissions: [
-      P.TASK_ASSIGN, P.TASK_REVIEW, P.MENTEE_VIEW, P.MENTEE_MANAGE,
+      P.TASK_ASSIGN, P.TASK_REVIEW, P.MENTEE_VIEW, P.MENTEE_MANAGE, P.MENTEE_ADD,
       P.ROADMAP_PUBLISH_LOCAL, P.LIBRARY_MANAGE, P.ANNOUNCEMENT_POST,
       P.ANALYTICS_VIEW, P.COMMUNITY_POST
     ]

--- a/server/src/controllers/clanController.js
+++ b/server/src/controllers/clanController.js
@@ -95,8 +95,17 @@ const updateClan = catchAsync(async (req, res) => {
  * Assign a user to the clan with a clan-scoped role (clan-based assignment).
  */
 const addMember = catchAsync(async (req, res) => {
-  const membership = await clanService.addMember(req.params.id, req.body);
+  const membership = await clanService.addMember(req.params.id, req.body, req.user);
   res.status(201).json(successResponse('Member added', { membership }, 201));
+});
+
+/**
+ * GET /api/clans/:id/members/me/access  (lead / co-mentor of this clan)
+ * Clan-scoped capabilities for the current user — drives the clan-team UI.
+ */
+const getMyClanAccess = catchAsync(async (req, res) => {
+  const access = await clanService.getMyClanAccess(req.params.id, req.user);
+  res.status(200).json(successResponse('Clan access retrieved', access));
 });
 
 /**
@@ -218,6 +227,7 @@ module.exports = {
   createClan,
   updateClan,
   addMember,
+  getMyClanAccess,
   removeMember,
   getMemberPermissions,
   setMemberPermissions,

--- a/server/src/middlewares/authz.js
+++ b/server/src/middlewares/authz.js
@@ -1,4 +1,5 @@
 const authzService = require('../services/authzService');
+const { PERMISSIONS } = require('../config/permissions');
 const { AuthenticationError, AuthorizationError } = require('../utils/errors/errorTypes');
 
 /**
@@ -26,6 +27,61 @@ function requirePermission(permission, scopeResolver = null) {
         throw new AuthorizationError('You do not have permission to perform this action');
       }
       next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+/**
+ * Admit the request when the user holds ANY of the listed permissions at the
+ * resolved scope. Same assignment caching as requirePermission.
+ */
+function requireAnyPermission(permissions, scopeResolver = null) {
+  return async (req, res, next) => {
+    try {
+      if (!req.user) throw new AuthenticationError('You must be logged in to access this resource');
+
+      req._assignments = req.loadAssignments
+        ? await req.loadAssignments()
+        : (req._assignments || (await authzService.getAssignments(req.user)));
+      const resource = scopeResolver ? await scopeResolver(req) : null;
+
+      for (const permission of permissions) {
+        // eslint-disable-next-line no-await-in-loop
+        if (await authzService.can(req.user, permission, resource, { assignments: req._assignments })) {
+          return next();
+        }
+      }
+      throw new AuthorizationError('You do not have permission to perform this action');
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+/**
+ * Add a member to a clan: clan.manage_members covers any role; mentee.add covers
+ * adding mentees only (co-mentor toggle). Prevents mentee.add from assigning
+ * co-mentors / core team.
+ */
+function requireAddClanMember(scopeResolver) {
+  return async (req, res, next) => {
+    try {
+      if (!req.user) throw new AuthenticationError('You must be logged in to access this resource');
+
+      req._assignments = req.loadAssignments
+        ? await req.loadAssignments()
+        : (req._assignments || (await authzService.getAssignments(req.user)));
+      const resource = await scopeResolver(req);
+
+      if (await authzService.can(req.user, PERMISSIONS.CLAN_MANAGE_MEMBERS, resource, { assignments: req._assignments })) {
+        return next();
+      }
+      if (req.body?.role === 'mentee' && await authzService.can(req.user, PERMISSIONS.MENTEE_ADD, resource, { assignments: req._assignments })) {
+        return next();
+      }
+      throw new AuthorizationError('You do not have permission to perform this action');
     } catch (err) {
       next(err);
     }
@@ -95,4 +151,4 @@ const scope = {
     authzService.scopeOfAnnouncementAudience(req.body && req.body.audience, req.body && req.body.audienceId)
 };
 
-module.exports = { requirePermission, requirePermissionAnyScope, requirePermissionMinScope, scope };
+module.exports = { requirePermission, requireAnyPermission, requireAddClanMember, requirePermissionAnyScope, requirePermissionMinScope, scope };

--- a/server/src/routes/clans.js
+++ b/server/src/routes/clans.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const clanController = require('../controllers/clanController');
 const { authenticate, authorize } = require('../middlewares/auth');
-const { requirePermission, requirePermissionMinScope, scope } = require('../middlewares/authz');
+const { requirePermission, requireAnyPermission, requireAddClanMember, requirePermissionMinScope, scope } = require('../middlewares/authz');
 const { validateQuery } = require('../middlewares/validate');
 const clanSchemas = require('../validations/clanValidation');
 const { PERMISSIONS } = require('../config/permissions');
@@ -29,11 +29,14 @@ router.get('/:id', authenticate, clanController.getClan);
 router.post('/', authenticate, requirePermission(PERMISSIONS.CLAN_CREATE, (req) => ({ programId: req.body.programId })), clanController.createClan);
 
 // Update / manage members - needs clan.manage_members ON THIS CLAN. That's held
-// by admins and the clan's LEAD MENTOR (not co-mentors). This is how a lead
-// mentor adds a co-mentor / core-team member to their own clan.
+// by admins and the clan's LEAD MENTOR (not co-mentors). Co-mentors may add
+// mentees when they hold mentee.add (see requireAddClanMember below).
 router.patch('/:id', authenticate, requirePermission(PERMISSIONS.CLAN_MANAGE_MEMBERS, scope.clan('id')), clanController.updateClan);
-router.post('/:id/members', authenticate, requirePermission(PERMISSIONS.CLAN_MANAGE_MEMBERS, scope.clan('id')), clanController.addMember);
+router.post('/:id/members', authenticate, requireAddClanMember(scope.clan('id')), clanController.addMember);
 router.delete('/:id/members/:userId', authenticate, requirePermission(PERMISSIONS.CLAN_MANAGE_MEMBERS, scope.clan('id')), clanController.removeMember);
+
+// Clan-scoped capabilities for the current mentor (before /:userId routes).
+router.get('/:id/members/me/access', authenticate, clanController.getMyClanAccess);
 
 // Fine-tune one co-mentor's permissions (lead mentor of THIS clan, or an admin).
 // Co-mentors don't hold clan.manage_members, so they can't edit anyone's perms.
@@ -46,8 +49,9 @@ router.patch('/:id/members/:userId/permissions', authenticate, requirePermission
 router.post('/reassign', authenticate, requirePermissionMinScope(PERMISSIONS.CLAN_MANAGE_MEMBERS, 'program'), clanController.reassignClan);
 
 // Lead mentor: pull in unassigned mentees, or invite a new one straight into the clan.
-router.get('/:id/available', authenticate, requirePermission(PERMISSIONS.CLAN_MANAGE_MEMBERS, scope.clan('id')), clanController.availableMembers);
-router.post('/:id/invite', authenticate, requirePermission(PERMISSIONS.CLAN_MANAGE_MEMBERS, scope.clan('id')), clanController.inviteToClan);
+// Co-mentors with mentee.add may use these too.
+router.get('/:id/available', authenticate, requireAnyPermission([PERMISSIONS.CLAN_MANAGE_MEMBERS, PERMISSIONS.MENTEE_ADD], scope.clan('id')), clanController.availableMembers);
+router.post('/:id/invite', authenticate, requireAnyPermission([PERMISSIONS.CLAN_MANAGE_MEMBERS, PERMISSIONS.MENTEE_ADD], scope.clan('id')), clanController.inviteToClan);
 
 // Candidates for co-mentor / core-team (anyone active, not already in the clan).
 router.get('/:id/candidates', authenticate, requirePermission(PERMISSIONS.CLAN_MANAGE_MEMBERS, scope.clan('id')), clanController.candidates);

--- a/server/src/services/clanService.js
+++ b/server/src/services/clanService.js
@@ -213,7 +213,7 @@ class ClanService {
     const user = await models.User.findByPk(userId);
     if (!user) throw new NotFoundError('User not found');
 
-    return sequelize.transaction(async (transaction) => {
+    const membership = await sequelize.transaction(async (transaction) => {
       await this.ensureCapability(user, CAPABILITY_FOR_CLAN_ROLE[role], transaction);
 
       let membership = await models.ClanMembership.findOne({ where: { clanId, userId }, transaction });
@@ -266,6 +266,18 @@ class ClanService {
 
       return membership;
     });
+
+    // Audit who added whom — especially a co-mentor using mentee.add — so leads
+    // and admins have an accountability trail. Internal/system placements pass
+    // no actor and are intentionally not attributed here.
+    if (actor) {
+      await createAuditLog({
+        userId: actor.id, action: 'CLAN_MEMBER_ADDED', entityType: 'Clan', entityId: clanId,
+        newValues: { clanId, userId, role }
+      }).catch(() => {});
+    }
+
+    return membership;
   }
 
   async removeMember(clanId, userId) {
@@ -288,19 +300,29 @@ class ClanService {
    */
   async getMyClanAccess(clanId, user) {
     const userId = user.id;
+    const resource = await authzService.scopeOfClan(clanId);
+
+    // Derive capabilities from authzService so this matches the route guards for
+    // a co-mentor from ANY source — a team membership, a cross-clan cover, or an
+    // IAM grant — not just a clan_memberships row. (A membership-only check here
+    // would 403 a legitimate cover/IAM co-mentor that the API actually allows.)
+    const canManageTeam = await authzService.can(user, P.CLAN_MANAGE_MEMBERS, resource);
+    const canAddMentees = canManageTeam || await authzService.can(user, P.MENTEE_ADD, resource);
+    const canViewMentees = await authzService.can(user, P.MENTEE_VIEW, resource);
+
+    if (!canManageTeam && !canAddMentees && !canViewMentees) {
+      throw new AuthorizationError('You are not a mentor of this clan');
+    }
+
+    // Prefer the real membership role; fall back to an inferred role for
+    // cover/IAM co-mentors who hold capability without a membership row.
     const membership = await models.ClanMembership.findOne({
       where: { clanId, userId, status: 'active' },
       attributes: ['role']
     });
-    if (!membership || !['lead_mentor', 'co_mentor'].includes(membership.role)) {
-      throw new AuthorizationError('You are not a mentor of this clan');
-    }
+    const role = membership?.role || (canManageTeam ? 'lead_mentor' : 'co_mentor');
 
-    const resource = await authzService.scopeOfClan(clanId);
-    const canManageTeam = await authzService.can(user, P.CLAN_MANAGE_MEMBERS, resource);
-    const canAddMentees = canManageTeam || await authzService.can(user, P.MENTEE_ADD, resource);
-
-    return { role: membership.role, canManageTeam, canAddMentees };
+    return { role, canManageTeam, canAddMentees };
   }
 
   /**

--- a/server/src/services/clanService.js
+++ b/server/src/services/clanService.js
@@ -1,7 +1,9 @@
 const { models, sequelize } = require('../db');
-const { NotFoundError, ValidationError, ConflictError } = require('../utils/errors/errorTypes');
+const { NotFoundError, ValidationError, ConflictError, AuthorizationError } = require('../utils/errors/errorTypes');
 const { createAuditLog } = require('../utils/auditContext');
 const { ROLES } = require('../config/roles');
+const authzService = require('./authzService');
+const { PERMISSIONS: P } = require('../config/permissions');
 
 // The permissions a co-mentor holds by default — and therefore the exact set a
 // lead mentor / admin may toggle on or off for an individual co-mentor. Derived
@@ -192,9 +194,18 @@ class ClanService {
    * clan-based assignment entry point: assigning a mentee here is how they're
    * "matched". Ensures the user gains the implied platform capability.
    */
-  async addMember(clanId, { userId, role, enrollmentId }) {
+  async addMember(clanId, { userId, role, enrollmentId }, actor = null) {
     if (!userId || !role) throw new ValidationError('userId and role are required');
     if (!CAPABILITY_FOR_CLAN_ROLE[role]) throw new ValidationError(`Invalid clan role: ${role}`);
+
+    if (actor) {
+      const resource = await authzService.scopeOfClan(clanId);
+      const canManageTeam = await authzService.can(actor, P.CLAN_MANAGE_MEMBERS, resource);
+      const canAddMentee = role === 'mentee' && await authzService.can(actor, P.MENTEE_ADD, resource);
+      if (!canManageTeam && !canAddMentee) {
+        throw new AuthorizationError('You do not have permission to perform this action');
+      }
+    }
 
     const clan = await models.Clan.findByPk(clanId);
     if (!clan) throw new NotFoundError('Clan not found');
@@ -269,6 +280,27 @@ class ClanService {
   /** The permission keys a lead/admin may toggle for a co-mentor (the defaults). */
   coMentorPermissionKeys() {
     return [...CO_MENTOR_PERMISSIONS];
+  }
+
+  /**
+   * What the current user may do in THIS clan — clan-scoped, matches route guards.
+   * Drives the mentor clan-team UI (so co-mentor "Add mentees" aligns with the API).
+   */
+  async getMyClanAccess(clanId, user) {
+    const userId = user.id;
+    const membership = await models.ClanMembership.findOne({
+      where: { clanId, userId, status: 'active' },
+      attributes: ['role']
+    });
+    if (!membership || !['lead_mentor', 'co_mentor'].includes(membership.role)) {
+      throw new AuthorizationError('You are not a mentor of this clan');
+    }
+
+    const resource = await authzService.scopeOfClan(clanId);
+    const canManageTeam = await authzService.can(user, P.CLAN_MANAGE_MEMBERS, resource);
+    const canAddMentees = canManageTeam || await authzService.can(user, P.MENTEE_ADD, resource);
+
+    return { role: membership.role, canManageTeam, canAddMentees };
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds a new `mentee.add` permission so co-mentors can bring mentees into their clan (add from the available list or invite by email).
- Co-mentors receive this permission by default; lead mentors can turn it off per co-mentor via the existing permissions drawer on Clan Team.
- Full team management (add/remove co-mentors, remove members, edit permissions) remains with lead mentors via `clan.manage_members`.

## Changes

**Backend**
- New permission: `mentee.add`
- Co-mentor role bundle updated (lead mentor included for delegation parity)
- Route guards: add member, available list, and invite accept `mentee.add` or `clan.manage_members`
- `requireAddClanMember` ensures co-mentors can only add `role: mentee`
- New `GET /api/clans/:id/members/me/access` for clan-scoped UI gating
- Service-level authorization in `addMember`

**Frontend**
- "Add mentees" toggle in co-mentor permissions drawer
- Clan Team shows Add mentees for co-mentors when allowed (clan-scoped via API)
- Admin access page lists `mentee.add` in People & clans

## Screenshots

**Lead mentor — permission toggle** 
<img width="513" height="857" alt="Screenshot 2026-06-18 at 3 17 59 PM" src="https://github.com/user-attachments/assets/d0ed73b8-ffc3-41c2-bdec-0d9d0fbbc67b" />

**Co-mentor — Add mentees** 
<img width="1232" height="808" alt="Screenshot 2026-06-18 at 3 18 20 PM" src="https://github.com/user-attachments/assets/7854f2cc-b5a5-4dce-b6e2-2e371e041e6c" />


## Test plan

- [ ] RBAC script passes (`DB_SSL=false node scripts/test-rbac.js`)
- [ ] Lead mentor opens Clan Team → co-mentor permissions → toggle **Add mentees** off/on
- [ ] Co-mentor with permission sees **Add mentees** on Clan Team and can add an unassigned mentee
- [ ] Co-mentor with permission revoked gets 403 / button hidden
- [ ] Co-mentor cannot add co-mentors, remove members, or edit permissions
- [ ] Lead mentor retains full team management