### PR TITLE
feat: adopt React Query for client data fetching (#425)

### DIFF
--- a/client-interface/app/layout.tsx
+++ b/client-interface/app/layout.tsx
@@ -1,6 +1,7 @@
 ﻿import type { Metadata } from 'next';
 import { Plus_Jakarta_Sans, JetBrains_Mono } from 'next/font/google';
 import '../styles/globals.css';
+import { QueryProvider } from '@/lib/context/QueryProvider';
 import { AuthProvider } from '@/lib/context/AuthContext';
 import { ThemeProvider } from '@/lib/context/ThemeContext';
 import { ClanProvider } from '@/lib/context/ClanContext';
@@ -23,16 +24,18 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${jakarta.variable} ${jetbrains.variable}`} suppressHydrationWarning>
       <body suppressHydrationWarning>
-        <ThemeProvider>
-          <AuthProvider>
-            <ClanProvider>
-              <ConfirmProvider>
-                {children}
-                <Toaster />
-              </ConfirmProvider>
-            </ClanProvider>
-          </AuthProvider>
-        </ThemeProvider>
+        <QueryProvider>
+          <ThemeProvider>
+            <AuthProvider>
+              <ClanProvider>
+                <ConfirmProvider>
+                  {children}
+                  <Toaster />
+                </ConfirmProvider>
+              </ClanProvider>
+            </AuthProvider>
+          </ThemeProvider>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/client-interface/app/mentor/at-risk/page.tsx
+++ b/client-interface/app/mentor/at-risk/page.tsx
@@ -6,7 +6,8 @@ import { toast } from 'sonner';
 import {
   Bell, MessageSquare, ArrowUpRight, Clock, TrendingUp, TrendingDown, Minus, Loader2,
 } from 'lucide-react';
-import { useMentorCohort, type CohortMentee, type CohortMomentum } from '@/lib/hooks/mentor';
+import { useMentorCohort } from '@/lib/hooks/mentor';
+import type { CohortMentee, CohortMomentum } from '@/lib/types/cohort';
 import { mentorApi } from '@/lib/services/mentor-api';
 import { DualProgress } from '@/components/mentor/DualProgress';
 

--- a/client-interface/app/mentor/dashboard/page.tsx
+++ b/client-interface/app/mentor/dashboard/page.tsx
@@ -6,7 +6,8 @@ import {
   Users, ClipboardCheck, AlertTriangle, Flag, Loader2, Plus,
 } from 'lucide-react';
 import { useAuth } from '@/lib/context/AuthContext';
-import { useMentorCohort, type CohortMentee, type CohortRisk } from '@/lib/hooks/mentor';
+import { useMentorCohort } from '@/lib/hooks/mentor';
+import type { CohortMentee, CohortRisk } from '@/lib/types/cohort';
 import { StatsCard } from '@/components/admin/ui';
 import { MenteeCard } from '@/components/mentor/MenteeCard';
 import { AssignTaskDrawer } from '@/components/mentor/AssignTaskDrawer';

--- a/client-interface/app/mentor/leaderboard/page.tsx
+++ b/client-interface/app/mentor/leaderboard/page.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo, useState } from 'react';
 import { Trophy, Loader2, Award, TrendingUp, TrendingDown, Minus, Crown, Info } from 'lucide-react';
-import { useMentorCohort, type CohortMentee, type CohortMomentum } from '@/lib/hooks/mentor';
+import { useMentorCohort } from '@/lib/hooks/mentor';
+import type { CohortMentee, CohortMomentum } from '@/lib/types/cohort';
 
 // Real, honest signals only - no fabricated XP. Standings rank by RELATIVE
 // progress (the platform's fairness metric: output credited for logged,

--- a/client-interface/app/mentor/mentees/[id]/page.tsx
+++ b/client-interface/app/mentor/mentees/[id]/page.tsx
@@ -9,7 +9,9 @@ import {
   Target, TrendingUp, TrendingDown, Minus, Flag, Check, User, Loader2,
   Star, ThumbsUp, ThumbsDown, AlertCircle, ChevronLeft,
 } from 'lucide-react';
-import { useMenteeDetailPage, useMenteeProfile, type CohortRisk, type CohortMomentum } from '@/lib/hooks/mentor';
+import { useMenteeDetailPage, useMenteeProfile } from '@/lib/hooks/mentor';
+import type { CohortRisk, CohortMomentum } from '@/lib/types/cohort';
+import type { WorkHistoryItem } from '@/lib/types/task';
 import { useAuth } from '@/lib/context/AuthContext';
 import { useMenteeActivity } from '@/lib/hooks/mentor/useMenteeActivity';
 import { frictionApi } from '@/lib/services/friction-api';
@@ -190,19 +192,19 @@ export default function MenteeDetail() {
   const mentee = match.mentee;
   const enrollment = match.enrollment;
   const profile = mentee?.menteeProfile;
-  const progress = insights?.absoluteProgress ?? (parseFloat(enrollment?.overallProgressPercentage) || 0);
+  const progress = insights?.absoluteProgress ?? (parseFloat(enrollment?.overallProgressPercentage ?? '') || 0);
 
   const levelName = insights?.level || 'Level 1';
   const week = insights?.week ?? enrollment?.currentWeek ?? 1;
   const totalWeeks = insights?.totalWeeks || 0;
 
   // Work history groups (prefer computed grouping; fall back to raw task list).
-  const grouped: Record<string, any[]> =
+  const grouped: Record<string, WorkHistoryItem[]> =
     insights?.tasksByStatus ??
-    (tasks || []).reduce((acc: Record<string, any[]>, t: any) => {
+    (tasks ?? []).reduce((acc: Record<string, WorkHistoryItem[]>, t) => {
       const k = t.status || 'assigned';
       (acc[k] = acc[k] || []).push({
-        id: t.id, title: t.roadmapTask?.title || t.title, status: t.status,
+        id: t.id, title: t.roadmapTask?.title || t.title || '', status: t.status,
         source: t.isCustomTask ? 'Custom' : (t.roadmapName || t.roadmapTask?.roadmap?.name ? `Roadmap · ${t.roadmapName || t.roadmapTask?.roadmap?.name}` : 'Roadmap'),
         points: t.points ?? t.pointsBase ?? t.roadmapTask?.pointsBase ?? null,
       });
@@ -362,7 +364,7 @@ export default function MenteeDetail() {
                       <span className="text-xs text-slate-400">{grouped[status].length}</span>
                     </div>
                     <div className="space-y-2">
-                      {grouped[status].map((t: any) => (
+                      {grouped[status].map((t) => (
                         <button
                           key={t.id}
                           onClick={() => router.push(`/mentor/tasks/${t.id}`)}
@@ -612,21 +614,21 @@ export default function MenteeDetail() {
       <div className="grid lg:grid-cols-2 gap-6">
         <div className="bg-card rounded-2xl border border-slate-200 p-6">
           <h3 className="text-slate-900 mb-4">Learning profile</h3>
-          {profile?.learningGoals?.length > 0 && (
+          {(profile?.learningGoals?.length ?? 0) > 0 && (
             <div className="mb-4">
               <div className="flex items-center gap-2 text-slate-600 text-sm mb-2"><Target className="w-4 h-4" />Goals</div>
               <div className="flex flex-wrap gap-2">
-                {profile.learningGoals.map((g: string, i: number) => (
+                {profile?.learningGoals?.map((g, i) => (
                   <span key={i} className="px-2 py-1 bg-brand-50 text-brand-700 rounded text-xs">{g}</span>
                 ))}
               </div>
             </div>
           )}
-          {profile?.interests?.length > 0 && (
+          {(profile?.interests?.length ?? 0) > 0 && (
             <div className="mb-4">
               <div className="flex items-center gap-2 text-slate-600 text-sm mb-2"><Star className="w-4 h-4" />Interests</div>
               <div className="flex flex-wrap gap-2">
-                {profile.interests.map((s: string, i: number) => (
+                {profile?.interests?.map((s, i) => (
                   <span key={i} className="px-2 py-1 bg-purple-50 text-purple-700 rounded text-xs">{s}</span>
                 ))}
               </div>

--- a/client-interface/app/mentor/reports/page.tsx
+++ b/client-interface/app/mentor/reports/page.tsx
@@ -7,7 +7,8 @@ import {
   FileText, Loader2, Copy, Check, AlertTriangle, Star, TrendingUp, TrendingDown,
   Minus, ClipboardCheck, Flag, ArrowUpRight, Activity, Gauge, Sparkles, Printer, RefreshCw,
 } from 'lucide-react';
-import { useMentorCohort, type CohortMentee } from '@/lib/hooks/mentor';
+import { useMentorCohort } from '@/lib/hooks/mentor';
+import type { CohortMentee } from '@/lib/types/cohort';
 import { mentorApi } from '@/lib/services/mentor-api';
 import { extractApiErrorMessage } from '@/lib/utils/api-error';
 import { useAuth } from '@/lib/context/AuthContext';

--- a/client-interface/app/mentor/review/page.tsx
+++ b/client-interface/app/mentor/review/page.tsx
@@ -9,7 +9,8 @@ import {
   Trash2, X, History, RotateCcw, CalendarDays, AlertTriangle, StickyNote, Search, Lock, Unlock,
 } from 'lucide-react';
 import Link from 'next/link';
-import { useMentorCohort, useMentorApprovals, type CohortMentee, type CohortMomentum, type CohortRisk, type ApprovalItem } from '@/lib/hooks/mentor';
+import { useMentorCohort, useMentorApprovals, type ApprovalItem } from '@/lib/hooks/mentor';
+import type { CohortMentee, CohortMomentum, CohortRisk } from '@/lib/types/cohort';
 import { useAuth } from '@/lib/context/AuthContext';
 import { useClan, ALL_CLANS } from '@/lib/context/ClanContext';
 import { mentorApi } from '@/lib/services/mentor-api';

--- a/client-interface/app/mentor/scores/page.tsx
+++ b/client-interface/app/mentor/scores/page.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Gauge, Loader2, TrendingUp, TrendingDown, Minus, ArrowUpRight, Search } from 'lucide-react';
-import { useMentorCohort, type CohortMentee, type CohortMomentum } from '@/lib/hooks/mentor';
+import { useMentorCohort } from '@/lib/hooks/mentor';
+import type { CohortMentee, CohortMomentum } from '@/lib/types/cohort';
 import { SelectMenu } from '@/components/shared/SelectMenu';
 import { usePagination } from '@/lib/hooks/shared/usePagination';
 import { TablePagination } from '@/components/shared/TablePagination';

--- a/client-interface/components/mentor/CollaboratorsCard.tsx
+++ b/client-interface/components/mentor/CollaboratorsCard.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { UserPlus, Loader2, Trash2, Stethoscope } from 'lucide-react';
-import type { ProfileCollaborator } from '@/lib/hooks/mentor';
+import type { ProfileCollaborator } from '@/lib/types/insights';
 
 /**
  * Collaborators - specialists invited to work with a mentee (psychologist,

--- a/client-interface/components/mentor/InsightsPanel.tsx
+++ b/client-interface/components/mentor/InsightsPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { Loader2, Plus, Lightbulb } from 'lucide-react';
-import type { ProfileInsight } from '@/lib/hooks/mentor';
+import type { ProfileInsight } from '@/lib/types/insights';
 
 const KINDS = ['general', 'personality', 'analytical', 'issue', 'strength'];
 const SOURCES = ['1:1', 'text', 'observation'];

--- a/client-interface/components/mentor/MenteeCard.tsx
+++ b/client-interface/components/mentor/MenteeCard.tsx
@@ -5,7 +5,7 @@ import {
 } from 'lucide-react';
 import { DualProgress } from '@/components/mentor/DualProgress';
 import { NudgeButton } from '@/components/mentor/NudgeButton';
-import type { CohortMentee, CohortRisk, CohortMomentum } from '@/lib/hooks/mentor';
+import type { CohortMentee, CohortRisk, CohortMomentum } from '@/lib/types/cohort';
 
 /**
  * The single, consistent mentee summary card. Used by the Cockpit, My Mentees

--- a/client-interface/components/mentor/PersonalityBars.tsx
+++ b/client-interface/components/mentor/PersonalityBars.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Loader2, Pencil, Check } from 'lucide-react';
-import type { Personality } from '@/lib/hooks/mentor';
+import type { Personality } from '@/lib/types/insights';
 
 const DIMS: { key: keyof Personality; label: string }[] = [
   { key: 'consistency', label: 'Consistency' },

--- a/client-interface/lib/context/QueryProvider.tsx
+++ b/client-interface/lib/context/QueryProvider.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider, QueryCache, MutationCache } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { toast } from 'sonner';
+import { extractApiErrorMessage } from '@/lib/utils/api-error';
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    // Global error handling, so individual hooks don't each reimplement toasting.
+    // Queries: only toast when cached data is already on screen and a background
+    // refetch failed (otherwise silent) — first-load errors are owned by the page's
+    // inline error state / ErrorBoundary (see throwOnError below), so no double report.
+    queryCache: new QueryCache({
+      onError: (error, query) => {
+        if (query.state.data !== undefined) toast.error(extractApiErrorMessage(error));
+      },
+    }),
+    // Mutations rarely have an inline error region, so always toast.
+    mutationCache: new MutationCache({
+      onError: (error) => toast.error(extractApiErrorMessage(error)),
+    }),
+    defaultOptions: {
+      queries: {
+        // Data is considered fresh for 2 min — no refetch on remount within this window.
+        staleTime: 2 * 60 * 1000,
+        // Keep unused/inactive cache entries for 5 min before garbage collection.
+        gcTime: 5 * 60 * 1000,
+        retry: 1,
+        // Bubble fresh-data errors to an error boundary; when cached data is still
+        // available, keep showing it and rely on the toast above instead.
+        throwOnError: (_error, query) => typeof query.state.data === 'undefined',
+      },
+    },
+  });
+}
+
+interface QueryProviderProps {
+  children: ReactNode;
+}
+
+export function QueryProvider({ children }: QueryProviderProps) {
+  // useState ensures a single QueryClient instance survives re-renders on the
+  // client, while each SSR pass gets its own (no cross-request cache sharing).
+  const [queryClient] = useState(makeQueryClient);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
+  );
+}

--- a/client-interface/lib/hooks/mentee/useMyProgress.ts
+++ b/client-interface/lib/hooks/mentee/useMyProgress.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { menteeApi } from '@/lib/services/mentee-api';
-import type { MenteeProfile } from '@/lib/hooks/mentor';
+import type { MenteeProfile } from '@/lib/types/insights';
 
 export interface UseMyProgressReturn {
   progress: MenteeProfile | null;

--- a/client-interface/lib/hooks/mentor/index.ts
+++ b/client-interface/lib/hooks/mentor/index.ts
@@ -3,25 +3,10 @@ export { useMentorDashboard } from './useMentorDashboard';
 export type { UseMentorDashboardReturn } from './useMentorDashboard';
 
 export { useMentorCohort } from './useMentorCohort';
-export type {
-  UseMentorCohortReturn,
-  CohortMentee,
-  CohortTotals,
-  CohortRisk,
-  CohortMomentum,
-} from './useMentorCohort';
+export type { UseMentorCohortReturn } from './useMentorCohort';
 
 export { useMenteeProfile } from './useMenteeProfile';
-export type {
-  UseMenteeProfileReturn,
-  MenteeProfile,
-  ProfileBlocker,
-  ProfileDelay,
-  Personality,
-  ProfileInsight,
-  MeetingNote,
-  ProfileCollaborator,
-} from './useMenteeProfile';
+export type { UseMenteeProfileReturn } from './useMenteeProfile';
 
 export { useMentorApprovals } from './useMentorApprovals';
 export type { UseMentorApprovalsReturn, ApprovalItem, BulkReviewPayload } from './useMentorApprovals';

--- a/client-interface/lib/hooks/mentor/useMenteeActivity.ts
+++ b/client-interface/lib/hooks/mentor/useMenteeActivity.ts
@@ -1,12 +1,9 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-import { activityApi } from '@/lib/services/activity-api';
-import type {
-  ActivitySummary,
-  DailySession,
-  RecentEvent,
-} from '@/lib/types/activity';
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { activityQueries } from '@/lib/queries/activity';
+import type { ActivitySummary, DailySession, RecentEvent } from '@/lib/types/activity';
 
 export interface UseMenteeActivityReturn {
   summary: ActivitySummary | null;
@@ -19,52 +16,19 @@ export interface UseMenteeActivityReturn {
 }
 
 export function useMenteeActivity(menteeId: string | null): UseMenteeActivityReturn {
-  const [summary, setSummary] = useState<ActivitySummary | null>(null);
-  const [dailySessions, setDailySessions] = useState<DailySession[]>([]);
-  const [recentEvents, setRecentEvents] = useState<RecentEvent[]>([]);
-  const [loading, setLoading] = useState(true);
   const [days, setDays] = useState(7);
+  
+  const query = useQuery(activityQueries.menteeSummary({ menteeId: menteeId ?? '', days }));
 
-  const fetch = useCallback(async () => {
-    if (!menteeId) return;
-    setLoading(true);
-    try {
-      // apiClient.get<T> returns response.data which is { success, message, data: MenteeActivityResponse }
-      const res = await activityApi.getMenteeSummary(menteeId, days) as unknown as { data: { summary: ActivitySummary; dailySessions: DailySession[]; recentEvents: RecentEvent[] } };
-      const payload = res?.data;
-      setSummary(payload?.summary ?? null);
-      setDailySessions(payload?.dailySessions ?? []);
-      setRecentEvents(payload?.recentEvents ?? []);
-    } catch {
-      // Non-fatal
-    } finally {
-      setLoading(false);
-    }
-  }, [menteeId, days]);
-
-  useEffect(() => {
-    fetch();
-  }, [fetch]);
-
-  // Auto-refresh every 5 min so the card stays live without a page reload
-  useEffect(() => {
-    const id = setInterval(fetch, 5 * 60 * 1000);
-    return () => clearInterval(id);
-  }, [fetch]);
-
-  // Refresh when mentor returns to the tab
-  useEffect(() => {
-    const onFocus = () => fetch();
-    const onVisible = () => {
-      if (document.visibilityState === 'visible') fetch();
-    };
-    window.addEventListener('focus', onFocus);
-    document.addEventListener('visibilitychange', onVisible);
-    return () => {
-      window.removeEventListener('focus', onFocus);
-      document.removeEventListener('visibilitychange', onVisible);
-    };
-  }, [fetch]);
-
-  return { summary, dailySessions, recentEvents, loading, days, setDays, refetch: fetch };
+  return {
+    summary: query.data?.summary ?? null,
+    dailySessions: query.data?.dailySessions ?? [],
+    recentEvents: query.data?.recentEvents ?? [],
+    loading: query.isPending,
+    days,
+    setDays,
+    refetch: () => {
+      query.refetch();
+    },
+  };
 }

--- a/client-interface/lib/hooks/mentor/useMenteeDetailPage.ts
+++ b/client-interface/lib/hooks/mentor/useMenteeDetailPage.ts
@@ -1,16 +1,20 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-import { matchingApi, enrollmentApi } from '@/lib/services/enrollment-api';
-import { taskApi } from '@/lib/services/task-api';
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { enrollmentApi } from '@/lib/services/enrollment-api';
 import { useAuth } from '@/lib/context/AuthContext';
 import { extractApiErrorMessage } from '@/lib/utils/api-error';
 import { toast } from 'sonner';
+import { matchQueries } from '@/lib/queries/matches';
+import { taskQueries } from '@/lib/queries/task';
+import { cohortQueries } from '@/lib/queries/cohort';
+import type { MenteeDetailMatch, CompletionResult } from '@/lib/types/matches';
+import type { MenteeTask } from '@/lib/types/task';
 
 export interface UseMenteeDetailPageReturn {
-  match: any | null;
-  tasks: any[];
+  match: MenteeDetailMatch | null;
+  tasks: MenteeTask[];
   loading: boolean;
   completionLoading: boolean;
   rejectReason: string;
@@ -26,110 +30,79 @@ export interface UseMenteeDetailPageReturn {
 
 export function useMenteeDetailPage(menteeId: string): UseMenteeDetailPageReturn {
   const { user } = useAuth();
+  const queryClient = useQueryClient();
 
-  const [match, setMatch] = useState<any>(null);
-  const [tasks, setTasks] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [completionLoading, setCompletionLoading] = useState(false);
+  const matchQuery = useQuery(matchQueries.menteeDetail({ mentorId: user?.id ?? '', menteeId }));
+  const tasksQuery = useQuery(taskQueries.byMentee(menteeId));
+
+  const match = matchQuery.data ?? null;
+  const enrollmentId = match?.enrollment?.id ?? null;
+
   const [rejectReason, setRejectReason] = useState('');
   const [showRejectModal, setShowRejectModal] = useState(false);
   const [showCompleteConfirm, setShowCompleteConfirm] = useState(false);
 
-  const fetchMenteeDetails = useCallback(async () => {
-    if (!user?.id || !menteeId) return;
-    try {
-      setLoading(true);
-      const response = await matchingApi.getMatches({
-        mentorId: user.id,
-        menteeId,
-        status: 'active',
-      });
-      const matches = response?.data?.matches || response?.matches || [];
-      if (matches.length > 0) {
-        setMatch(matches[0]);
-      } else {
-        // Clan-placed mentees have no MentorMenteeMatch - resolve them via their
-        // enrollment instead so the page works for the clan model.
-        const enrRes: any = await enrollmentApi.getAll({ menteeId });
-        const enrollments = enrRes?.data?.enrollments || enrRes?.data || [];
-        const active = enrollments.find((e: any) => !['rejected', 'dropped'].includes(e.status)) || enrollments[0];
-        if (active) {
-          setMatch({ mentee: active.mentee, enrollment: active });
-        }
-      }
-      // Mentee-centric: ALL of this mentee's tasks (whoever assigned them), so a
-      // co-mentor sees the same work as the lead — not just their own assignments.
-      const tasksRes = await taskApi.getMenteeTasks(menteeId);
-      setTasks(tasksRes?.data?.tasks || []);
-    } catch (error: any) {
-      console.error('Failed to fetch mentee details:', error);
-      toast.error('Failed to load mentee details');
-    } finally {
-      setLoading(false);
-    }
-  }, [user?.id, menteeId]);
+  // Completion changes status and can auto-promote → refresh this match + the
+  // cohort lists that 11 mentor pages read.
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: matchQueries.all() });
+    queryClient.invalidateQueries({ queryKey: cohortQueries.all() });
+  };
 
-  useEffect(() => {
-    if (user?.id && menteeId) {
-      fetchMenteeDetails();
-    }
-  }, [user?.id, menteeId, fetchMenteeDetails]);
-
-  const enrollment = match?.enrollment;
-
-  const handleApproveCompletion = useCallback(async () => {
-    if (!enrollment?.id) return;
-    try {
-      setCompletionLoading(true);
-      const res = await enrollmentApi.approveCompletion(enrollment.id);
-      const result = (res as any)?.data?.result;
+  const approveMutation = useMutation<{ data?: { result?: CompletionResult } }, Error, void>({
+    mutationFn: async () => {
+      if (!enrollmentId) throw new Error('No active enrollment');
+      const res: { data?: { result?: CompletionResult } } = await enrollmentApi.approveCompletion(enrollmentId);
+      return res;
+    },
+    onSuccess: (res) => {
+      const result = res.data?.result;
       if (result?.autoPromoted) {
-        toast.success(
-          `Level complete! Mentee advanced to "${result.nextLevelName}" - awaiting new mentor match.`
-        );
+        toast.success(`Level complete! Mentee advanced to "${result.nextLevelName}" - awaiting new mentor match.`);
       } else if (result?.hasNextLevel === false) {
         toast.success('Program completed! Well done.');
       } else {
         toast.success('Completion approved!');
       }
       setShowCompleteConfirm(false);
-      fetchMenteeDetails();
-    } catch (err: any) {
-      toast.error(extractApiErrorMessage(err, 'Failed to approve completion'));
-    } finally {
-      setCompletionLoading(false);
-    }
-  }, [enrollment?.id, fetchMenteeDetails]);
+      invalidate();
+    },
+    onError: (err) => toast.error(extractApiErrorMessage(err, 'Failed to approve completion')),
+  });
 
-  const handleRejectCompletion = useCallback(async () => {
-    if (!enrollment?.id) return;
-    try {
-      setCompletionLoading(true);
-      await enrollmentApi.rejectCompletion(enrollment.id, rejectReason);
+  const rejectMutation = useMutation<unknown, Error, void>({
+    mutationFn: async () => {
+      if (!enrollmentId) throw new Error('No active enrollment');
+      return enrollmentApi.rejectCompletion(enrollmentId, rejectReason);
+    },
+    onSuccess: () => {
       toast.success('Completion request rejected - mentee returned to active');
       setShowRejectModal(false);
       setRejectReason('');
-      fetchMenteeDetails();
-    } catch (err: any) {
-      toast.error(extractApiErrorMessage(err, 'Failed to reject completion'));
-    } finally {
-      setCompletionLoading(false);
-    }
-  }, [enrollment?.id, rejectReason, fetchMenteeDetails]);
+      invalidate();
+    },
+    onError: (err) => toast.error(extractApiErrorMessage(err, 'Failed to reject completion')),
+  });
 
   return {
     match,
-    tasks,
-    loading,
-    completionLoading,
+    tasks: tasksQuery.data ?? [],
+    loading: matchQuery.isPending || tasksQuery.isPending,
+    completionLoading: approveMutation.isPending || rejectMutation.isPending,
     rejectReason,
     showRejectModal,
     showCompleteConfirm,
     setRejectReason,
     setShowRejectModal,
     setShowCompleteConfirm,
-    handleApproveCompletion,
-    handleRejectCompletion,
-    fetchMenteeDetails,
+    handleApproveCompletion: async () => {
+      await approveMutation.mutateAsync().catch(() => {/* onError toasts */});
+    },
+    handleRejectCompletion: async () => {
+      await rejectMutation.mutateAsync().catch(() => {/* onError toasts */});
+    },
+    fetchMenteeDetails: async () => {
+      await Promise.all([matchQuery.refetch(), tasksQuery.refetch()]);
+    },
   };
 }

--- a/client-interface/lib/hooks/mentor/useMenteeProfile.ts
+++ b/client-interface/lib/hooks/mentor/useMenteeProfile.ts
@@ -1,85 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
-import { mentorApi } from '@/lib/services/mentor-api';
-import type { CohortMentee } from './useMentorCohort';
-
-export interface ProfileBlocker {
-  id: string;
-  title: string;
-  category: string;
-  severity: 'low' | 'medium' | 'high';
-  status: 'open' | 'resolved';
-  daysOpen: number;
-  taskTitle: string | null;
-}
-
-export interface ProfileDelay {
-  id: string;
-  reason: string;
-  kind: string;
-  days: number;
-  accepted: boolean;
-  category: 'external' | 'scope' | 'avoidance';
-  aiRationale: string | null;
-  occurredAt: string;
-}
-
-export interface Personality {
-  consistency: number | null;
-  communication: number | null;
-  resilience: number | null;
-  independence: number | null;
-  /** Free-text "how they think/work" read, captured in 1:1s. */
-  read?: string | null;
-}
-
-export interface ProfileInsight {
-  id: string;
-  kind: 'personality' | 'analytical' | 'issue' | 'strength' | 'general';
-  note: string;
-  source: '1:1' | 'text' | 'observation' | null;
-  at: string;
-  by: string | null;
-}
-
-export interface MeetingNote {
-  id: string;
-  date: string;
-  kind: string;
-  summary: string;
-  sentiment: 'positive' | 'neutral' | 'low';
-  issues: string[];
-  nextSteps: string[];
-  by: string | null;
-}
-
-export interface ProfileCollaborator {
-  id: string;
-  name: string;
-  role: string;
-  email: string | null;
-  status: 'invited' | 'active';
-}
-
-export interface MenteeProfile extends CohortMentee {
-  aiSummary: string;
-  aiSignals: string[];
-  blockers: ProfileBlocker[];
-  delays: ProfileDelay[];
-  personality: Personality | null;
-  insights: ProfileInsight[];
-  notes: MeetingNote[];
-  collaborators: ProfileCollaborator[];
-  dailyLogs: { dateKey: string; tasksDone: number; note: string | null; loggedAt: string }[];
-  tasksByStatus: Record<string, Array<{
-    id: string;
-    title: string;
-    type: string | null;
-    status: string;
-    dueDate: string | null;
-    isLate: boolean;
-    finalRating: number | null;
-  }>>;
-}
+import { useQuery } from '@tanstack/react-query';
+import { insightsQueries } from '@/lib/queries/insights';
+import type { MenteeProfile } from '@/lib/types/insights';
 
 export interface UseMenteeProfileReturn {
   profile: MenteeProfile | null;
@@ -89,28 +10,13 @@ export interface UseMenteeProfileReturn {
 }
 
 export function useMenteeProfile(menteeId: string): UseMenteeProfileReturn {
-  const [profile, setProfile] = useState<MenteeProfile | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchProfile = useCallback(async () => {
-    if (!menteeId) return;
-    try {
-      setLoading(true);
-      setError(null);
-      const res = await mentorApi.getMenteeProfile(menteeId);
-      setProfile(res?.data?.profile ?? null);
-    } catch (err) {
-      setError('Failed to load mentee insights');
-      setProfile(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [menteeId]);
-
-  useEffect(() => {
-    fetchProfile();
-  }, [fetchProfile]);
-
-  return { profile, loading, error, refetch: fetchProfile };
+  const query = useQuery(insightsQueries.byMentee(menteeId));
+  return {
+    profile: query.data ?? null,
+    loading: query.isPending,
+    error: query.isError ? 'Failed to load mentee insights' : null,
+    refetch: async () => {
+      await query.refetch();
+    },
+  };
 }

--- a/client-interface/lib/hooks/mentor/useMentorCohort.ts
+++ b/client-interface/lib/hooks/mentor/useMentorCohort.ts
@@ -1,43 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { mentorApi } from '@/lib/services/mentor-api';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useClan, ALL_CLANS } from '@/lib/context/ClanContext';
-
-export type CohortMomentum = 'up' | 'flat' | 'down';
-export type CohortRisk = 'low' | 'watch' | 'high';
-
-export interface CohortMentee {
-  id: string;
-  name: string;
-  avatar: string;
-  email: string;
-  profilePictureUrl: string | null;
-  program: string;
-  level: string;
-  week: number;
-  totalWeeks: number;
-  absoluteProgress: number;
-  relativeProgress: number;
-  onTimeRate: number;
-  pendingApprovals: number;
-  openBlockers: number;
-  momentum: CohortMomentum;
-  risk: CohortRisk;
-  riskReason: string | null;
-  /** Concrete rule-based "why" chips, e.g. "No activity in 6 days". */
-  signals?: string[];
-  avgRating: number;
-  lastActive: string;
-  sentiment: string;
-  clan?: { id: string; name: string } | null;
-}
-
-export interface CohortTotals {
-  mentees: number;
-  pendingApprovals: number;
-  openBlockers: number;
-  atRisk: number;
-  onTimeRate: number;
-}
+import { cohortQueries } from '@/lib/queries/cohort';
+import type { CohortMentee, CohortTotals } from '@/lib/types/cohort';
 
 export interface UseMentorCohortReturn {
   cohort: CohortMentee[];
@@ -48,31 +13,13 @@ export interface UseMentorCohortReturn {
 }
 
 export function useMentorCohort(): UseMentorCohortReturn {
-  const [allCohort, setAllCohort] = useState<CohortMentee[]>([]);
-  const [rawTotals, setRawTotals] = useState<CohortTotals | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const { activeClanId } = useClan();
+  const query = useQuery(cohortQueries.mine());
 
-  const fetchCohort = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const res = await mentorApi.getCohort();
-      setAllCohort(res?.data?.cohort ?? []);
-      setRawTotals(res?.data?.totals ?? null);
-    } catch (err) {
-      setError('Failed to load your cohort');
-      setAllCohort([]);
-      setRawTotals(null);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchCohort();
-  }, [fetchCohort]);
+  // useMemo so the `?? []` default doesn't produce a new array ref each render
+  // (which would churn the dependent useMemos below).
+  const allCohort = useMemo(() => query.data?.cohort ?? [], [query.data?.cohort]);
+  const rawTotals = query.data?.totals ?? null;
 
   // Scope to the active clan (multi-clan mentors). 'all' = the merged view.
   const cohort = useMemo(
@@ -94,5 +41,13 @@ export function useMentorCohort(): UseMentorCohortReturn {
     };
   }, [cohort, allCohort, activeClanId, rawTotals]);
 
-  return { cohort, totals, loading, error, refetch: fetchCohort };
+  return {
+    cohort,
+    totals,
+    loading: query.isPending,
+    error: query.isError ? 'Failed to load your cohort' : null,
+    refetch: async () => {
+      await query.refetch();
+    },
+  };
 }

--- a/client-interface/lib/queries/activity.ts
+++ b/client-interface/lib/queries/activity.ts
@@ -1,0 +1,29 @@
+import { queryOptions } from '@tanstack/react-query';
+import { activityApi } from '@/lib/services/activity-api';
+import type { ActivitySummary, DailySession, RecentEvent } from '@/lib/types/activity';
+
+export interface MenteeActivityData {
+  summary: ActivitySummary | null;
+  dailySessions: DailySession[];
+  recentEvents: RecentEvent[];
+}
+
+export const activityQueries = {
+  all: () => ['activity'] as const,
+  menteeSummary: ({ menteeId, days }: { menteeId: string; days: number }) =>
+    queryOptions({
+      queryKey: [...activityQueries.all(), 'mentee', menteeId, { days }] as const,
+      queryFn: async (): Promise<MenteeActivityData> => {
+        const res = await activityApi.getMenteeSummary(menteeId, days);
+        return {
+          summary: res?.data?.summary ?? null,
+          dailySessions: res?.data?.dailySessions ?? [],
+          recentEvents: res?.data?.recentEvents ?? [],
+        };
+      },
+      enabled: !!menteeId,
+      refetchInterval: 5 * 60 * 1000,
+      refetchOnWindowFocus: true,
+      throwOnError: false,
+    }),
+};

--- a/client-interface/lib/queries/cohort.ts
+++ b/client-interface/lib/queries/cohort.ts
@@ -1,0 +1,31 @@
+import { queryOptions } from '@tanstack/react-query';
+import { mentorApi } from '@/lib/services/mentor-api';
+import type { CohortMentee, CohortTotals } from '@/lib/types/cohort';
+
+export interface MentorCohortData {
+  cohort: CohortMentee[];
+  totals: CohortTotals | null;
+}
+
+/**
+ * Query factory for the mentor's cohort (GET /mentor/cohort). Cached under
+ * ['cohort','mine'] so the ~11 mentor pages that read it share one fetch.
+ */
+export const cohortQueries = {
+  all: () => ['cohort'] as const,
+  mine: () =>
+    queryOptions({
+      queryKey: [...cohortQueries.all(), 'mine'] as const,
+      queryFn: async (): Promise<MentorCohortData> => {
+        const res = await mentorApi.getCohort();
+        return {
+          cohort: res?.data?.cohort ?? [],
+          totals: res?.data?.totals ?? null,
+        };
+      },
+      // This data drives inline error UIs (the page renders an `error` + retry),
+      // not an ErrorBoundary — so override the global throwOnError default and
+      // let consumers read `isError` instead of the query throwing.
+      throwOnError: false,
+    }),
+};

--- a/client-interface/lib/queries/insights.ts
+++ b/client-interface/lib/queries/insights.ts
@@ -1,0 +1,19 @@
+import { queryOptions } from '@tanstack/react-query';
+import { mentorApi } from '@/lib/services/mentor-api';
+import type { MenteeProfile } from '@/lib/types/insights';
+
+/** Query factory for a mentee's AI-enriched profile (mentorApi.getMenteeProfile). */
+export const insightsQueries = {
+  all: () => ['insights'] as const,
+  byMentee: (menteeId: string) =>
+    queryOptions({
+      queryKey: [...insightsQueries.all(), 'mentee', menteeId] as const,
+      queryFn: async (): Promise<MenteeProfile | null> => {
+        const res: { data?: { profile?: MenteeProfile | null } } =
+          await mentorApi.getMenteeProfile(menteeId);
+        return res?.data?.profile ?? null;
+      },
+      enabled: !!menteeId,
+      throwOnError: false,
+    }),
+};

--- a/client-interface/lib/queries/matches.ts
+++ b/client-interface/lib/queries/matches.ts
@@ -1,0 +1,34 @@
+import { queryOptions } from '@tanstack/react-query';
+import { matchingApi, enrollmentApi } from '@/lib/services/enrollment-api';
+import type { MentorMenteeMatch, MenteeDetailMatch, EnrollmentWithMentee } from '@/lib/types/matches';
+
+/**
+ * Query factory for mentor↔mentee matches. Keyed under ['matches', …] so the
+ * detail query is cached per (mentor, mentee)
+ */
+export const matchQueries = {
+  all: () => ['matches'] as const,
+  menteeDetail: ({ mentorId, menteeId }: { mentorId: string; menteeId: string }) =>
+    queryOptions({
+      queryKey: [...matchQueries.all(), 'mentor', mentorId, 'mentee', menteeId] as const,
+      queryFn: async (): Promise<MenteeDetailMatch | null> => {
+        const res: { data?: { matches?: MentorMenteeMatch[] } } =
+          await matchingApi.getMatches({ mentorId, menteeId, status: 'active' });
+        const matches = res?.data?.matches ?? [];
+        if (matches.length > 0) return matches[0];
+
+        // Clan-placed mentees have no MentorMenteeMatch — resolve them via their
+        // enrollment instead so the page works for the clan model.
+        const enrRes: { data?: { enrollments?: EnrollmentWithMentee[] } } =
+          await enrollmentApi.getAll({ menteeId });
+        const enrollments = enrRes?.data?.enrollments ?? [];
+        const active =
+          enrollments.find((e) => !['rejected', 'dropped'].includes(e.status)) ?? enrollments[0];
+        if (active) return { mentee: active.mentee, enrollment: active };
+        return null;
+      },
+      enabled: !!mentorId && !!menteeId,
+      // Page renders inline "Mentee not found" / loading, not an ErrorBoundary.
+      throwOnError: false,
+    }),
+};

--- a/client-interface/lib/queries/task.ts
+++ b/client-interface/lib/queries/task.ts
@@ -1,0 +1,18 @@
+import { queryOptions } from '@tanstack/react-query';
+import { taskApi } from '@/lib/services/task-api';
+import type { MenteeTask } from '@/lib/types/task';
+
+/** Query factory for a mentee's assigned tasks (taskApi.getMenteeTasks). */
+export const taskQueries = {
+  all: () => ['task'] as const,
+  byMentee: (menteeId: string) =>
+    queryOptions({
+      queryKey: [...taskQueries.all(), 'mentee', menteeId] as const,
+      queryFn: async (): Promise<MenteeTask[]> => {
+        const res: { data?: { tasks?: MenteeTask[] } } = await taskApi.getMenteeTasks(menteeId);
+        return res?.data?.tasks ?? [];
+      },
+      enabled: !!menteeId,
+      throwOnError: false,
+    }),
+};

--- a/client-interface/lib/services/activity-api.ts
+++ b/client-interface/lib/services/activity-api.ts
@@ -38,7 +38,9 @@ export const activityApi = {
     apiClient.get<MyActivityResponse>('/activity/me/summary', { params: { days } }),
 
   getMenteeSummary: (menteeId: string, days = 7) =>
-    apiClient.get<MenteeActivityResponse>(`/activity/mentee/${menteeId}/summary`, {
+    // Body is the standard envelope { data: MenteeActivityResponse } — the old
+    // generic omitted the `data` wrapper, which forced an `as unknown as` cast.
+    apiClient.get<{ data: MenteeActivityResponse }>(`/activity/mentee/${menteeId}/summary`, {
       params: { days },
     }),
 

--- a/client-interface/lib/services/mentor-api.ts
+++ b/client-interface/lib/services/mentor-api.ts
@@ -1,5 +1,6 @@
 import {apiClient} from './api-client';
 import { apiConfig } from '@/lib/config/api';
+import type { CohortMentee, CohortTotals } from '@/lib/types/cohort';
 
 export const mentorApi = {
   // Get all active mentors
@@ -9,7 +10,8 @@ export const mentorApi = {
   },
 
   // The logged-in mentor's cohort for the Cockpit (computed fairness signals).
-  getCohort: () => apiClient.get('/mentor/cohort'),
+  getCohort: () =>
+    apiClient.get<{ data?: { cohort?: CohortMentee[]; totals?: CohortTotals | null } }>('/mentor/cohort'),
 
   // Period-scoped cohort throughput (week / month window).
   getCohortActivity: (period: 'week' | 'month') =>

--- a/client-interface/lib/types/cohort.ts
+++ b/client-interface/lib/types/cohort.ts
@@ -1,0 +1,39 @@
+// Mentor cohort (Cockpit) — the mentor's mentees enriched with computed
+// fairness/progress signals. Served by GET /mentor/cohort.
+
+export type CohortMomentum = 'up' | 'flat' | 'down';
+export type CohortRisk = 'low' | 'watch' | 'high';
+
+export interface CohortMentee {
+  id: string;
+  name: string;
+  avatar: string;
+  email: string;
+  profilePictureUrl: string | null;
+  program: string;
+  level: string;
+  week: number;
+  totalWeeks: number;
+  absoluteProgress: number;
+  relativeProgress: number;
+  onTimeRate: number;
+  pendingApprovals: number;
+  openBlockers: number;
+  momentum: CohortMomentum;
+  risk: CohortRisk;
+  riskReason: string | null;
+  /** Concrete rule-based "why" chips, e.g. "No activity in 6 days". */
+  signals?: string[];
+  avgRating: number;
+  lastActive: string;
+  sentiment: string;
+  clan?: { id: string; name: string } | null;
+}
+
+export interface CohortTotals {
+  mentees: number;
+  pendingApprovals: number;
+  openBlockers: number;
+  atRisk: number;
+  onTimeRate: number;
+}

--- a/client-interface/lib/types/index.ts
+++ b/client-interface/lib/types/index.ts
@@ -6,3 +6,6 @@ export * from './task';
 export * from './enrollment';
 export * from './common';
 export * from './activity';
+export * from './cohort';
+export * from './matches';
+export * from './insights';

--- a/client-interface/lib/types/insights.ts
+++ b/client-interface/lib/types/insights.ts
@@ -1,0 +1,82 @@
+// Mentee insights / profile — the AI-enriched profile a mentor sees, served by
+// mentorApi.getMenteeProfile. Extends the cohort mentee with deeper signals.
+import type { CohortMentee } from './cohort';
+
+export interface ProfileBlocker {
+  id: string;
+  title: string;
+  category: string;
+  severity: 'low' | 'medium' | 'high';
+  status: 'open' | 'resolved';
+  daysOpen: number;
+  taskTitle: string | null;
+}
+
+export interface ProfileDelay {
+  id: string;
+  reason: string;
+  kind: string;
+  days: number;
+  accepted: boolean;
+  category: 'external' | 'scope' | 'avoidance';
+  aiRationale: string | null;
+  occurredAt: string;
+}
+
+export interface Personality {
+  consistency: number | null;
+  communication: number | null;
+  resilience: number | null;
+  independence: number | null;
+  /** Free-text "how they think/work" read, captured in 1:1s. */
+  read?: string | null;
+}
+
+export interface ProfileInsight {
+  id: string;
+  kind: 'personality' | 'analytical' | 'issue' | 'strength' | 'general';
+  note: string;
+  source: '1:1' | 'text' | 'observation' | null;
+  at: string;
+  by: string | null;
+}
+
+export interface MeetingNote {
+  id: string;
+  date: string;
+  kind: string;
+  summary: string;
+  sentiment: 'positive' | 'neutral' | 'low';
+  issues: string[];
+  nextSteps: string[];
+  by: string | null;
+}
+
+export interface ProfileCollaborator {
+  id: string;
+  name: string;
+  role: string;
+  email: string | null;
+  status: 'invited' | 'active';
+}
+
+export interface MenteeProfile extends CohortMentee {
+  aiSummary: string;
+  aiSignals: string[];
+  blockers: ProfileBlocker[];
+  delays: ProfileDelay[];
+  personality: Personality | null;
+  insights: ProfileInsight[];
+  notes: MeetingNote[];
+  collaborators: ProfileCollaborator[];
+  dailyLogs: { dateKey: string; tasksDone: number; note: string | null; loggedAt: string }[];
+  tasksByStatus: Record<string, Array<{
+    id: string;
+    title: string;
+    type: string | null;
+    status: string;
+    dueDate: string | null;
+    isLate: boolean;
+    finalRating: number | null;
+  }>>;
+}

--- a/client-interface/lib/types/matches.ts
+++ b/client-interface/lib/types/matches.ts
@@ -1,0 +1,59 @@
+// Mentor↔mentee match (and the enrollment-fallback) consumed by the mentee
+// detail page. Served by GET /matches (matchingApi.getMatches).
+
+export type MatchStatus = 'pending' | 'active' | 'completed' | 'cancelled';
+
+/** Intake-profile fields on a mentee user (subset the detail page reads). */
+export interface MenteeIntakeProfile {
+  learningGoals?: string[];
+  interests?: string[];
+  priorExperience?: string | null;
+}
+
+export interface MatchUser {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  menteeProfile?: MenteeIntakeProfile | null;
+}
+
+/** Enrollment as nested in a match — includes the extra fields the page reads. */
+export interface MatchEnrollment {
+  id: string;
+  status: string;
+  currentWeek: number | null;
+  // DECIMAL(5,2) → serialized as a string; the page parseFloat()s it.
+  overallProgressPercentage: string | null;
+  completionRequestedByRole: string | null;
+  program?: { id: string; name: string } | null;
+}
+
+/** An enrollment row that carries its mentee (the clan-placed fallback path). */
+export type EnrollmentWithMentee = MatchEnrollment & { mentee: MatchUser };
+
+export interface MentorMenteeMatch {
+  id: string;
+  mentorId: string;
+  menteeId: string;
+  enrollmentId: string;
+  status: MatchStatus;
+  matchedAt: string | null;
+  mentor?: MatchUser | null;
+  mentee: MatchUser;
+  enrollment: MatchEnrollment | null;
+}
+
+/** What the mentee-detail query actually exposes (page reads only these two). */
+export interface MenteeDetailMatch {
+  mentee: MatchUser;
+  enrollment: MatchEnrollment | null;
+}
+
+/** Result of approve completion — union of the service's return shapes. */
+export interface CompletionResult {
+  autoPromoted?: boolean;
+  nextLevelName?: string;
+  hasNextLevel?: boolean;
+  programCompleted?: boolean;
+}

--- a/client-interface/lib/types/task.ts
+++ b/client-interface/lib/types/task.ts
@@ -1,5 +1,39 @@
 import { TaskType, TaskDifficulty } from './roadmap';
 
+// A mentee's assigned task as returned by taskApi.getMenteeTasks (AssignedTask
+// with its roadmapTask join) — the subset the mentee detail page consumes.
+export interface MenteeTask {
+  id: string;
+  title: string | null;
+  status: string;
+  dueDate?: string | null;
+  isLate?: boolean;
+  finalRating?: number | null;
+  points?: number | null;
+  pointsBase?: number | null;
+  isCustomTask?: boolean;
+  roadmapName?: string | null;
+  roadmapTask?: {
+    title?: string | null;
+    pointsBase?: number | null;
+    roadmap?: { id: string; name: string } | null;
+  } | null;
+}
+
+// Flattened row rendered in the mentee detail "Work history" list. Compatible
+// with both MenteeProfile.tasksByStatus items and the raw-task fallback mapping.
+export interface WorkHistoryItem {
+  id: string;
+  title: string;
+  status?: string;
+  source?: string;
+  points?: number | null;
+  isLate?: boolean;
+  finalRating?: number | null;
+  type?: string | null;
+  dueDate?: string | null;
+}
+
 // Task Instance Types (Assigned to Mentees)
 export interface Task {
   id: string;

--- a/client-interface/package-lock.json
+++ b/client-interface/package-lock.json
@@ -34,6 +34,8 @@
         "@radix-ui/react-toggle": "^1.1.2",
         "@radix-ui/react-toggle-group": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.8",
+        "@tanstack/react-query": "^5.101.0",
+        "@tanstack/react-query-devtools": "^5.101.0",
         "@tiptap/extension-link": "^3.17.1",
         "@tiptap/extension-placeholder": "^3.17.1",
         "@tiptap/react": "^3.17.1",
@@ -3229,6 +3231,59 @@
         "@tailwindcss/oxide": "4.1.17",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.17"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.101.0.tgz",
+      "integrity": "sha512-MVqw17k08RQtGGLEL654+dX/btbX9p/8WjkznO//zusLTMaObxi3Q+MoFwGVkC9K3tqjn8qrrNhJevXx4fJTeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.101.0.tgz",
+      "integrity": "sha512-cpZA0+WqKXwrwMfiWZEGGF6QrIWVQFbhBtxqDF5sQsAfrFf47HIE6fiPbQU3wyAUEN2+7UNqLCQe7oG6m3f93w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.101.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tiptap/core": {

--- a/client-interface/package.json
+++ b/client-interface/package.json
@@ -35,6 +35,8 @@
     "@radix-ui/react-toggle": "^1.1.2",
     "@radix-ui/react-toggle-group": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query-devtools": "^5.101.0",
     "@tiptap/extension-link": "^3.17.1",
     "@tiptap/extension-placeholder": "^3.17.1",
     "@tiptap/react": "^3.17.1",

--- a/docs/REACT_QUERY.md
+++ b/docs/REACT_QUERY.md
@@ -1,0 +1,706 @@
+# React Query Architecture Guide
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Core Principles](#core-principles)
+3. [Project Structure](#project-structure)
+4. [Query Factories Pattern](#query-factories-pattern)
+5. [Implementation Examples](#implementation-examples)
+6. [Best Practices](#best-practices)
+7. [Migration Strategy](#migration-strategy)
+8. [Common Patterns](#common-patterns)
+9. [Troubleshooting](#troubleshooting)
+
+## Overview
+
+This architecture is based on the **Query Factories** pattern recommended by the TkDODO (maintainer of react query), which keeps `queryKey` and `queryFn` together while providing type safety and reusability.
+
+### Why Query Factories?
+
+- **Maintains inseparable relationship** between `queryKey` and `queryFn`
+- **Reduces abstraction layers** that could make code harder to follow
+- **Provides type safety** with TypeScript
+- **Enables reusability** across different contexts (hooks, prefetching, SSR)
+- **Supports composition** for hierarchical key structures
+
+## Core Principles
+
+### 1. **QueryKey + QueryFn Together**
+
+Always keep query keys and query functions in the same place.They are an inseparable pair since the queryKey defines the dependencies needed inside the queryFn. 
+
+### 2. **Entity-Based Organization**
+
+Create one query factory per **entity/domain** (mirroring `lib/services/<entity>-api.ts`), with all queryKeys starting with the same prefix. Group factories by entity, **not** by role — the same entity is read by admin/mentor/mentee and should share a single cache namespace.
+
+### 3. **Hierarchical Key Structure**
+
+Use arrays with consistent structure for easy invalidation and composition.
+
+### 4. **Type Safety First**
+
+Use `queryOptions` for better TypeScript inference and autocomplete.
+
+### 5. **Global Configuration**
+
+Set sensible defaults in QueryClient while allowing per-query customization.
+
+## Project Structure
+
+This guide is adapted to Pathment's existing **layer-then-role** layout in `client-interface/`, not a generic `src/features/` tree. Most pieces already exist — the only genuinely new layer is the **Query Factories** in `lib/queries/`.
+
+```
+client-interface/
+├── lib/
+│   ├── context/
+│   │   └── QueryProvider.tsx     # QueryClientProvider + client config — DONE
+│   ├── config/
+│   │   └── api.ts                # apiConfig: base URL + endpoints (existing)
+│   ├── services/                 # axios API functions, one file per entity (existing, ~38)
+│   │   ├── roadmap-api.ts
+│   │   ├── mentee-api.ts
+│   │   └── ...
+│   ├── queries/                  # NEW — Query Factories, one file per entity
+│   │   ├── roadmap.ts            #   roadmapQueries  (pairs with roadmap-api.ts)
+│   │   ├── mentee.ts
+│   │   └── ...
+│   ├── hooks/                    # custom hooks, grouped by ROLE (existing, ~64)
+│   │   ├── admin/                #   e.g. useDashboard, useMentorsList
+│   │   ├── mentor/
+│   │   ├── mentee/               #   e.g. useMyRoadmaps → useQuery(roadmapQueries…)
+│   │   ├── shared/
+│   │   └── community/
+│   └── types/                    # shared TS types (existing)
+└── app/                          # Next.js App Router; layout.tsx mounts QueryProvider — DONE
+```
+
+**Two axes to keep straight:**
+
+- **Services & query factories are grouped by _entity_** (`roadmap`, `mentee`, `program`…) — one cache namespace per entity.
+- **Hooks are grouped by _role_** (`admin/`, `mentor/`, `mentee/`) — a role hook imports the entity factory and calls `useQuery(...)`.
+
+> **Reading the examples below:** the generic `todos` examples illustrate the pattern. In this repo, read `todos` as a real entity — e.g. `roadmap`:
+> - `features/todos/api/todos.ts` → `lib/services/roadmap-api.ts` (already exists)
+> - `features/todos/queries.ts` → `lib/queries/roadmap.ts` (new)
+> - `features/todos/hooks/use-todos.ts` → `lib/hooks/<role>/useMyRoadmaps.ts` (already exists)
+
+## Query Factories Pattern
+
+### Basic Structure
+
+```typescript
+// features/todos/queries.ts
+import { queryOptions } from "@tanstack/react-query";
+import { fetchTodos, fetchTodo, fetchTodosByUser } from "./api/todos";
+
+export const todoQueries = {
+  // Key-only factories for invalidation
+  all: () => ["todos"] as const,
+  allLists: () => [...todoQueries.all(), "list"] as const,
+  allDetails: () => [...todoQueries.all(), "detail"] as const,
+  allByUser: (userId: number) =>
+    [...todoQueries.all(), "user", userId] as const,
+
+  // Complete query factories with queryOptions
+  list: (sort?: string) =>
+    queryOptions({
+      queryKey: [...todoQueries.allLists(), { sort }] as const,
+      queryFn: () => fetchTodos(sort),
+      staleTime: 5 * 60 * 1000,
+    }),
+
+  detail: (id: number) =>
+    queryOptions({
+      queryKey: [...todoQueries.allDetails(), id] as const,
+      queryFn: () => fetchTodo(id),
+      staleTime: 5 * 60 * 1000,
+      enabled: !!id,
+    }),
+
+  byUser: (userId: number, sort?: string) =>
+    queryOptions({
+      queryKey: [...todoQueries.allByUser(userId), { sort }] as const,
+      queryFn: () => fetchTodosByUser(userId, sort),
+      staleTime: 5 * 60 * 1000,
+      enabled: !!userId,
+    }),
+} as const;
+```
+
+### Key-Only vs Complete Factories
+
+**Key-Only Factories** (for invalidation):
+
+```typescript
+all: () => ['todos'] as const,
+allLists: () => [...todoQueries.all(), 'list'] as const,
+```
+
+**Complete Factories** (for useQuery):
+
+```typescript
+list: (sort?: string) => queryOptions({
+  queryKey: [...todoQueries.allLists(), { sort }] as const,
+  queryFn: () => fetchTodos(sort),
+  staleTime: 5 * 60 * 1000,
+}),
+```
+
+## Implementation Examples
+
+### 1. QueryClient Setup — already configured ✅
+
+The `QueryClient` and its global defaults already live in [`lib/context/QueryProvider.tsx`](../client-interface/lib/context/QueryProvider.tsx) (`makeQueryClient()`), mounted at the app root in `app/layout.tsx`. **Do not** add a separate `lib/query-client.ts` — tune the defaults (`staleTime`, `gcTime`, `retry`) in the existing provider, and put per-query overrides in the factories.
+
+**Centralize error handling here, not in every hook**, reusing the app's existing `sonner` + `extractApiErrorMessage`. The split matters so toasts don't double up with pages' own error states:
+
+- **Mutations** rarely have an inline error region → **always toast**.
+- **Queries** → toast **only when cached data is already on screen** (a background refetch failed, otherwise silent). First-load errors (`data === undefined`) are owned by the page's inline error state / ErrorBoundary via `throwOnError`, so toasting them too would double-report.
+
+```typescript
+// inside makeQueryClient() in lib/context/QueryProvider.tsx
+import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { extractApiErrorMessage } from "@/lib/utils/api-error";
+
+new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error, query) => {
+      // Only background-refetch failures (data already on screen); first-load
+      // errors are handled by the page / ErrorBoundary.
+      if (query.state.data !== undefined) toast.error(extractApiErrorMessage(error));
+    },
+  }),
+  mutationCache: new MutationCache({
+    onError: (error) => toast.error(extractApiErrorMessage(error)),
+  }),
+  defaultOptions: {
+    queries: {
+      staleTime: 2 * 60 * 1000,
+      gcTime: 5 * 60 * 1000,
+      retry: 1,
+      // First-load errors (no cached data) bubble to an ErrorBoundary; when cached
+      // data exists, keep showing it and rely on the query toast above instead.
+      throwOnError: (_error, query) => typeof query.state.data === "undefined",
+    },
+  },
+});
+```
+
+### 2. Custom Hooks
+
+**Yes — keep custom hooks.** They're the consumption seam: components import hooks, never `useQuery` directly. A hook is just `useQuery(entityQueries.x())`, and during migration each existing hook keeps its **public return shape** while its internals switch to React Query — so components don't change. Factories hold the query (key + fn); hooks are where components plug in.
+
+```typescript
+// lib/hooks/<role>/use-todos.ts  (role-grouped hook consuming an entity factory)
+import { useQuery } from "@tanstack/react-query";
+import { todoQueries } from "@/lib/queries/todos";
+
+// Hooks take a SINGLE OBJECT argument — order-independent and type-safe.
+export function useTodos({ sort }: { sort?: string } = {}) {
+  return useQuery(todoQueries.list(sort));
+}
+
+export function useTodo({ id }: { id: number }) {
+  return useQuery(todoQueries.detail(id));
+}
+
+export function useTodosByUser({ userId, sort }: { userId: number; sort?: string }) {
+  return useQuery(todoQueries.byUser(userId, sort));
+}
+
+// Composing extra options on top of a factory
+export function useTodosWithPolling({ sort }: { sort?: string } = {}) {
+  return useQuery({
+    ...todoQueries.list(sort),
+    refetchInterval: 10 * 1000,
+  });
+}
+```
+
+### 3. Mutations
+
+```typescript
+// features/todos/hooks/use-todo-mutations.ts
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { todoQueries } from "../queries";
+import { createTodo, updateTodo, deleteTodo } from "../api/todos";
+
+export function useCreateTodo() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createTodo,
+    onSuccess: () => {
+      // Invalidate using key-only factories
+      queryClient.invalidateQueries({
+        queryKey: todoQueries.allLists(),
+      });
+    },
+  });
+}
+
+export function useUpdateTodo() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateTodo,
+    onSuccess: (data) => {
+      // Invalidate lists
+      queryClient.invalidateQueries({
+        queryKey: todoQueries.allLists(),
+      });
+      // Update specific item in cache
+      queryClient.setQueryData(todoQueries.detail(data.id).queryKey, data);
+    },
+  });
+}
+
+export function useDeleteTodo() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteTodo,
+    onSuccess: (_, deletedId) => {
+      // Remove from cache
+      queryClient.removeQueries({
+        queryKey: todoQueries.detail(deletedId).queryKey,
+      });
+      // Invalidate lists
+      queryClient.invalidateQueries({
+        queryKey: todoQueries.allLists(),
+      });
+    },
+  });
+}
+```
+
+### 4. Error Handling
+
+```typescript
+// components/error-boundary.tsx
+import { ErrorBoundary } from "react-error-boundary";
+
+function ErrorFallback({ error, resetErrorBoundary }: any) {
+  return (
+    <div role="alert">
+      <h2>Something went wrong:</h2>
+      <pre>{error.message}</pre>
+      <button onClick={resetErrorBoundary}>Try again</button>
+    </div>
+  );
+}
+
+export function AppErrorBoundary({ children }: { children: React.ReactNode }) {
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback}>{children}</ErrorBoundary>
+  );
+}
+```
+
+### 5. Component Usage
+
+```typescript
+// components/TodoList.tsx
+import { useQueryClient } from "@tanstack/react-query";
+import { useTodos } from "@/lib/hooks/<role>/use-todos";
+import { useCreateTodo } from "@/lib/hooks/<role>/use-todo-mutations";
+import { todoQueries } from "@/lib/queries/todos";
+
+export function TodoList({ sort }: { sort?: string }) {
+  const { data: todos, isPending, error } = useTodos({ sort });
+  const { mutate: createTodo, isPending: isCreating } = useCreateTodo();
+  const queryClient = useQueryClient();
+
+  // Prefetch on hover — no dedicated hook needed; useQueryClient gives you the
+  // client anywhere, so just call prefetchQuery with the factory inline.
+  const prefetchTodo = (id: number) =>
+    queryClient.prefetchQuery(todoQueries.detail(id));
+
+  if (isPending) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+
+  return (
+    <div>
+      {todos?.map((todo) => (
+        <TodoItem key={todo.id} todo={todo} onHover={() => prefetchTodo(todo.id)} />
+      ))}
+      <button onClick={() => createTodo({ title: "New Todo" })} disabled={isCreating}>
+        {isCreating ? "Creating..." : "Add Todo"}
+      </button>
+    </div>
+  );
+}
+```
+
+## Best Practices
+
+### 1. **Naming Conventions**
+
+- **Query Factories**: `featureQueries` (e.g., `todoQueries`, `userQueries`)
+- **Key-only factories**: Use descriptive names like `all`, `allLists`, `allDetails`
+- **Complete factories**: Use action names like `list`, `detail`, `byUser`
+- **Custom hooks**: Prefix with `use` (e.g., `useTodos`, `useCreateTodo`)
+- **Hook arguments**: pass a **single object** (`useTodo({ id })`), never positional params — type-safe and order-independent
+
+### 2. **Key Structure**
+
+```typescript
+// Good: Hierarchical and consistent
+["todos", "list", { sort: "asc" }][("todos", "detail", 123)][
+  ("todos", "user", 456, "list", { sort: "desc" })
+][
+  // Bad: Inconsistent structure
+  ("todos", "list", "asc")
+][("todo", "detail", 123)]; // Missing object wrapper // Inconsistent singular/plural
+```
+
+### 3. **TypeScript Usage**
+
+```typescript
+// Always use const assertions for better type inference
+all: () => ['todos'] as const,
+list: (sort?: string) => queryOptions({
+  queryKey: [...todoQueries.allLists(), { sort }] as const,
+  // ... rest of options
+}),
+```
+
+### 4. **Error Handling → configured in the QueryClient**
+
+Global error handling is set up **once** in the QueryClient — see [Implementation Examples §1](#1-queryclient-setup--already-configured-): mutations always toast; query failures toast only when cached data is already on screen (first-load errors go to the page / ErrorBoundary). Don't add per-hook error toasts — use a local `error` only when a component needs bespoke inline UI.
+
+
+
+## Migration Strategy
+
+### Phase 1: Setup — DONE ✅
+
+1. ~~Install React Query and dependencies~~ — `@tanstack/react-query` v5 (+ devtools) installed
+2. ~~Create QueryClient configuration~~ — in `lib/context/QueryProvider.tsx` (incl. global error handling)
+3. ~~Set up provider~~ — mounted in `app/layout.tsx`
+
+### Phase 2: Create Query Factories
+
+1. Add `lib/queries/<entity>.ts` per entity, pairing with the existing `lib/services/<entity>-api.ts`
+2. Start with the most commonly used entities (e.g. roadmap, programs, dashboard)
+3. Keep keys hierarchical and entity-prefixed for easy invalidation
+
+### Phase 3: Convert Hooks (one role-area at a time)
+
+1. Rewrite each `lib/hooks/<role>/useX.ts` internally to `useQuery(entityQueries…)` / `useMutation`
+2. **Preserve each hook's public return shape** so consuming components don't change
+3. Migrate by area (e.g. mentee → mentor → admin) and test each before moving on
+
+## Common Patterns
+
+### 1. **Dependent Queries**
+
+```typescript
+// User must be loaded before loading user's todos
+export function useUserTodos(userId: number) {
+  const { data: user } = useUser(userId);
+
+  return useQuery({
+    ...todoQueries.byUser(userId),
+    enabled: !!user, // Only run when user is loaded
+  });
+}
+```
+
+### 2. **Parallel Queries**
+
+```typescript
+// The three observers mount together and fetch in PARALLEL automatically —
+// useQuery doesn't block, so there's no request waterfall.
+export function useDashboardData() {
+  const todosQuery = useQuery(todoQueries.list());
+  const usersQuery = useQuery(userQueries.list());
+  const postsQuery = useQuery(postQueries.list());
+
+  return {
+    todos: todosQuery.data,
+    users: usersQuery.data,
+    posts: postsQuery.data,
+    isPending:
+      todosQuery.isPending || usersQuery.isPending || postsQuery.isPending,
+  };
+}
+```
+
+> For a **dynamic** number of parallel queries (you can't call hooks in a loop), use `useQueries` instead of a fixed set of `useQuery` calls.
+
+### 3. **Infinite Queries**
+
+```typescript
+// features/posts/queries.ts
+export const postQueries = {
+  infiniteList: (filters: PostFilters) =>
+    queryOptions({
+      queryKey: [...postQueries.allLists(), "infinite", filters] as const,
+      queryFn: ({ pageParam = 0 }) =>
+        fetchPosts({ ...filters, page: pageParam }),
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+      initialPageParam: 0,
+    }),
+};
+
+// features/posts/hooks/use-posts.ts
+export function useInfinitePosts(filters: PostFilters) {
+  return useInfiniteQuery(postQueries.infiniteList(filters));
+}
+```
+
+### 4. **Pagination Patterns**
+
+#### A. **Traditional Pagination (External State)**
+
+```typescript
+// features/posts/queries.ts
+export const postQueries = {
+  all: () => ["posts"] as const,
+  allLists: () => [...postQueries.all(), "list"] as const,
+  
+  // Paginated query factory
+  list: (filters: PostFilters, page: number = 1) =>
+    queryOptions({
+      queryKey: [...postQueries.allLists(), { ...filters, page }] as const,
+      queryFn: () => fetchPosts({ ...filters, page }),
+      staleTime: 5 * 60 * 1000,
+      // Keep previous data for smooth pagination
+      placeholderData: (previousData) => previousData,
+    }),
+};
+
+// features/posts/hooks/use-posts.ts
+export function usePosts(filters: PostFilters, page: number = 1) {
+  return useQuery(postQueries.list(filters, page));
+}
+
+// Component implementation
+export function PostList({ filters }: { filters: PostFilters }) {
+  const [page, setPage] = useState(1);
+  const { data, isLoading, isPlaceholderData } = usePosts(filters, page);
+
+  // Reset to page 1 when filters change
+  useEffect(() => {
+    setPage(1);
+  }, [filters]);
+
+  if (isLoading && !data) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <ul style={{ opacity: isPlaceholderData ? 0.5 : 1 }}>
+        {data?.posts.map((post) => (
+          <li key={post.id}>{post.title}</li>
+        ))}
+      </ul>
+      
+      <div>
+        <button
+          onClick={() => setPage(p => p - 1)}
+          disabled={page === 1 || isPlaceholderData}
+        >
+          Previous
+        </button>
+        
+        <span>Page {page} of {data?.totalPages}</span>
+        
+        <button
+          onClick={() => setPage(p => p + 1)}
+          disabled={page >= (data?.totalPages || 1) || isPlaceholderData}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+#### B. **Infinite Queries**
+
+```typescript
+// features/posts/queries.ts
+export const postQueries = {
+  all: () => ["posts"] as const,
+  allLists: () => [...postQueries.all(), "list"] as const,
+  
+  // Infinite query factory
+  infiniteList: (filters: PostFilters) =>
+    queryOptions({
+      queryKey: [...postQueries.allLists(), "infinite", filters] as const,
+      queryFn: ({ pageParam = 1 }) => fetchPosts({ ...filters, page: pageParam }),
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+      getPreviousPageParam: (firstPage) => firstPage.prevPage,
+      initialPageParam: 1,
+      staleTime: 5 * 60 * 1000,
+    }),
+};
+
+// features/posts/hooks/use-posts.ts
+export function useInfinitePosts(filters: PostFilters) {
+  return useInfiniteQuery(postQueries.infiniteList(filters));
+}
+
+// Component implementation
+export function InfinitePostList({ filters }: { filters: PostFilters }) {
+  const {
+    data,
+    fetchNextPage,
+    fetchPreviousPage,
+    hasNextPage,
+    hasPreviousPage,
+    isFetchingNextPage,
+    isFetchingPreviousPage,
+  } = useInfinitePosts(filters);
+
+  const posts = data?.pages.flatMap(page => page.posts) ?? [];
+
+  return (
+    <div>
+      <ul>
+        {posts.map((post) => (
+          <li key={post.id}>{post.title}</li>
+        ))}
+      </ul>
+      
+      <div>
+        <button
+          onClick={() => fetchPreviousPage()}
+          disabled={!hasPreviousPage || isFetchingPreviousPage}
+        >
+          {isFetchingPreviousPage ? "Loading..." : "Previous"}
+        </button>
+        
+        <button
+          onClick={() => fetchNextPage()}
+          disabled={!hasNextPage || isFetchingNextPage}
+        >
+          {isFetchingNextPage ? "Loading..." : "Next"}
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+**When to Use Each Pattern:**
+- **Traditional Pagination**: When you need discrete page navigation with page numbers
+- **Infinite Queries**: When you want seamless infinite scrolling or "Load More" functionality
+
+### 5. **Optimistic Updates**
+
+```typescript
+export function useUpdateTodoOptimistic() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateTodo,
+    onMutate: async (newTodo) => {
+      // Cancel outgoing refetches
+      await queryClient.cancelQueries({
+        queryKey: todoQueries.detail(newTodo.id).queryKey,
+      });
+
+      // Snapshot previous value
+      const previousTodo = queryClient.getQueryData(
+        todoQueries.detail(newTodo.id).queryKey
+      );
+
+      // Optimistically update
+      queryClient.setQueryData(
+        todoQueries.detail(newTodo.id).queryKey,
+        newTodo
+      );
+
+      return { previousTodo };
+    },
+    onError: (err, newTodo, context) => {
+      // Rollback on error
+      queryClient.setQueryData(
+        todoQueries.detail(newTodo.id).queryKey,
+        context?.previousTodo
+      );
+    },
+    onSettled: (data, error, variables) => {
+      // Always refetch after error or success
+      queryClient.invalidateQueries({
+        queryKey: todoQueries.detail(variables.id).queryKey,
+      });
+    },
+  });
+}
+```
+
+> **Why this works (re: subscribers):** every component subscribed to that query key reads the **same** cache entry, so `setQueryData` re-renders **all** of them instantly with the optimistic value. `cancelQueries` stops an in-flight refetch from clobbering it, and the `onSettled` invalidation re-syncs every subscriber with server truth.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **TypeScript Errors with queryOptions**
+
+   ```typescript
+   // Make sure to import queryOptions
+   import { queryOptions } from '@tanstack/react-query'
+
+   // Use const assertions
+   queryKey: [...todoQueries.allLists(), { sort }] as const,
+   ```
+
+2. **Incorrect Invalidation**
+
+   ```typescript
+   // Wrong: Passing array directly
+   queryClient.invalidateQueries(todoQueries.allLists());
+
+   // Correct: Wrapping in object
+   queryClient.invalidateQueries({
+     queryKey: todoQueries.allLists(),
+   });
+   ```
+
+3. **Missing Dependencies in QueryKey**
+
+   ```typescript
+   // Make sure all variables used in queryFn are in queryKey
+   list: (sort?: string) => queryOptions({
+     queryKey: [...todoQueries.allLists(), { sort }] as const, // ✅ sort included
+     queryFn: () => fetchTodos(sort), // ✅ sort used in queryFn
+   }),
+   ```
+
+### Performance Tips
+
+1. **Use appropriate staleTime** based on data freshness requirements
+2. **Implement proper garbage collection** with gcTime
+3. **Use select option** for data transformation to prevent unnecessary re-renders
+4. **Implement proper prefetching** for better UX
+5. **Use React.memo** for components that receive query data
+
+### Debugging
+
+1. **Enable React Query DevTools** in development
+2. **Use consistent queryKey structure** for easier debugging
+3. **Add logging** to query functions for debugging
+4. **Monitor network requests** in browser dev tools
+5. **Use queryClient.getQueryData()** to inspect cache state
+
+---
+
+## Conclusion
+
+This architecture provides a scalable, maintainable approach to React Query integration that follows the official course recommendations. The Query Factories pattern ensures that query keys and functions stay together while providing excellent TypeScript support and reusability across your application.
+
+Remember to:
+
+- Keep queryKey and queryFn together
+- Use feature-based organization
+- Implement proper error handling
+- Follow TypeScript best practices
+- Test thoroughly during migration
+
+For more advanced patterns and edge cases, refer to the official React Query documentation and the course materials.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "axios": "^1.13.2",
         "bcrypt": "^5.1.1",
-        "bull": "^4.16.5",
         "cloudinary": "^2.9.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
@@ -721,12 +720,6 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
-    "node_modules/@ioredis/commands": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
-      "integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==",
-      "license": "MIT"
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1215,84 +1208,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -2360,36 +2275,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
-    "node_modules/bull": {
-      "version": "4.16.5",
-      "resolved": "https://registry.npmjs.org/bull/-/bull-4.16.5.tgz",
-      "integrity": "sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cron-parser": "^4.9.0",
-        "get-port": "^5.1.1",
-        "ioredis": "^5.3.2",
-        "lodash": "^4.17.21",
-        "msgpackr": "^1.11.2",
-        "semver": "^7.5.2",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/bull/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -2705,15 +2590,6 @@
         "node": ">=9"
       }
     },
-    "node_modules/cluster-key-slot": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2947,18 +2823,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/cron-parser": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
-      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "luxon": "^3.2.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3031,15 +2895,6 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT"
-    },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -3925,18 +3780,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/get-port": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -4248,53 +4091,6 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ioredis": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.2.tgz",
-      "integrity": "sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@ioredis/commands": "1.4.0",
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.4",
-        "denque": "^2.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.isarguments": "^3.1.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ioredis"
-      }
-    },
-    "node_modules/ioredis/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ioredis/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -5630,22 +5426,10 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -5713,15 +5497,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/luxon": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -5938,37 +5713,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/msgpackr": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.5.tgz",
-      "integrity": "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
-      }
-    },
-    "node_modules/msgpackr-extract": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build-optional-packages": "5.2.2"
-      },
-      "bin": {
-        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
-      },
-      "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
-      }
-    },
     "node_modules/multer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
@@ -6055,21 +5799,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-gyp-build-optional-packages": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
-      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.1"
-      },
-      "bin": {
-        "node-gyp-build-optional-packages": "bin.js",
-        "node-gyp-build-optional-packages-optional": "optional.js",
-        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -6899,27 +6628,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "license": "MIT",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7625,12 +7333,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/standard-as-callback": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "license": "MIT"
     },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",


### PR DESCRIPTION
## Description

Introduces **TanStack Query (React Query) v5** to `client-interface` as the data-fetching/caching layer, and migrates the first two high-traffic areas onto it. This is the first installment of the incremental adoption tracked in #425 — the foundation plus a representative read-heavy area (cohort) and a read+mutate area (mentee detail), so the pattern is proven end-to-end.

**Foundation**
- `@tanstack/react-query` (+ devtools, dev-only) and an SSR-safe `QueryProvider` mounted at the app root.
- Global error handling centralized in the `QueryClient` (`QueryCache`/`MutationCache` `onError` → toast via the existing `sonner` + `extractApiErrorMessage`); query toasts fire only when cached data is already on screen so they don't double up with pages' inline error states.
- `docs/REACT_QUERY.md` — architecture guide (Query Factories pattern, conventions, migration strategy) adapted to this repo's layer-then-role structure.

**Migrations** (public hook return shapes preserved → consuming components unchanged)
- **Cohort** (`useMentorCohort`, read by ~11 mentor pages) → one cached `['cohort','mine']` query, so navigating across the mentor section reuses a single fetch instead of refetching per page.
- **Mentee detail trio** (`useMenteeDetailPage` + `useMenteeActivity` + `useMenteeProfile`) → per-`menteeId` queries so revisiting a mentee is instant; completion approve/reject are `useMutation`s that invalidate the match + cohort caches. The activity hook's hand-rolled interval/focus/visibility plumbing is replaced by `refetchInterval` + `refetchOnWindowFocus`.

**Typing**: the previously `any`-heavy hooks now use precise types (`lib/types/{cohort,matches,insights}`, `MenteeTask`/`WorkHistoryItem`), grounded in the backend response shapes. Entity types live in `lib/types/` (consumed across the service/query/hook layers).

## Related Issue

Refs #425 (first installment — remaining hooks to be migrated in follow-up PRs)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s) — changed files are clean (repo has pre-existing, unrelated lint debt)
- [x] I ran build checks for impacted app(s) — `tsc --noEmit` clean; mentor routes compile
- [x] I ran tests for impacted app(s), or confirmed no test suite exists — no client test suite exists (eslint only); verified manually in-app
- [x] I updated documentation where needed — added `docs/REACT_QUERY.md`

## Screenshots (Required for UI changes)

No visual change — the UI renders identically; the change is caching/perf. Verified manually with an artificial 10s API delay: a cold load showed the spinner, while in-app navigation back to the mentees list and re-opening a previously viewed mentee both rendered **instantly** from cache (no spinner). No console errors.
