### PR TITLE
Feat/attendance feature update

### DIFF
--- a/client-interface/app/mentor/review/page.tsx
+++ b/client-interface/app/mentor/review/page.tsx
@@ -26,6 +26,7 @@ import { AssignTaskDrawer } from '@/components/mentor/AssignTaskDrawer';
 import { MenteeTaskDrawer } from '@/components/mentor/MenteeTaskDrawer';
 import { Drawer } from '@/components/shared/Drawer';
 import { useConfirm } from '@/lib/context/ConfirmContext';
+import { AttendanceSection } from '@/components/mentor/attendance/AttendanceSection';
 
 type Attendance = 'present' | 'absent' | 'excused';
 type EntryStatus = 'pending' | 'reviewed' | 'deferred';
@@ -104,6 +105,7 @@ export default function CohortReview() {
   // Extension request the mentor is reviewing (approve-with-adjust / decline).
   const [extReview, setExtReview] = useState<any>(null); // eslint-disable-line @typescript-eslint/no-explicit-any
   const [extDays, setExtDays] = useState(3);
+  const [isSavingAttendance, setIsSavingAttendance] = useState(false);
 
   const mentee: CohortMentee | undefined = cohort[idx];
   const menteeId = mentee?.id;
@@ -269,6 +271,43 @@ export default function CohortReview() {
       }
     } catch { toast.error('Could not save the review'); }
   }, [session, ensureSession]);
+
+  const patchMultipleEntries = useCallback(async (updates: Record<string, Attendance>) => {
+    if (!session) return;
+    setIsSavingAttendance(true);
+    try {
+      const changes = Object.entries(updates).filter(([mId, newAtt]) => {
+        const currentAtt = entriesByMentee[mId]?.attendance ?? null;
+        return currentAtt !== newAtt;
+      });
+
+      if (changes.length === 0) {
+        setIsSavingAttendance(false);
+        return;
+      }
+
+      const s = await ensureSession();
+      if (!s) throw new Error('Could not create session');
+
+      let newEntries = [...s.entries];
+      changes.forEach(([mId, newAtt]) => {
+        newEntries = upsert(newEntries, mId, { attendance: newAtt, status: 'reviewed' });
+      });
+      setSession({ ...s, entries: newEntries });
+
+      await Promise.all(
+        changes.map(([mId, newAtt]) =>
+          mentorApi.setReviewEntry(s.id, mId, { attendance: newAtt, status: 'reviewed' })
+        )
+      );
+
+      toast.success(`Attendance updated for ${changes.length} mentees`);
+    } catch (e) {
+      toast.error('Failed to save some attendance records');
+    } finally {
+      setIsSavingAttendance(false);
+    }
+  }, [session, entriesByMentee, ensureSession]);
 
   // Load open blockers + assigned tasks + the full profile (state/summary) for
   // the current mentee; reset state.
@@ -731,14 +770,15 @@ export default function CohortReview() {
         )}
       </div>
 
-      {/* Progress dots */}
-      <div className="flex flex-wrap items-center gap-1.5">
-        {cohort.map((m, i) => {
-          const a = attendance[m.id];
-          const cls = i === idx ? 'bg-slate-900' : a === 'present' ? 'bg-emerald-500' : a === 'absent' ? 'bg-red-500' : seen.has(m.id) ? 'bg-slate-400' : 'bg-slate-200';
-          return <button key={m.id} onClick={() => selectMentee(i)} title={m.name} className={`w-2.5 h-2.5 rounded-full ${cls}`} />;
-        })}
-      </div>
+      {/* Attendance Strip */}
+      <AttendanceSection
+        cohort={cohort}
+        attendance={attendance}
+        activeMenteeId={menteeId}
+        onSelectMentee={selectMentee}
+        onSaveAttendance={patchMultipleEntries}
+        isSaving={isSavingAttendance}
+      />
 
       {deferred.size > 0 && (
         <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-2 flex flex-wrap items-center gap-2 text-sm">

--- a/client-interface/app/mentor/review/page.tsx
+++ b/client-interface/app/mentor/review/page.tsx
@@ -272,7 +272,10 @@ export default function CohortReview() {
     } catch { toast.error('Could not save the review'); }
   }, [session, ensureSession]);
 
