### PR TITLE
fix:gamification points history displays the raw Task ID

### DIFF
--- a/server/src/services/submissionService.js
+++ b/server/src/services/submissionService.js
@@ -117,7 +117,7 @@ class SubmissionService {
     });
 
     // Re-engagement: a paused mentee who submits work has come back → resume.
-    require('./mentorshipPauseService').autoResumeIfPaused(task.menteeId, 'submitted work').catch(() => {});
+    require('./mentorshipPauseService').autoResumeIfPaused(task.menteeId, 'submitted work').catch(() => { });
 
     // Return complete submission with files
     const fullSubmission = await this.getSubmissionById(submission.id);
@@ -284,7 +284,7 @@ class SubmissionService {
 
     //  ADD: Send notification to mentee
     const updatedSubmission = await this.getSubmissionById(submissionId);
-    
+
     await notificationOrchestrator.dispatch({
       eventKey: NOTIFICATION_EVENTS.EXTENSION_HANDLED,
       recipients: [{ userId: submission.assignedTask.menteeId }],
@@ -364,7 +364,7 @@ class SubmissionService {
 
     // Create feedback
     const feedbackType = inlineFeedback && inlineFeedback.length > 0 ? 'both' : 'general';
-    
+
     await models.TaskFeedback.create({
       assignedTaskId: task.id,
       submissionId: submission.id,
@@ -432,7 +432,7 @@ class SubmissionService {
             pointsToAward,
             'task_completed',
             task.id,
-            `Task completed: "${task.title || task.id}"`
+            `Task completed: "${task.roadmapTask?.title || task.id}"`
           );
         }
 
@@ -747,7 +747,7 @@ class SubmissionService {
       const publicId = publicIdWithExt.replace(/\.[^/.]+$/, '');
       const cloudinaryResourceType = (file.fileType || '').startsWith('video/') ? 'video'
         : (file.fileType || '').startsWith('image/') ? 'image'
-        : 'raw';
+          : 'raw';
       await deleteFromCloudinary(publicId, cloudinaryResourceType);
     } catch (error) {
       console.error('Error deleting from Cloudinary:', error);


### PR DESCRIPTION
## Description

This PR fixes a bug in the gamification system where the mentee's Points History was displaying the raw Task ID (e.g. `ca34b5e3...`) instead of the actual Task Title when a task was approved. 

The issue occurred because the backend was attempting to read the `title` field directly from the `AssignedTask` model, which does not have one. The title actually resides on the associated `RoadmapTask` model. This PR updates `submissionService.js` to correctly pull the title from the joined `RoadmapTask` (`task.roadmapTask?.title`), falling back to the task ID only if the title is truly unavailable.

## Related Issue

 Closes #509 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed


*N/A - Backend data fix. The frontend Points History will now correctly display "Task completed: [Title]" for newly approved tasks.*
