### PR TITLE
fix: render mentor feedback HTML content correctly

### DIFF
--- a/client-interface/app/mentee/tasks/[id]/page.tsx
+++ b/client-interface/app/mentee/tasks/[id]/page.tsx
@@ -357,7 +357,7 @@ export default function TaskDetailsPage({ params }: PageProps) {
                 {fb.feedbackText && (
                   <div>
                     <p className="text-xs font-medium text-slate-500 mb-1">{isChanges ? 'What the mentor asked for' : 'Feedback'}</p>
-                    <p className="text-sm text-slate-800 whitespace-pre-wrap">{fb.feedbackText}</p>
+                    <div className="text-sm text-slate-800 whitespace-pre-wrap" dangerouslySetInnerHTML={{ __html: fb.feedbackText }} />
                   </div>
                 )}
 


### PR DESCRIPTION
## Description

This PR fixes an issue where mentor feedback containing HTML content was displayed as raw HTML tags on the mentee side instead of being rendered as formatted text.

## Related Issue

Closes #504 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

BEFORE:
<img width="1918" height="1006" alt="image" src="https://github.com/user-attachments/assets/4e75733a-081c-4542-b39a-b9f14845903f" />
AFTER:
<img width="1918" height="1006" alt="image" src="https://github.com/user-attachments/assets/f36574b0-6f1e-4b90-8e20-4b728e84f3d3" />