-  const patchMultipleEntries = useCallback(async (updates: Record<string, Attendance>) => {
+  // Bulk-apply the Attendance Sheet. `null` means "clear the mark". Only rows
+  // that actually changed are persisted; status follows attendance (a cleared
+  // mark drops back to pending).
+  const patchMultipleEntries = useCallback(async (updates: Record<string, Attendance | null>) => {
     if (!session) return;
     setIsSavingAttendance(true);
     try {
@@ -291,18 +294,18 @@ export default function CohortReview() {
 
       let newEntries = [...s.entries];
       changes.forEach(([mId, newAtt]) => {
-        newEntries = upsert(newEntries, mId, { attendance: newAtt, status: 'reviewed' });
+        newEntries = upsert(newEntries, mId, { attendance: newAtt, status: newAtt ? 'reviewed' : 'pending' });
       });
       setSession({ ...s, entries: newEntries });
 
       await Promise.all(
         changes.map(([mId, newAtt]) =>
-          mentorApi.setReviewEntry(s.id, mId, { attendance: newAtt, status: 'reviewed' })
+          mentorApi.setReviewEntry(s.id, mId, { attendance: newAtt, status: newAtt ? 'reviewed' : 'pending' })
         )
       );
 
-      toast.success(`Attendance updated for ${changes.length} mentees`);
-    } catch (e) {
+      toast.success(`Attendance updated for ${changes.length} mentee${changes.length === 1 ? '' : 's'}`);
+    } catch {
       toast.error('Failed to save some attendance records');
     } finally {
       setIsSavingAttendance(false);

--- a/client-interface/components/mentor/attendance/AttendanceFilters.tsx
+++ b/client-interface/components/mentor/attendance/AttendanceFilters.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export type AttendanceFilter = 'all' | 'present' | 'absent' | 'excused';
+
+interface AttendanceFiltersProps {
+  currentFilter: AttendanceFilter;
+  onFilterChange: (filter: AttendanceFilter) => void;
+}
+
+export function AttendanceFilters({ currentFilter, onFilterChange }: AttendanceFiltersProps) {
+  const filters: { value: AttendanceFilter; label: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: 'present', label: 'Present' },
+    { value: 'absent', label: 'Absent' },
+    { value: 'excused', label: 'Excused' },
+  ];
+
+  return (
+    <div className="flex items-center gap-2">
+      {filters.map((f) => {
+        const isActive = currentFilter === f.value;
+        return (
+          <button
+            key={f.value}
+            onClick={() => onFilterChange(f.value)}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              isActive
+                ? 'bg-slate-900 text-white'
+                : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+            }`}
+          >
+            {f.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/client-interface/components/mentor/attendance/AttendanceModal.tsx
+++ b/client-interface/components/mentor/attendance/AttendanceModal.tsx
@@ -1,0 +1,139 @@
+import React, { useState, useEffect } from 'react';
+import { Loader2, X, UserCheck, UserX, CheckCircle2 } from 'lucide-react';
+import { Drawer } from '@/components/shared/Drawer';
+
+type Attendance = 'present' | 'absent' | 'excused' | null;
+
+interface AttendanceModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  mentees: { id: string; name: string }[];
+  initialAttendance: Record<string, Attendance>;
+  onSave: (updates: Record<string, Attendance>) => void;
+  isSaving: boolean;
+}
+
+export function AttendanceModal({ isOpen, onClose, mentees, initialAttendance, onSave, isSaving }: AttendanceModalProps) {
+  const [localAttendance, setLocalAttendance] = useState<Record<string, Attendance>>({});
+
+  useEffect(() => {
+    if (isOpen) {
+      setLocalAttendance({ ...initialAttendance });
+    }
+  }, [isOpen, initialAttendance]);
+
+  const markAll = (status: Attendance) => {
+    const next = { ...localAttendance };
+    mentees.forEach(m => {
+      next[m.id] = status;
+    });
+    setLocalAttendance(next);
+  };
+
+  const markOne = (id: string, status: Attendance) => {
+    setLocalAttendance(prev => ({
+      ...prev,
+      [id]: prev[id] === status ? null : status,
+    }));
+  };
+
+  const getInitials = (name: string) => {
+    const parts = name.trim().split(/\s+/);
+    if (parts.length === 0) return '?';
+    if (parts.length === 1) return parts[0].substring(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  };
+
+  const handleSave = () => {
+    onSave(localAttendance);
+  };
+
+  return (
+    <Drawer
+      open={isOpen}
+      onClose={onClose}
+      title="Attendance Sheet"
+      width="md"
+      subtitle={`Managing attendance for ${mentees.length} mentee${mentees.length !== 1 ? 's' : ''}`}
+      footer={
+        <>
+          <button
+            onClick={onClose}
+            className="px-4 py-2 border border-slate-200 text-slate-700 rounded-xl text-sm hover:bg-slate-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={isSaving}
+            className="px-4 py-2 rounded-xl bg-brand-600 hover:bg-brand-700 text-white text-sm font-medium inline-flex items-center gap-2 disabled:opacity-50"
+          >
+            {isSaving ? <Loader2 className="w-4 h-4 animate-spin" /> : <CheckCircle2 className="w-4 h-4" />}
+            Save Attendance
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        {/* Bulk Actions */}
+        <div className="flex items-center gap-2 pb-4 border-b border-slate-100">
+          <button
+            onClick={() => markAll('present')}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-emerald-200 bg-emerald-50 text-emerald-700 text-xs font-medium hover:bg-emerald-100"
+          >
+            <UserCheck className="w-3.5 h-3.5" /> Mark All Present
+          </button>
+          <button
+            onClick={() => markAll('absent')}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-red-200 bg-red-50 text-red-700 text-xs font-medium hover:bg-red-100"
+          >
+            <UserX className="w-3.5 h-3.5" /> Mark All Absent
+          </button>
+        </div>
+
+        {/* Mentee List */}
+        <div className="space-y-2">
+          {mentees.map(m => {
+            const att = localAttendance[m.id];
+            return (
+              <div key={m.id} className="flex items-center justify-between p-3 rounded-xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-full bg-brand-50 border border-brand-100 flex items-center justify-center text-brand-700 font-semibold text-xs shrink-0">
+                    {getInitials(m.name)}
+                  </div>
+                  <span className="text-sm font-medium text-slate-900 truncate max-w-[140px] sm:max-w-[200px]">
+                    {m.name}
+                  </span>
+                </div>
+
+                <div className="flex items-center gap-1 bg-white p-1 rounded-lg border border-slate-200 shrink-0">
+                  {(['present', 'absent', 'excused'] as Attendance[]).map(status => {
+                    const isActive = att === status;
+                    let activeCls = 'bg-slate-100 text-slate-600';
+                    if (isActive) {
+                      if (status === 'present') activeCls = 'bg-emerald-100 text-emerald-700 font-medium border-emerald-200';
+                      else if (status === 'absent') activeCls = 'bg-red-100 text-red-700 font-medium border-red-200';
+                      else activeCls = 'bg-slate-200 text-slate-800 font-medium border-slate-300';
+                    } else {
+                      activeCls = 'text-slate-500 hover:bg-slate-50 border-transparent';
+                    }
+
+                    return (
+                      <button
+                        key={status}
+                        onClick={() => markOne(m.id, status)}
+                        className={`px-3 py-1 rounded-md text-xs capitalize transition-colors border ${activeCls}`}
+                      >
+                        {status}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Drawer>
+  );
+}

--- a/client-interface/components/mentor/attendance/AttendanceModal.tsx
+++ b/client-interface/components/mentor/attendance/AttendanceModal.tsx
@@ -1,13 +1,15 @@
 import React, { useState, useEffect } from 'react';
-import { Loader2, X, UserCheck, UserX, CheckCircle2 } from 'lucide-react';
+import { Loader2, UserCheck, UserX, CheckCircle2 } from 'lucide-react';
 import { Drawer } from '@/components/shared/Drawer';
+import { getInitials } from '@/lib/utils/formatting';
+import type { AttendanceMentee } from './MenteeAttendanceCard';
 
 type Attendance = 'present' | 'absent' | 'excused' | null;
 
 interface AttendanceModalProps {
   isOpen: boolean;
   onClose: () => void;
-  mentees: { id: string; name: string }[];
+  mentees: AttendanceMentee[];
   initialAttendance: Record<string, Attendance>;
   onSave: (updates: Record<string, Attendance>) => void;
   isSaving: boolean;
@@ -35,13 +37,6 @@ export function AttendanceModal({ isOpen, onClose, mentees, initialAttendance, o
       ...prev,
       [id]: prev[id] === status ? null : status,
     }));
-  };
-
-  const getInitials = (name: string) => {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length === 0) return '?';
-    if (parts.length === 1) return parts[0].substring(0, 2).toUpperCase();
-    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
   };
 
   const handleSave = () => {
@@ -98,9 +93,14 @@ export function AttendanceModal({ isOpen, onClose, mentees, initialAttendance, o
             return (
               <div key={m.id} className="flex items-center justify-between p-3 rounded-xl border border-slate-100 bg-slate-50/50 hover:bg-slate-50 transition-colors">
                 <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-full bg-brand-50 border border-brand-100 flex items-center justify-center text-brand-700 font-semibold text-xs shrink-0">
-                    {getInitials(m.name)}
-                  </div>
+                  {m.profilePictureUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={m.profilePictureUrl} alt={m.name} className="w-8 h-8 rounded-full object-cover shrink-0" />
+                  ) : (
+                    <div className="w-8 h-8 rounded-full bg-brand-50 border border-brand-100 flex items-center justify-center text-brand-700 font-semibold text-xs shrink-0">
+                      {m.avatar || getInitials(m.name)}
+                    </div>
+                  )}
                   <span className="text-sm font-medium text-slate-900 truncate max-w-[140px] sm:max-w-[200px]">
                     {m.name}
                   </span>

--- a/client-interface/components/mentor/attendance/AttendanceSection.tsx
+++ b/client-interface/components/mentor/attendance/AttendanceSection.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useMemo } from 'react';
+import { AttendanceFilters, type AttendanceFilter } from './AttendanceFilters';
+import { MenteeCarousel } from './MenteeCarousel';
+import { MenteeAttendanceCard } from './MenteeAttendanceCard';
+import { AttendanceModal } from './AttendanceModal';
+import { CheckCircle2 } from 'lucide-react';
+
+type Attendance = 'present' | 'absent' | 'excused' | null;
+
+interface AttendanceSectionProps {
+  cohort: { id: string; name: string }[];
+  attendance: Record<string, Attendance>;
+  activeMenteeId?: string;
+  onSelectMentee: (index: number) => void;
+  onSaveAttendance: (updates: Record<string, Attendance>) => Promise<void>;
+  isSaving: boolean;
+}
+
+export function AttendanceSection({
+  cohort,
+  attendance,
+  activeMenteeId,
+  onSelectMentee,
+  onSaveAttendance,
+  isSaving,
+}: AttendanceSectionProps) {
+  const [currentFilter, setCurrentFilter] = useState<AttendanceFilter>('all');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const filteredMentees = useMemo(() => {
+    let list = [...cohort];
+
+    if (currentFilter === 'present') {
+      list = list.filter(m => attendance[m.id] === 'present');
+    } else if (currentFilter === 'absent') {
+      list = list.filter(m => attendance[m.id] === 'absent');
+    } else if (currentFilter === 'excused') {
+      list = list.filter(m => attendance[m.id] === 'excused');
+    } else {
+      // 'all' -> smart sorting: Present, Absent, Excused, Not Marked
+      list.sort((a, b) => {
+        const order = { present: 1, absent: 2, excused: 3, null: 4 };
+        const valA = attendance[a.id] || 'null';
+        const valB = attendance[b.id] || 'null';
+        return (order[valA as keyof typeof order] || 4) - (order[valB as keyof typeof order] || 4);
+      });
+    }
+
+    return list;
+  }, [cohort, attendance, currentFilter]);
+
+  const handleSave = async (updates: Record<string, Attendance>) => {
+    await onSaveAttendance(updates);
+    setIsModalOpen(false);
+  };
+
+  return (
+    <div className="space-y-4 mb-6">
+      <div className="flex items-center justify-between flex-wrap gap-4">
+        <AttendanceFilters currentFilter={currentFilter} onFilterChange={setCurrentFilter} />
+        <button
+          onClick={() => setIsModalOpen(true)}
+          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-brand-600 hover:bg-brand-700 text-white text-sm font-medium transition-colors"
+        >
+          <CheckCircle2 className="w-4 h-4" />
+          Attendance Sheet
+        </button>
+      </div>
+
+      <div className="bg-slate-50/50 rounded-2xl border border-slate-200 p-2">
+        {filteredMentees.length === 0 ? (
+          <div className="py-8 text-center text-sm text-slate-500">
+            No mentees match the current filter.
+          </div>
+        ) : (
+          <MenteeCarousel>
+            {filteredMentees.map(mentee => {
+              const originalIndex = cohort.findIndex(m => m.id === mentee.id);
+              return (
+                <MenteeAttendanceCard
+                  key={mentee.id}
+                  mentee={mentee}
+                  attendance={attendance[mentee.id] || null}
+                  isActive={mentee.id === activeMenteeId}
+                  onClick={() => onSelectMentee(originalIndex)}
+                />
+              );
+            })}
+          </MenteeCarousel>
+        )}
+      </div>
+
+      <AttendanceModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        mentees={filteredMentees}
+        initialAttendance={attendance}
+        onSave={handleSave}
+        isSaving={isSaving}
+      />
+    </div>
+  );
+}

--- a/client-interface/components/mentor/attendance/AttendanceSection.tsx
+++ b/client-interface/components/mentor/attendance/AttendanceSection.tsx
@@ -1,20 +1,23 @@
 import React, { useState, useMemo } from 'react';
 import { AttendanceFilters, type AttendanceFilter } from './AttendanceFilters';
 import { MenteeCarousel } from './MenteeCarousel';
-import { MenteeAttendanceCard } from './MenteeAttendanceCard';
+import { MenteeAttendanceCard, type AttendanceMentee } from './MenteeAttendanceCard';
 import { AttendanceModal } from './AttendanceModal';
 import { CheckCircle2 } from 'lucide-react';
 
 type Attendance = 'present' | 'absent' | 'excused' | null;
 
 interface AttendanceSectionProps {
-  cohort: { id: string; name: string }[];
+  cohort: AttendanceMentee[];
   attendance: Record<string, Attendance>;
   activeMenteeId?: string;
   onSelectMentee: (index: number) => void;
   onSaveAttendance: (updates: Record<string, Attendance>) => Promise<void>;
   isSaving: boolean;
 }
+
+// Sort weight for the "all" view: present → absent → excused → not-yet-marked.
+const SORT_WEIGHT: Record<string, number> = { present: 1, absent: 2, excused: 3, null: 4 };
 
 export function AttendanceSection({
   cohort,
@@ -27,26 +30,28 @@ export function AttendanceSection({
   const [currentFilter, setCurrentFilter] = useState<AttendanceFilter>('all');
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  // Headline tallies so the mentor sees the split without counting chips.
+  const counts = useMemo(() => {
+    const c = { present: 0, absent: 0, excused: 0, marked: 0 };
+    cohort.forEach((m) => {
+      const a = attendance[m.id];
+      if (a === 'present') c.present++;
+      else if (a === 'absent') c.absent++;
+      else if (a === 'excused') c.excused++;
+      if (a) c.marked++;
+    });
+    return c;
+  }, [cohort, attendance]);
+
   const filteredMentees = useMemo(() => {
-    let list = [...cohort];
-
-    if (currentFilter === 'present') {
-      list = list.filter(m => attendance[m.id] === 'present');
-    } else if (currentFilter === 'absent') {
-      list = list.filter(m => attendance[m.id] === 'absent');
-    } else if (currentFilter === 'excused') {
-      list = list.filter(m => attendance[m.id] === 'excused');
-    } else {
-      // 'all' -> smart sorting: Present, Absent, Excused, Not Marked
-      list.sort((a, b) => {
-        const order = { present: 1, absent: 2, excused: 3, null: 4 };
-        const valA = attendance[a.id] || 'null';
-        const valB = attendance[b.id] || 'null';
-        return (order[valA as keyof typeof order] || 4) - (order[valB as keyof typeof order] || 4);
-      });
+    if (currentFilter !== 'all') {
+      return cohort.filter((m) => attendance[m.id] === currentFilter);
     }
-
-    return list;
+    return [...cohort].sort((a, b) => {
+      const wa = SORT_WEIGHT[attendance[a.id] ?? 'null'];
+      const wb = SORT_WEIGHT[attendance[b.id] ?? 'null'];
+      return wa - wb;
+    });
   }, [cohort, attendance, currentFilter]);
 
   const handleSave = async (updates: Record<string, Attendance>) => {
@@ -55,32 +60,40 @@ export function AttendanceSection({
   };
 
   return (
-    <div className="space-y-4 mb-6">
-      <div className="flex items-center justify-between flex-wrap gap-4">
-        <AttendanceFilters currentFilter={currentFilter} onFilterChange={setCurrentFilter} />
+    <div className="space-y-3 mb-6">
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
+          <AttendanceFilters currentFilter={currentFilter} onFilterChange={setCurrentFilter} />
+          <span className="text-xs text-slate-500">
+            {counts.marked}/{cohort.length} marked
+            {counts.marked > 0 && (
+              <span className="text-slate-400"> · {counts.present} present · {counts.absent} absent · {counts.excused} excused</span>
+            )}
+          </span>
+        </div>
         <button
           onClick={() => setIsModalOpen(true)}
-          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-brand-600 hover:bg-brand-700 text-white text-sm font-medium transition-colors"
+          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-brand-600 hover:bg-brand-700 text-white text-sm font-medium transition-colors shrink-0"
         >
           <CheckCircle2 className="w-4 h-4" />
           Attendance Sheet
         </button>
       </div>
 
-      <div className="bg-slate-50/50 rounded-2xl border border-slate-200 p-2">
+      <div className="bg-card rounded-2xl border border-slate-200">
         {filteredMentees.length === 0 ? (
-          <div className="py-8 text-center text-sm text-slate-500">
+          <div className="py-10 text-center text-sm text-slate-500">
             No mentees match the current filter.
           </div>
         ) : (
           <MenteeCarousel>
-            {filteredMentees.map(mentee => {
-              const originalIndex = cohort.findIndex(m => m.id === mentee.id);
+            {filteredMentees.map((mentee) => {
+              const originalIndex = cohort.findIndex((m) => m.id === mentee.id);
               return (
                 <MenteeAttendanceCard
                   key={mentee.id}
                   mentee={mentee}
-                  attendance={attendance[mentee.id] || null}
+                  attendance={attendance[mentee.id] ?? null}
                   isActive={mentee.id === activeMenteeId}
                   onClick={() => onSelectMentee(originalIndex)}
                 />
@@ -90,10 +103,12 @@ export function AttendanceSection({
         )}
       </div>
 
+      {/* The sheet always manages the WHOLE cohort, not the filtered rail, so
+          "Mark all present" can't silently skip mentees hidden by a filter. */}
       <AttendanceModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        mentees={filteredMentees}
+        mentees={cohort}
         initialAttendance={attendance}
         onSave={handleSave}
         isSaving={isSaving}

--- a/client-interface/components/mentor/attendance/MenteeAttendanceCard.tsx
+++ b/client-interface/components/mentor/attendance/MenteeAttendanceCard.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+type Attendance = 'present' | 'absent' | 'excused' | null;
+
+interface MenteeAttendanceCardProps {
+  mentee: { id: string; name: string };
+  attendance: Attendance;
+  isActive: boolean;
+  onClick: () => void;
+}
+
+export function MenteeAttendanceCard({ mentee, attendance, isActive, onClick }: MenteeAttendanceCardProps) {
+  const getInitials = (name: string) => {
+    const parts = name.trim().split(/\s+/);
+    if (parts.length === 0) return '?';
+    if (parts.length === 1) return parts[0].substring(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  };
+
+  const getGlassmorphismStyle = (att: Attendance) => {
+    switch (att) {
+      case 'present':
+        return 'bg-emerald-500/10 backdrop-blur-md border-emerald-500/20 text-emerald-700';
+      case 'absent':
+        return 'bg-red-500/10 backdrop-blur-md border-red-500/20 text-red-700';
+      case 'excused':
+        return 'bg-slate-500/10 backdrop-blur-md border-slate-500/20 text-slate-700';
+      default:
+        return 'bg-slate-100/50 backdrop-blur-md border-slate-200 text-slate-500';
+    }
+  };
+
+  const getStatusDot = (att: Attendance) => {
+    switch (att) {
+      case 'present':
+        return 'bg-emerald-500';
+      case 'absent':
+        return 'bg-red-500';
+      case 'excused':
+        return 'bg-slate-500';
+      default:
+        return 'bg-slate-300';
+    }
+  };
+
+  const style = getGlassmorphismStyle(attendance);
+  const dotStyle = getStatusDot(attendance);
+
+  return (
+    <button
+      onClick={onClick}
+      className={`relative flex items-center gap-3 p-3 rounded-2xl border transition-all hover:-translate-y-0.5 hover:shadow-md shrink-0 w-64 ${
+        isActive ? 'ring-2 ring-brand-500 border-brand-200' : 'border-slate-200 hover:border-brand-300 bg-card'
+      }`}
+    >
+      <div className="relative">
+        <div className="w-10 h-10 rounded-full bg-brand-50 border border-brand-100 flex items-center justify-center text-brand-700 font-semibold text-sm">
+          {getInitials(mentee.name)}
+        </div>
+        <div className={`absolute -bottom-1 -right-1 w-3.5 h-3.5 rounded-full border-2 border-white ${dotStyle}`} />
+      </div>
+
+      <div className="flex-1 min-w-0 text-left">
+        <p className="text-sm font-semibold text-slate-900 truncate">{mentee.name}</p>
+        <div className={`mt-1 inline-flex items-center px-2 py-0.5 rounded-full border text-[10px] font-medium capitalize ${style}`}>
+          {attendance || 'Not Marked'}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/client-interface/components/mentor/attendance/MenteeAttendanceCard.tsx
+++ b/client-interface/components/mentor/attendance/MenteeAttendanceCard.tsx
@@ -1,71 +1,98 @@
 import React from 'react';
+import { Check, X, Minus, HelpCircle } from 'lucide-react';
+import { getInitials } from '@/lib/utils/formatting';
 
 type Attendance = 'present' | 'absent' | 'excused' | null;
 
+export interface AttendanceMentee {
+  id: string;
+  name: string;
+  /** Pre-computed initials from the cohort payload; falls back to deriving them. */
+  avatar?: string;
+  profilePictureUrl?: string | null;
+}
+
 interface MenteeAttendanceCardProps {
-  mentee: { id: string; name: string };
+  mentee: AttendanceMentee;
   attendance: Attendance;
   isActive: boolean;
   onClick: () => void;
 }
 
+/**
+ * Instagram-story-style attendance chip: a circular avatar wrapped in a
+ * status-coloured ring, a small status badge, and the mentee's first name.
+ * The ring/badge encode attendance at a glance (green = present, red = absent,
+ * amber = excused, grey = not yet marked), and the active mentee gets a brand
+ * halo so the mentor never loses their place while scrubbing the cohort.
+ */
+
+const RING: Record<NonNullable<Attendance> | 'null', string> = {
+  present: 'bg-emerald-500',
+  absent: 'bg-red-500',
+  excused: 'bg-amber-400',
+  null: 'bg-slate-200',
+};
+
+const BADGE: Record<NonNullable<Attendance> | 'null', { cls: string; Icon: typeof Check }> = {
+  present: { cls: 'bg-emerald-500 text-white', Icon: Check },
+  absent: { cls: 'bg-red-500 text-white', Icon: X },
+  excused: { cls: 'bg-amber-400 text-white', Icon: Minus },
+  null: { cls: 'bg-slate-300 text-white', Icon: HelpCircle },
+};
+
 export function MenteeAttendanceCard({ mentee, attendance, isActive, onClick }: MenteeAttendanceCardProps) {
-  const getInitials = (name: string) => {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length === 0) return '?';
-    if (parts.length === 1) return parts[0].substring(0, 2).toUpperCase();
-    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-  };
-
-  const getGlassmorphismStyle = (att: Attendance) => {
-    switch (att) {
-      case 'present':
-        return 'bg-emerald-500/10 backdrop-blur-md border-emerald-500/20 text-emerald-700';
-      case 'absent':
-        return 'bg-red-500/10 backdrop-blur-md border-red-500/20 text-red-700';
-      case 'excused':
-        return 'bg-slate-500/10 backdrop-blur-md border-slate-500/20 text-slate-700';
-      default:
-        return 'bg-slate-100/50 backdrop-blur-md border-slate-200 text-slate-500';
-    }
-  };
-
-  const getStatusDot = (att: Attendance) => {
-    switch (att) {
-      case 'present':
-        return 'bg-emerald-500';
-      case 'absent':
-        return 'bg-red-500';
-      case 'excused':
-        return 'bg-slate-500';
-      default:
-        return 'bg-slate-300';
-    }
-  };
-
-  const style = getGlassmorphismStyle(attendance);
-  const dotStyle = getStatusDot(attendance);
+  const key = (attendance ?? 'null') as NonNullable<Attendance> | 'null';
+  const ring = RING[key];
+  const { cls: badgeCls, Icon } = BADGE[key];
+  const initials = mentee.avatar || getInitials(mentee.name);
+  const firstName = mentee.name.split(' ')[0];
 
   return (
     <button
       onClick={onClick}
-      className={`relative flex items-center gap-3 p-3 rounded-2xl border transition-all hover:-translate-y-0.5 hover:shadow-md shrink-0 w-64 ${
-        isActive ? 'ring-2 ring-brand-500 border-brand-200' : 'border-slate-200 hover:border-brand-300 bg-card'
-      }`}
+      title={`${mentee.name} — ${attendance ?? 'not marked'}`}
+      aria-pressed={isActive}
+      className="group/card flex flex-col items-center gap-2 shrink-0 w-[84px] snap-start outline-none"
     >
       <div className="relative">
-        <div className="w-10 h-10 rounded-full bg-brand-50 border border-brand-100 flex items-center justify-center text-brand-700 font-semibold text-sm">
-          {getInitials(mentee.name)}
+        {/* Status ring — a coloured halo around the avatar. */}
+        <div
+          className={`rounded-full p-[3px] transition-transform duration-200 group-hover/card:-translate-y-0.5 ${ring} ${
+            isActive ? 'ring-2 ring-brand-500 ring-offset-2 ring-offset-card' : ''
+          }`}
+        >
+          <div className="rounded-full bg-card p-[2px]">
+            {mentee.profilePictureUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={mentee.profilePictureUrl}
+                alt={mentee.name}
+                className="w-14 h-14 rounded-full object-cover"
+              />
+            ) : (
+              <div className="w-14 h-14 rounded-full bg-brand-50 flex items-center justify-center text-brand-700 font-semibold text-base">
+                {initials}
+              </div>
+            )}
+          </div>
         </div>
-        <div className={`absolute -bottom-1 -right-1 w-3.5 h-3.5 rounded-full border-2 border-white ${dotStyle}`} />
+
+        {/* Status badge — bottom-right tick / cross / dash / question. */}
+        <span
+          className={`absolute -bottom-0.5 -right-0.5 w-5 h-5 rounded-full border-2 border-card flex items-center justify-center ${badgeCls}`}
+        >
+          <Icon className="w-3 h-3" strokeWidth={3} />
+        </span>
       </div>
 
-      <div className="flex-1 min-w-0 text-left">
-        <p className="text-sm font-semibold text-slate-900 truncate">{mentee.name}</p>
-        <div className={`mt-1 inline-flex items-center px-2 py-0.5 rounded-full border text-[10px] font-medium capitalize ${style}`}>
-          {attendance || 'Not Marked'}
-        </div>
-      </div>
+      <span
+        className={`max-w-full truncate text-xs font-medium ${
+          isActive ? 'text-brand-700' : 'text-slate-700 group-hover/card:text-slate-900'
+        }`}
+      >
+        {firstName}
+      </span>
     </button>
   );
 }

--- a/client-interface/components/mentor/attendance/MenteeCarousel.tsx
+++ b/client-interface/components/mentor/attendance/MenteeCarousel.tsx
@@ -1,0 +1,46 @@
+import React, { useRef } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface MenteeCarouselProps {
+  children: React.ReactNode;
+}
+
+export function MenteeCarousel({ children }: MenteeCarouselProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const scrollByAmount = (direction: 'left' | 'right') => {
+    if (scrollRef.current) {
+      // Assuming each card is ~256px wide + 12px gap. 2 cards ~ 536px
+      const scrollAmount = direction === 'left' ? -536 : 536;
+      scrollRef.current.scrollBy({ left: scrollAmount, behavior: 'smooth' });
+    }
+  };
+
+  return (
+    <div className="relative group flex items-center">
+      <button
+        onClick={() => scrollByAmount('left')}
+        className="absolute left-0 z-10 -ml-4 w-8 h-8 flex items-center justify-center bg-white border border-slate-200 rounded-full shadow-sm text-slate-500 hover:text-slate-700 hover:border-slate-300 opacity-0 group-hover:opacity-100 transition-opacity"
+        aria-label="Scroll left"
+      >
+        <ChevronLeft className="w-5 h-5" />
+      </button>
+
+      <div
+        ref={scrollRef}
+        className="flex overflow-x-auto gap-3 py-2 scrollbar-hide snap-x snap-mandatory"
+        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+      >
+        {children}
+      </div>
+
+      <button
+        onClick={() => scrollByAmount('right')}
+        className="absolute right-0 z-10 -mr-4 w-8 h-8 flex items-center justify-center bg-white border border-slate-200 rounded-full shadow-sm text-slate-500 hover:text-slate-700 hover:border-slate-300 opacity-0 group-hover:opacity-100 transition-opacity"
+        aria-label="Scroll right"
+      >
+        <ChevronRight className="w-5 h-5" />
+      </button>
+    </div>
+  );
+}

--- a/client-interface/components/mentor/attendance/MenteeCarousel.tsx
+++ b/client-interface/components/mentor/attendance/MenteeCarousel.tsx
@@ -1,46 +1,88 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 interface MenteeCarouselProps {
   children: React.ReactNode;
 }
 
+/**
+ * Horizontal, snap-scrolling rail for the round attendance chips. Arrows only
+ * appear (and only on the side you can actually move toward) once the content
+ * overflows, and soft edge fades hint there's more off-screen. Scrollbar is
+ * hidden via the shared `.scrollbar-hide` utility; touch / trackpad still work.
+ */
 export function MenteeCarousel({ children }: MenteeCarouselProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [canLeft, setCanLeft] = useState(false);
+  const [canRight, setCanRight] = useState(false);
+
+  const update = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    setCanLeft(scrollLeft > 4);
+    setCanRight(scrollLeft + clientWidth < scrollWidth - 4);
+  }, []);
+
+  useEffect(() => {
+    update();
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener('scroll', update, { passive: true });
+    window.addEventListener('resize', update);
+    return () => {
+      el.removeEventListener('scroll', update);
+      window.removeEventListener('resize', update);
+    };
+  }, [update, children]);
 
   const scrollByAmount = (direction: 'left' | 'right') => {
-    if (scrollRef.current) {
-      // Assuming each card is ~256px wide + 12px gap. 2 cards ~ 536px
-      const scrollAmount = direction === 'left' ? -536 : 536;
-      scrollRef.current.scrollBy({ left: scrollAmount, behavior: 'smooth' });
-    }
+    const el = scrollRef.current;
+    if (!el) return;
+    // Page by ~80% of the visible width so a click always reveals fresh chips
+    // while keeping a couple in view for context.
+    const amount = Math.round(el.clientWidth * 0.8) * (direction === 'left' ? -1 : 1);
+    el.scrollBy({ left: amount, behavior: 'smooth' });
   };
 
   return (
-    <div className="relative group flex items-center">
-      <button
-        onClick={() => scrollByAmount('left')}
-        className="absolute left-0 z-10 -ml-4 w-8 h-8 flex items-center justify-center bg-white border border-slate-200 rounded-full shadow-sm text-slate-500 hover:text-slate-700 hover:border-slate-300 opacity-0 group-hover:opacity-100 transition-opacity"
-        aria-label="Scroll left"
-      >
-        <ChevronLeft className="w-5 h-5" />
-      </button>
+    <div className="relative">
+      {/* Left arrow + fade — only when there's something to the left. */}
+      {canLeft && (
+        <>
+          <div className="pointer-events-none absolute inset-y-0 left-0 w-12 z-10 bg-gradient-to-r from-card to-transparent rounded-l-xl" />
+          <button
+            type="button"
+            onClick={() => scrollByAmount('left')}
+            className="absolute left-1 top-1/2 -translate-y-1/2 z-20 w-8 h-8 flex items-center justify-center bg-card border border-slate-200 rounded-full shadow-sm text-slate-600 hover:text-slate-900 hover:border-slate-300 transition-colors"
+            aria-label="Scroll left"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </button>
+        </>
+      )}
 
       <div
         ref={scrollRef}
-        className="flex overflow-x-auto gap-3 py-2 scrollbar-hide snap-x snap-mandatory"
-        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+        className="flex overflow-x-auto gap-1 px-2 py-2 scrollbar-hide snap-x"
       >
         {children}
       </div>
 
-      <button
-        onClick={() => scrollByAmount('right')}
-        className="absolute right-0 z-10 -mr-4 w-8 h-8 flex items-center justify-center bg-white border border-slate-200 rounded-full shadow-sm text-slate-500 hover:text-slate-700 hover:border-slate-300 opacity-0 group-hover:opacity-100 transition-opacity"
-        aria-label="Scroll right"
-      >
-        <ChevronRight className="w-5 h-5" />
-      </button>
+      {/* Right arrow + fade — only when there's something further right. */}
+      {canRight && (
+        <>
+          <div className="pointer-events-none absolute inset-y-0 right-0 w-12 z-10 bg-gradient-to-l from-card to-transparent rounded-r-xl" />
+          <button
+            type="button"
+            onClick={() => scrollByAmount('right')}
+            className="absolute right-1 top-1/2 -translate-y-1/2 z-20 w-8 h-8 flex items-center justify-center bg-card border border-slate-200 rounded-full shadow-sm text-slate-600 hover:text-slate-900 hover:border-slate-300 transition-colors"
+            aria-label="Scroll right"
+          >
+            <ChevronRight className="w-5 h-5" />
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/client-interface/styles/globals.css
+++ b/client-interface/styles/globals.css
@@ -269,6 +269,18 @@ html[data-accent='graphite'] {
     text-wrap: balance;
   }
 
+  /* Hide the native scrollbar while keeping the element scrollable (touch /
+   * trackpad / arrow buttons still work). Tailwind v4 has no built-in for this,
+   * and the inline `scrollbar-width` style alone doesn't cover WebKit. Used by
+   * horizontal carousels (e.g. the cohort-review attendance strip). */
+  .scrollbar-hide {
+    scrollbar-width: none;          /* Firefox */
+    -ms-overflow-style: none;       /* old Edge / IE */
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;                  /* Chrome / Safari */
+  }
+
   /*
    * Frosted-glass surface for floating / elevated chrome — popovers, dropdown
    * menus, the ⌘K palette, drawers. Token-driven (uses --card / --border) so it

--- a/server/scripts/seed-demo.js
+++ b/server/scripts/seed-demo.js
@@ -15,6 +15,16 @@
  *   • real submissions (+ feedback on completed tasks) so the review flow works
  *   • a co-mentor promotion candidate awaiting admin approval
  *   • blockers, accepted delays, meeting notes, filled schedules, announcements
+ *   • cohort-review SESSIONS + attendance (last week finished + today in-progress)
+ *     so the weekly-review screen and the round attendance strip show real data
+ *   • 1:1 scheduling — open availability slots + booked meetings (upcoming /
+ *     completed / cancelled-with-reason) carrying real UTC instants + timezones
+ *   • direct-message threads (mentor ↔ mentee), and notifications for every role
+ *   • community posts across clan / program / global scopes (incl. a resolved
+ *     question with an accepted answer, kudos and a win) + comments + reactions
+ *   • anonymous mentor feedback (program_reviews, ≥3 each so the card unlocks)
+ *   • daily activity logs (streaks), badges + points history + a leaderboard
+ *   • roadmap chaining (Core → Advanced Patterns) and a sample bug report
  *
  * Idempotent: it always wipes and recreates the demo namespace (everything
  * scoped to @demo.pathment.com users + the demo program), so re-running gives
@@ -77,6 +87,49 @@ async function cleanupDemo() {
     await models.Enrollment.destroy(byMentee);
     await models.ClanMembership.destroy({ where: { userId: { [Op.in]: userIds } }, force: true });
     await models.Announcement.destroy({ where: { authorId: { [Op.in]: userIds } }, force: true });
+
+    // ── Newer feature tables (added after the original seeder) ────────────────
+    const userIn = { [Op.in]: userIds };
+    // Cohort review sessions + their attendance entries (entries first).
+    if (models.CohortReviewSession) {
+      const sessions = await models.CohortReviewSession.findAll({ where: { mentorId: userIn }, attributes: ["id"], paranoid: false });
+      const sessionIds = sessions.map((s) => s.id);
+      if (sessionIds.length && models.CohortReviewEntry) await models.CohortReviewEntry.destroy({ where: { sessionId: { [Op.in]: sessionIds } }, force: true });
+      if (models.CohortReviewUnlockRequest) await models.CohortReviewUnlockRequest.destroy({ where: { sessionId: { [Op.in]: sessionIds.length ? sessionIds : ["00000000-0000-0000-0000-000000000000"] } }, force: true });
+      await models.CohortReviewSession.destroy({ where: { mentorId: userIn }, force: true });
+    }
+    // 1:1 scheduling — meetings before the slots they reference.
+    if (models.ScheduledMeeting) await models.ScheduledMeeting.destroy({ where: { [Op.or]: [{ mentorId: userIn }, { menteeId: userIn }] }, force: true });
+    if (models.AvailabilitySlot) await models.AvailabilitySlot.destroy({ where: { mentorId: userIn }, force: true });
+    // Community — reactions + comments before posts.
+    if (models.CommunityPost) {
+      const posts = await models.CommunityPost.findAll({ where: { authorId: userIn }, attributes: ["id"], paranoid: false });
+      const postIds = posts.map((p) => p.id);
+      if (postIds.length) {
+        if (models.CommunityReaction) await models.CommunityReaction.destroy({ where: { postId: { [Op.in]: postIds } }, force: true });
+        if (models.CommunityComment) await models.CommunityComment.destroy({ where: { postId: { [Op.in]: postIds } }, force: true });
+      }
+      if (models.CommunityReaction) await models.CommunityReaction.destroy({ where: { userId: userIn }, force: true });
+      if (models.CommunityComment) await models.CommunityComment.destroy({ where: { authorId: userIn }, force: true });
+      await models.CommunityPost.destroy({ where: { authorId: userIn }, force: true });
+    }
+    // Messaging — messages + participants before conversations.
+    if (models.Conversation) {
+      const convos = await models.Conversation.findAll({ where: { createdBy: userIn }, attributes: ["id"], paranoid: false });
+      const convoIds = convos.map((c) => c.id);
+      if (models.Message) await models.Message.destroy({ where: { [Op.or]: [{ senderId: userIn }, { recipientId: userIn }] }, force: true });
+      if (convoIds.length && models.ConversationParticipant) await models.ConversationParticipant.destroy({ where: { conversationId: { [Op.in]: convoIds } }, force: true });
+      if (models.ConversationParticipant) await models.ConversationParticipant.destroy({ where: { userId: userIn }, force: true });
+      await models.Conversation.destroy({ where: { createdBy: userIn }, force: true });
+    }
+    if (models.Notification) await models.Notification.destroy({ where: { userId: userIn }, force: true });
+    if (models.DailyLogEntry) await models.DailyLogEntry.destroy({ where: { menteeId: userIn }, force: true });
+    if (models.PointsHistory) await models.PointsHistory.destroy({ where: { userId: userIn }, force: true });
+    if (models.UserBadge) await models.UserBadge.destroy({ where: { userId: userIn }, force: true });
+    if (models.LeaderboardEntry) await models.LeaderboardEntry.destroy({ where: { userId: userIn }, force: true });
+    if (models.ProgramReview) await models.ProgramReview.destroy({ where: { [Op.or]: [{ reviewerId: userIn }, { mentorId: userIn }] }, force: true });
+    if (models.FeedbackReport) await models.FeedbackReport.destroy({ where: { reporterId: userIn }, force: true });
+    if (models.ProductUpdate) await models.ProductUpdate.destroy({ where: { createdBy: userIn }, force: true });
   }
   if (program) {
     const roadmaps = await models.Roadmap.findAll({ where: { programId: program.id }, attributes: ["id"], paranoid: false });
@@ -84,6 +137,8 @@ async function cleanupDemo() {
     if (rmIds.length) {
       // RoadmapProgress references roadmaps (the local copies) — clear any strays.
       if (models.RoadmapProgress) await models.RoadmapProgress.destroy({ where: { roadmapId: { [Op.in]: rmIds } }, force: true });
+      // Chaining links between demo roadmaps (either direction).
+      if (models.RoadmapLink) await models.RoadmapLink.destroy({ where: { [Op.or]: [{ fromRoadmapId: { [Op.in]: rmIds } }, { toRoadmapId: { [Op.in]: rmIds } }] }, force: true });
       await models.RoadmapTask.destroy({ where: { roadmapId: { [Op.in]: rmIds } }, force: true });
     }
     await models.Roadmap.destroy({ where: { programId: program.id }, force: true });
@@ -122,10 +177,8 @@ async function makeUser({ first, last, emailLocal, role, occupation, lastActivit
       userId: user.id,
       permissions: ["all"],
       canManageUsers: true,
-      canManagePrograms: true,
-      canManageContent: true,
+      canCreatePrograms: true,
       canViewAnalytics: true,
-      canManageSettings: true,
     });
   } else if (role === "mentor") {
     await models.MentorProfile.create({
@@ -539,7 +592,7 @@ async function seed() {
   // ── Meeting notes (1:1s with a personality read) ──────────────────────────────
   await models.MeetingNote.create({
     menteeId: mentees["mentee.maya"].user.id, mentorId: aisha.id, createdBy: aisha.id,
-    date: daysAgo(4), type: "1:1", sentiment: "positive",
+    date: daysAgo(4), kind: "1:1", sentiment: "positive",
     summary: "Maya is well ahead and ready for a stretch goal. Walked through the API task early.",
     issues: [], nextSteps: ["Start the Express auth task", "Pair with a peer on testing"],
     personalityRead: "Highly self-directed, learns fast, thrives on autonomy.",
@@ -548,7 +601,7 @@ async function seed() {
   });
   await models.MeetingNote.create({
     menteeId: noor.id, mentorId: omar.id, createdBy: omar.id,
-    date: daysAgo(3), type: "1:1", sentiment: "neutral",
+    date: daysAgo(3), kind: "1:1", sentiment: "neutral",
     summary: "Noor is juggling a full-time job. Behind on raw % but clearly putting in real effort. Logged delays as accepted.",
     issues: ["Limited weekday hours"], nextSteps: ["Break the API task into smaller chunks", "Check in mid-week"],
     personalityRead: "Conscientious and honest about constraints; communicates blockers early.",
@@ -558,7 +611,7 @@ async function seed() {
 
   // ── Schedules (org template + a couple of filled mentee schedules) ────────────
   const orgTemplate = await models.ScheduleTemplate.create({
-    name: "Fellowship Weekly Rhythm", scope: "org", createdBy: admin.id,
+    name: "Fellowship Weekly Rhythm", source: "org", createdBy: admin.id,
     blocks: [
       { day: "Monday", label: "Clan standup", start: "09:00", end: "09:30" },
       { day: "Wednesday", label: "Focused build time", start: "14:00", end: "17:00" },
@@ -669,6 +722,393 @@ async function seed() {
     console.log("✅ Promotion candidate created (Maya — awaiting admin)\n");
   }
 
+  // ════════════════════════════════════════════════════════════════════════════
+  //  Newer feature areas (these tables didn't exist when the seeder was first
+  //  written, so the demo looked empty on those screens). Everything below is
+  //  scoped to demo users / the demo program and torn down by cleanupDemo().
+  // ════════════════════════════════════════════════════════════════════════════
+
+  // Small date helpers for the new sections.
+  const ymd = (d) => d.toISOString().slice(0, 10); // DATEONLY 'YYYY-MM-DD'
+  const dayLabel = (d) => d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+  const TZ = "Asia/Karachi";
+
+  // Resolved mentee records with their clan + lead mentor (used throughout).
+  const menteeList = menteeSpecs.map((s) => ({
+    user: mentees[s.local].user,
+    spec: s,
+    clan: s.clan === "FE" ? feClan : beClan,
+    mentor: s.clan === "FE" ? aisha : omar,
+  }));
+  const feMentees = menteeList.filter((m) => m.spec.clan === "FE");
+  const beMentees = menteeList.filter((m) => m.spec.clan === "BE");
+  const byLocal = (l) => mentees[l].user;
+
+  // ── Cohort review sessions + attendance ──────────────────────────────────────
+  // One finished review from last week (fully marked) + today's in-progress one
+  // (only some marked, so the new round attendance strip shows real + "not yet
+  // marked" states). This is what powers /mentor/review and the attendance UI.
+  if (models.CohortReviewSession && models.CohortReviewEntry) {
+    console.log("📋 Seeding cohort review sessions & attendance…");
+    const ATT_BY_ARCH = {
+      star: "present", on_track: "present", review: "present", average: "present",
+      fighting: "present", watch: "excused", disengaged: "absent", new: "present",
+    };
+    async function seedReview(clan, mentor, clanMentees) {
+      // Last week — a finished, fully-marked review.
+      const finished = await models.CohortReviewSession.create({
+        mentorId: mentor.id, clanId: clan.id, sessionDate: ymd(daysAgo(7)),
+        title: "Weekly review — last week", status: "finished", finishedAt: daysAgo(7),
+        note: "Solid momentum overall. Flagged two mentees for closer follow-up this week.",
+      });
+      for (const m of clanMentees) {
+        await models.CohortReviewEntry.create({
+          sessionId: finished.id, menteeId: m.user.id,
+          attendance: ATT_BY_ARCH[m.spec.archetype] || "present", status: "reviewed",
+        });
+      }
+      // Today — in-progress: mark roughly the first half, leave the rest unmarked.
+      const today = await models.CohortReviewSession.create({
+        mentorId: mentor.id, clanId: clan.id, sessionDate: ymd(new Date()),
+        title: "Weekly review", status: "in_progress", note: null,
+      });
+      const half = Math.ceil(clanMentees.length / 2);
+      for (let i = 0; i < clanMentees.length; i++) {
+        const m = clanMentees[i];
+        if (i < half) {
+          await models.CohortReviewEntry.create({
+            sessionId: today.id, menteeId: m.user.id,
+            attendance: ATT_BY_ARCH[m.spec.archetype] || "present", status: "reviewed",
+          });
+        }
+        // The rest get no entry yet → they render as "not marked" in the strip.
+      }
+    }
+    await seedReview(feClan, aisha, feMentees);
+    await seedReview(beClan, omar, beMentees);
+    console.log("✅ Cohort review sessions + attendance created (last week + today)\n");
+  }
+
+  // ── 1:1 scheduling — availability slots + booked meetings ─────────────────────
+  if (models.AvailabilitySlot && models.ScheduledMeeting) {
+    console.log("🗓️  Seeding availability slots & 1:1 meetings…");
+    async function openSlot(mentor, daysFromNow, hour) {
+      const at = daysAhead(daysFromNow); at.setHours(hour, 0, 0, 0);
+      return models.AvailabilitySlot.create({
+        mentorId: mentor.id, day: dayLabel(at), date: ymd(at),
+        time: `${String(hour).padStart(2, "0")}:00`, durationMins: 30, startsAt: at, timezone: TZ,
+      });
+    }
+    async function book(mentor, mentee, daysFromNow, hour, status, reason) {
+      const at = daysFromNow >= 0 ? daysAhead(daysFromNow) : daysAgo(-daysFromNow);
+      at.setHours(hour, 0, 0, 0);
+      const time = `${String(hour).padStart(2, "0")}:00`;
+      const slot = await models.AvailabilitySlot.create({
+        mentorId: mentor.id, day: dayLabel(at), date: ymd(at), time, durationMins: 30,
+        startsAt: at, timezone: TZ, taken: true, takenBy: mentee.id,
+      });
+      await models.ScheduledMeeting.create({
+        mentorId: mentor.id, menteeId: mentee.id, availabilitySlotId: slot.id, kind: "1:1",
+        day: dayLabel(at), time, durationMins: 30, startsAt: at, timezone: TZ, status,
+        agenda: status === "cancelled" ? "Unblock the API task" : "Weekly 1:1 — progress, blockers & next steps",
+        cancellationReason: reason || null, cancelledBy: reason ? mentee.id : null,
+      });
+    }
+    // A few open slots each, then some booked meetings spanning the lifecycle.
+    for (const mentor of [aisha, omar]) {
+      await openSlot(mentor, 1, 11);
+      await openSlot(mentor, 2, 15);
+      await openSlot(mentor, 4, 16);
+    }
+    await book(aisha, byLocal("mentee.maya"), 2, 14, "scheduled");
+    await book(aisha, byLocal("mentee.leo"), -3, 15, "completed");
+    await book(omar, byLocal("mentee.noor"), 1, 16, "scheduled");
+    await book(omar, byLocal("mentee.priya"), -1, 13, "cancelled", "Hit a work deadline — will rebook for next week.");
+    console.log("✅ Availability slots + 1:1 meetings created (open / upcoming / completed / cancelled)\n");
+  }
+
+  // ── Direct messages (mentor ↔ mentee threads) ────────────────────────────────
+  if (models.Conversation && models.ConversationParticipant && models.Message) {
+    console.log("✉️  Seeding direct message threads…");
+    async function thread(a, b, msgs) {
+      const directKey = [a.id, b.id].sort().join(":");
+      const convo = await models.Conversation.create({
+        type: "direct", createdBy: a.id, metadata: { directKey },
+      });
+      await models.ConversationParticipant.bulkCreate([
+        { conversationId: convo.id, userId: a.id, role: "owner" },
+        { conversationId: convo.id, userId: b.id, role: "participant" },
+      ]);
+      let last = null;
+      for (const m of msgs) {
+        const sender = m.from === "a" ? a : b;
+        const recipient = m.from === "a" ? b : a;
+        const when = daysAgo(m.ago);
+        last = await models.Message.create({
+          senderId: sender.id, recipientId: recipient.id, threadId: convo.id,
+          messageText: m.text, isRead: !!m.read, readAt: m.read ? daysAgo(Math.max(0, m.ago - 1)) : null,
+          deliveredAt: when, createdAt: when, updatedAt: when,
+        });
+      }
+      if (last) await convo.update({ lastMessageId: last.id, lastMessageAt: last.createdAt }, { silent: true });
+    }
+    await thread(byLocal("mentee.maya"), aisha, [
+      { from: "a", text: "Hi Aisha! I finished the React dashboard early — could I get a stretch goal?", ago: 4, read: true },
+      { from: "b", text: "Love the energy 🙌 Take a look at the Express auth task and let's pair on testing Friday.", ago: 4, read: true },
+      { from: "a", text: "On it. Thank you!", ago: 3, read: true },
+    ]);
+    await thread(byLocal("mentee.noor"), omar, [
+      { from: "a", text: "Omar, work's been brutal this week. I logged the delays but I'm stuck on the JWT refresh flow.", ago: 3, read: true },
+      { from: "b", text: "No worries Noor — you've been honest and consistent. Let's break the API task into smaller chunks on our 1:1.", ago: 2, read: true },
+      { from: "b", text: "Also dropped a couple of links in your task feedback. Shout if they don't help.", ago: 1, read: false },
+    ]);
+    await thread(byLocal("mentee.priya"), omar, [
+      { from: "a", text: "Submitted both tasks for review — keen to hear your thoughts whenever you get a sec!", ago: 1, read: false },
+    ]);
+    console.log("✅ Direct message threads created\n");
+  }
+
+  // ── Notifications (the bell — varied types, read + unread) ────────────────────
+  if (models.Notification) {
+    console.log("🔔 Seeding notifications…");
+    const notify = (userId, type, title, message, o = {}) => models.Notification.create({
+      userId, type, title, message, status: o.read ? "read" : "unread",
+      actionUrl: o.actionUrl || null, actionLabel: o.actionLabel || null,
+      relatedEntityType: o.ret || null, relatedEntityId: o.reid || null,
+      readAt: o.read ? daysAgo(Math.max(0, (o.ago ?? 1) - 1)) : null,
+      sentAt: daysAgo(o.ago ?? 1), createdAt: daysAgo(o.ago ?? 1), updatedAt: daysAgo(o.ago ?? 1),
+    });
+    // Mentors
+    await notify(omar.id, "task", "Priya submitted 2 tasks for review", "Priya Sharma has work waiting on your review.", { actionUrl: "/mentor/approvals", actionLabel: "Review", ago: 1 });
+    await notify(omar.id, "system", "Noor logged a blocker", "“Stuck on JWT refresh-token flow” — Noor Hassan.", { actionUrl: "/mentor/mentees", ago: 1 });
+    await notify(aisha.id, "task", "Maya submitted a task", "Maya Patel submitted “React components & state”.", { actionUrl: "/mentor/approvals", actionLabel: "Review", ago: 2, read: true });
+    await notify(aisha.id, "milestone", "Maya is ready for more", "Maya is well ahead of pace — consider a stretch goal.", { actionUrl: "/mentor/mentees", ago: 3, read: true });
+    // Admin
+    await notify(admin.id, "milestone", "Maya nominated for co-mentor", "Aisha nominated Maya Patel. Awaiting your approval.", { actionUrl: "/admin/promotions", actionLabel: "Open", ago: 2 });
+    // Mentees
+    await notify(byLocal("mentee.maya").id, "feedback", "Your task was approved 🎉", "Aisha approved “React components & state”. Nice work!", { actionUrl: "/mentee/tasks", actionLabel: "View", ago: 2, read: true });
+    await notify(byLocal("mentee.noor").id, "task", "New task assigned", "Omar assigned “REST APIs with Node & Express”.", { actionUrl: "/mentee/tasks", actionLabel: "Start", ago: 1 });
+    await notify(byLocal("mentee.sara").id, "system", "Your mentor checked in", "Aisha sent you a nudge — jump back in when you can.", { actionUrl: "/mentee/dashboard", ago: 1 });
+    await notify(byLocal("mentee.priya").id, "feedback", "Feedback received", "Omar left feedback on your submission.", { actionUrl: "/mentee/tasks", ago: 1 });
+    console.log("✅ Notifications created (mentors, admin & mentees)\n");
+  }
+
+  // ── Community posts + comments + reactions ────────────────────────────────────
+  // Scopes: clan-private, program-wide, and global. Includes a resolved question
+  // with an accepted answer and some kudos, so every community surface has life.
+  if (models.CommunityPost && models.CommunityComment && models.CommunityReaction) {
+    console.log("💬 Seeding community posts, comments & reactions…");
+    const REACTIONS = ["like", "celebrate", "insightful", "helpful"];
+    async function makePost(author, o) {
+      const p = await models.CommunityPost.create({
+        authorId: author.id, type: o.type || "discussion",
+        scopeType: o.scopeType, scopeId: o.scopeId || null,
+        title: o.title || null, body: o.body, toId: o.toId || null,
+        tags: o.tags || [], resolved: !!o.resolved, commentCount: 0,
+        createdAt: daysAgo(o.ago ?? 2), updatedAt: daysAgo(o.ago ?? 2),
+      });
+      let acceptedCommentId = null;
+      const comments = o.comments || [];
+      for (let i = 0; i < comments.length; i++) {
+        const c = comments[i];
+        const comment = await models.CommunityComment.create({
+          postId: p.id, authorId: c.author.id, body: c.body,
+          createdAt: daysAgo(c.ago ?? 1), updatedAt: daysAgo(c.ago ?? 1),
+        });
+        if (c.accepted) acceptedCommentId = comment.id;
+      }
+      const reactors = o.reactors || [];
+      for (let i = 0; i < reactors.length; i++) {
+        await models.CommunityReaction.create({
+          postId: p.id, userId: reactors[i].id, type: REACTIONS[i % REACTIONS.length],
+        });
+      }
+      const patch = { commentCount: comments.length };
+      if (acceptedCommentId) patch.acceptedCommentId = acceptedCommentId;
+      await p.update(patch, { silent: true });
+      return p;
+    }
+    // Frontend clan — a resolved question with an accepted answer.
+    await makePost(byLocal("mentee.leo"), {
+      type: "question", scopeType: "clan", scopeId: feClan.id, resolved: true,
+      title: "How do you structure React context for a multi-view dashboard?",
+      body: "I keep prop-drilling. Splitting into multiple contexts vs one big store — what do you all do?",
+      tags: ["react", "state"], ago: 3,
+      comments: [
+        { author: byLocal("mentee.maya"), body: "Split by concern — one context per domain. Way easier to test.", accepted: true, ago: 2 },
+        { author: aisha, body: "Great answer Maya. Leo, start with 2–3 small contexts and only reach for a store if it gets noisy.", ago: 2 },
+      ],
+      reactors: [byLocal("mentee.maya"), aisha, byLocal("mentee.tom")],
+    });
+    // Frontend clan — a kudos shout-out.
+    await makePost(aisha, {
+      type: "kudos", scopeType: "clan", scopeId: feClan.id, toId: byLocal("mentee.maya").id,
+      body: "Big shout-out to Maya for helping two peers unblock this week 👏", ago: 1,
+      reactors: [byLocal("mentee.leo"), byLocal("mentee.tom"), omar],
+    });
+    // Backend clan — a real blocker turned discussion.
+    await makePost(byLocal("mentee.noor"), {
+      type: "question", scopeType: "clan", scopeId: beClan.id,
+      title: "JWT refresh-token rotation — where do you store the refresh token?",
+      body: "httpOnly cookie vs DB session table? Trying to get the security right without overcomplicating.",
+      tags: ["node", "auth", "security"], ago: 2,
+      comments: [{ author: omar, body: "httpOnly + secure cookie for the refresh token, rotate on use, keep a server-side allowlist. We'll walk through it on our 1:1.", ago: 1 }],
+      reactors: [byLocal("mentee.priya"), byLocal("mentee.ivan")],
+    });
+    // Program-wide win + a global welcome.
+    await makePost(byLocal("mentee.priya"), {
+      type: "win", scopeType: "program", scopeId: program.id,
+      body: "Shipped my first CRUD API with auth today 🚀 Three weeks ago I'd never touched Express. Thank you mentors!",
+      tags: ["milestone"], ago: 2,
+      reactors: [aisha, omar, byLocal("mentee.maya"), byLocal("mentee.noor")],
+    });
+    await makePost(admin, {
+      type: "discussion", scopeType: "global",
+      title: "Welcome to the Spring 2026 Fellowship 👋",
+      body: "Introduce yourself, find your clan, and don't be shy about asking questions here. We're all building together.",
+      ago: 6, reactors: [aisha, omar, byLocal("mentee.leo"), byLocal("mentee.jack")],
+    });
+    console.log("✅ Community posts, comments & reactions created\n");
+  }
+
+  // ── Anonymous mentor feedback (program_reviews) ───────────────────────────────
+  // ≥3 reviews per mentor so the mentor's "How your mentees rate you" card
+  // unlocks (the reveal gate is 3) and admin moderation has data.
+  if (models.ProgramReview) {
+    console.log("⭐ Seeding anonymous mentor feedback…");
+    const dims = (a, b, c, d) => ({ responsiveness: a, helpfulness: b, clarity: c, support: d });
+    async function review(reviewer, mentor, rating, d, text, rec) {
+      await models.ProgramReview.create({
+        programId: program.id, reviewerId: reviewer.id, mentorId: mentor.id,
+        rating, dimensions: d, reviewText: text || null, wouldRecommend: rec,
+        mentorQualityRating: rating,
+      });
+    }
+    // Aisha (Frontend lead) — 4 reviews.
+    await review(byLocal("mentee.maya"), aisha, 5, dims(5, 5, 5, 5), "Aisha pushes me with stretch goals and always replies fast. Best mentor I've had.", true);
+    await review(byLocal("mentee.leo"), aisha, 4.5, dims(4, 5, 5, 4), "Explains tricky React concepts really clearly.", true);
+    await review(byLocal("mentee.tom"), aisha, 4, dims(4, 4, 4, 5), "Patient with beginners — never makes you feel behind.", true);
+    await review(byLocal("mentee.sara"), aisha, 4, dims(3, 4, 4, 5), null, true);
+    // Omar (Backend lead) — 4 reviews.
+    await review(byLocal("mentee.noor"), omar, 5, dims(5, 5, 4, 5), "Omar gets that life happens. Practical, honest, and breaks big problems down.", true);
+    await review(byLocal("mentee.priya"), omar, 4.5, dims(5, 4, 5, 4), "Fast, detailed code review. I learn something every time.", true);
+    await review(byLocal("mentee.ivan"), omar, 4, dims(4, 4, 4, 4), "Solid backend depth and good with deadlines.", true);
+    await review(byLocal("mentee.jack"), omar, 3.5, dims(4, 3, 4, 4), null, true);
+    console.log("✅ Mentor feedback created (Aisha ×4, Omar ×4 — above the reveal gate)\n");
+  }
+
+  // ── Daily activity logs (drive streaks / activity heat) ───────────────────────
+  if (models.DailyLogEntry) {
+    console.log("🔥 Seeding daily activity logs…");
+    for (const m of menteeList) {
+      const st = MENTEE_STATS[m.spec.archetype] || MENTEE_STATS.average;
+      const streak = st.streak || 0;
+      for (let i = 0; i < streak && i < 21; i++) {
+        const d = daysAgo(i);
+        await models.DailyLogEntry.create({
+          menteeId: m.user.id, dateKey: ymd(d),
+          note: i === 0 ? "Logged today's progress." : null, loggedAt: d,
+        });
+      }
+    }
+    console.log("✅ Daily activity logs created (per-mentee streaks)\n");
+  }
+
+  // ── Gamification — badges, points history & leaderboard ───────────────────────
+  if (models.Badge && models.UserBadge && models.PointsHistory) {
+    console.log("🏅 Seeding badges, points history & leaderboard…");
+    const BADGES = [
+      { name: "First Steps", description: "Completed your first task.", category: "milestone", criteriaType: "tasks_completed", criteriaValue: { count: 1 }, pointsReward: 20 },
+      { name: "On Fire", description: "Reached a 7-day streak.", category: "streak", criteriaType: "streak_days", criteriaValue: { days: 7 }, pointsReward: 50 },
+      { name: "Halfway Hero", description: "Crossed 50% program progress.", category: "progress", criteriaType: "progress_pct", criteriaValue: { pct: 50 }, pointsReward: 75 },
+      { name: "Peer Helper", description: "Helped peers in the community.", category: "community", criteriaType: "community_kudos", criteriaValue: { count: 1 }, pointsReward: 40 },
+    ];
+    const badgeByName = {};
+    for (const b of BADGES) {
+      const [row] = await models.Badge.findOrCreate({ where: { name: b.name }, defaults: b });
+      badgeByName[b.name] = row;
+    }
+    const award = async (user, names) => {
+      for (const n of names) {
+        const b = badgeByName[n];
+        if (b) await models.UserBadge.create({ userId: user.id, badgeId: b.id, unlockedAt: daysAgo(3) });
+      }
+    };
+    // Award by archetype, and lay down a couple of points-history rows each.
+    for (const m of menteeList) {
+      const st = MENTEE_STATS[m.spec.archetype] || MENTEE_STATS.average;
+      const earned = [];
+      if (st.tasks >= 1) earned.push("First Steps");
+      if (st.streak >= 7) earned.push("On Fire");
+      if ((m.spec.archetype === "star") || (m.spec.archetype === "on_track")) earned.push("Halfway Hero");
+      if (m.spec.archetype === "star") earned.push("Peer Helper");
+      await award(m.user, earned);
+      // Points history — a small ledger so the points page isn't blank.
+      let running = 0;
+      const events = [];
+      if (st.tasks >= 1) events.push({ change: 10, reason: "Completed “Semantic HTML & accessible layout”", ago: 30 });
+      if (st.tasks >= 2) events.push({ change: 12, reason: "Completed “Modern CSS & responsive design”", ago: 16 });
+      if (st.streak >= 7) events.push({ change: 50, reason: "Earned the On Fire badge", ago: 5 });
+      for (const e of events) {
+        const before = running; running += e.change;
+        await models.PointsHistory.create({
+          userId: m.user.id, pointsChange: e.change, pointsBefore: before, pointsAfter: running,
+          sourceType: "task", reason: e.reason, createdAt: daysAgo(e.ago), updatedAt: daysAgo(e.ago),
+        });
+      }
+    }
+    // Program leaderboard (all-time), ranked by the points we set on profiles.
+    if (models.LeaderboardEntry) {
+      const ranked = [...menteeList]
+        .map((m) => ({ user: m.user, points: (MENTEE_STATS[m.spec.archetype] || MENTEE_STATS.average).points }))
+        .sort((a, b) => b.points - a.points);
+      for (let i = 0; i < ranked.length; i++) {
+        await models.LeaderboardEntry.create({
+          userId: ranked[i].user.id, programId: program.id, rank: i + 1, points: ranked[i].points,
+          periodType: "all_time", periodStart: ymd(daysAgo(7 * 7)), periodEnd: ymd(new Date()),
+        });
+      }
+    }
+    console.log("✅ Badges, points history & leaderboard created\n");
+  }
+
+  // ── Roadmap chaining — a follow-on roadmap linked after the core one ──────────
+  if (models.RoadmapLink) {
+    console.log("🔗 Seeding roadmap chaining…");
+    const advanced = await models.Roadmap.create({
+      programId: program.id, name: "Advanced Patterns & Deployment",
+      description: "The follow-on track after the core roadmap: testing, CI/CD and shipping to production.",
+      isBaseRoadmap: false, source: "org", published: true, totalWeeks: 4, totalTasks: 3,
+      skillTags: ["testing", "ci/cd", "docker", "deployment"],
+    });
+    const advTasks = [
+      { title: "Testing with Jest & React Testing Library", type: "project", difficulty: "medium" },
+      { title: "CI/CD pipeline with GitHub Actions", type: "practical", difficulty: "hard" },
+      { title: "Containerize & deploy with Docker", type: "project", difficulty: "hard" },
+    ];
+    for (let i = 0; i < advTasks.length; i++) {
+      await models.RoadmapTask.create({
+        roadmapId: advanced.id, title: advTasks[i].title,
+        description: `${advTasks[i].title}. Build, then submit for mentor review.`,
+        type: advTasks[i].type, difficulty: advTasks[i].difficulty, taskOrder: i + 1,
+        estimatedHours: 10, pointsBase: 14 + i * 2,
+      });
+    }
+    await models.RoadmapLink.create({ fromRoadmapId: roadmap.id, toRoadmapId: advanced.id, position: 0, createdBy: admin.id });
+    console.log("✅ Roadmap chaining created (Core → Advanced Patterns)\n");
+  }
+
+  // ── A sample bug report (admin feedback inbox) ────────────────────────────────
+  if (models.FeedbackReport) {
+    await models.FeedbackReport.create({
+      reporterId: byLocal("mentee.ivan").id, reporterRole: "mentee", type: "bug",
+      title: "Task deadline shows the wrong day on mobile",
+      description: "On my phone the due date is a day behind what the web shows. Might be a timezone thing.",
+      status: "open", priority: "normal", pageUrl: "/mentee/tasks",
+    });
+    console.log("✅ Sample bug report created (admin feedback inbox)\n");
+  }
+
   console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
   console.log("🎉 Demo data ready!  All accounts use password:  " + DEMO_PASSWORD);
   console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
@@ -681,6 +1121,11 @@ async function seed() {
   console.log("  Mentee   mentee.noor" + DEMO_DOMAIN + "    (struggling, fighting)");
   console.log("  Mentee   mentee.priya" + DEMO_DOMAIN + "   (submissions awaiting review)");
   console.log("  …+ 4 more mentees spanning on-track / watch / new");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log("  Now also seeded: cohort-review sessions + attendance, 1:1 slots");
+  console.log("  & meetings, DM threads, notifications, community posts, anonymous");
+  console.log("  mentor feedback, daily streaks, badges/points/leaderboard, roadmap");
+  console.log("  chaining (Core → Advanced) and a sample bug report.");
   console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
 }
 


### PR DESCRIPTION
 ## Description

  Builds on @hussainjamal760's attendance work for the Cohort Review screen and
  polishes it into a production-ready feature.

  **Attendance UI (mentor → Cohort Review)**                             
  - Replaces the old flat progress dots with an **Instagram-story-style attendance strip**:
    circular avatars (photo or initials) in a status-coloured ring
    — 🟢 present · 🔴 absent · 🟡 excused · ⚪ not-marked — each with a badge (✓ / ✗ / – / ?).
  - The mentee currently being reviewed gets a separate brand "you are here" halo.
  - Smooth horizontal **carousel**: scroll-snap, edge-aware arrows (only show on the
    side you can move toward), soft fade masks, and a live `marked/total · present · absent · excused` tally.
  - **"Attendance Sheet"** drawer for bulk marking — now always manages the **whole**
    cohort (fixes a bug where "Mark all present" while filtered only marked the visible subset).

  **Integration fixes on the original work**
  - Added a real `.scrollbar-hide` utility (the class didn't exist → scrollbar showed on Chrome/Safari).
  - Reused the shared `getInitials` helper instead of two local reimplementations.
  - Wired `profilePictureUrl` through so cards show real photos.
  - `patchMultipleEntries` now accepts `null` (clearing a mark drops status back to `pending`) — fixes a type error.

  **Also included in this branch** (heads-up for reviewers — unrelated to attendance):
  - **Demo seeder upgrade** (`server/scripts/seed-demo.js`): adds cohort-review sessions +
    attendance, 1:1 scheduling, notifications, community posts, anonymous mentor feedback,
    daily streaks, badges/points/leaderboard, roadmap chaining, and a sample bug report —
    so every newer feature screen shows real data. Also fixed 3 latent wrong-field-name bugs
    in the original seeder (`scope`→`source`, `type`→`kind`, `canManagePrograms`→`canCreatePrograms`).
    _Can be split into its own PR if preferred._

  Original commit by @hussainjamal760 is preserved with attribution.

  ## Related Issue

  Supersedes hussainjamal760/pathment#<his-PR-number> · Closes #<ENH-23 if filed>

  ## Type of Change                                     
   - [x] New feature
  - [x] Bug fix
  - [ ] Documentation update
  - [ ] Refactor

  ## Validation Checklist

  - [ ] I ran lint checks for impacted app(s)
  - [x] I ran build checks for impacted app(s) — `next build` ✓ compiled, `tsc --noEmit` ✓ 0 errors; `/mentor/review` stays statically prerendered
  - [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change — seeder validated end-to-end offline (all model fields verified); no UI test
  suite covers this screen
  - [ ] I updated documentation where needed

  <!-- TODO: add before/after of the Cohort Review attendance strip
       (old dots → new circular cards) + the Attendance Sheet drawer -->