### PR TITLE
Feature/admin mentee profile responsive fixes

### DIFF
--- a/client-interface/app/admin/mentees/[id]/page.tsx
+++ b/client-interface/app/admin/mentees/[id]/page.tsx
@@ -127,7 +127,9 @@ export default function AdminMenteeProfilePage() {
             <div className="space-y-3">
               <a href={`mailto:${mentee.email}`} className="flex items-center gap-3 text-sm text-slate-600 hover:text-brand-600 transition-colors">
                 <Mail className="w-4 h-4 text-slate-400 shrink-0" />
-                {mentee.email}
+                 <span className="truncate">
+                   {mentee.email}
+                 </span>
               </a>
               {mp?.currentEducation && (
                 <div className="flex items-center gap-3 text-sm text-slate-600">
@@ -222,11 +224,11 @@ export default function AdminMenteeProfilePage() {
         <div className="lg:col-span-2 space-y-6">
 
           {/* Stats grid */}
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4 gap-4">
             <StatsCard icon={TrendingUp}   label="Progress"        value={`${overallProgress}%`}                           colorClass="text-brand-600 bg-brand-50" />
             <StatsCard icon={CheckCircle2} label="Tasks Completed"  value={`${tasksCompleted}/${stats?.tasksTotal ?? tasksCompleted}`} colorClass="text-green-600 bg-green-50" />
             <StatsCard icon={Trophy}       label="Points"           value={points.toLocaleString()}                        colorClass="text-amber-600 bg-amber-50" />
-            <StatsCard icon={Users2}       label="Clan"             value={stats?.currentClanName ?? currentClan?.name ?? '-'} colorClass="text-purple-600 bg-purple-50" />
+            <StatsCard icon={Users2}       label="Clan"             value={stats?.currentClanName ?? currentClan?.name ?? '-'} colorClass="text-purple-600 bg-purple-50"   />
           </div>
 
           {/* Weekly schedule (read-only; the mentor fills it in Schedules) */}

--- a/client-interface/app/admin/mentees/[id]/page.tsx
+++ b/client-interface/app/admin/mentees/[id]/page.tsx
@@ -228,7 +228,7 @@ export default function AdminMenteeProfilePage() {
             <StatsCard icon={TrendingUp}   label="Progress"        value={`${overallProgress}%`}                           colorClass="text-brand-600 bg-brand-50" />
             <StatsCard icon={CheckCircle2} label="Tasks Completed"  value={`${tasksCompleted}/${stats?.tasksTotal ?? tasksCompleted}`} colorClass="text-green-600 bg-green-50" />
             <StatsCard icon={Trophy}       label="Points"           value={points.toLocaleString()}                        colorClass="text-amber-600 bg-amber-50" />
-            <StatsCard icon={Users2}       label="Clan"             value={stats?.currentClanName ?? currentClan?.name ?? '-'} colorClass="text-purple-600 bg-purple-50"   />
+            <StatsCard icon={Users2}       label="Clan"             value={stats?.currentClanName ?? currentClan?.name ?? '-'} colorClass="text-purple-600 bg-purple-50" />
           </div>
 
           {/* Weekly schedule (read-only; the mentor fills it in Schedules) */}

--- a/client-interface/components/admin/ui/StatsCard.tsx
+++ b/client-interface/components/admin/ui/StatsCard.tsx
@@ -12,6 +12,7 @@ interface StatsCardProps {
    * e.g. 'text-brand-600 bg-brand-50'  (default)
    */
   colorClass?: string;
+  valueClassName?: string;
 }
 
 export function StatsCard({

--- a/client-interface/components/admin/ui/StatsCard.tsx
+++ b/client-interface/components/admin/ui/StatsCard.tsx
@@ -12,7 +12,6 @@ interface StatsCardProps {
    * e.g. 'text-brand-600 bg-brand-50'  (default)
    */
   colorClass?: string;
-  valueClassName?: string;
 }
 
 export function StatsCard({


### PR DESCRIPTION
## Description

This PR improves the responsiveness of the Admin Mentee Profile page by fixing layout issues that occurred at intermediate desktop widths.

### Changes Made

* Updated the stats cards grid layout to display **2 cards per row** between **1024px and 1279px**, preventing the cards from becoming too narrow while preserving the existing layouts on smaller and larger screens.
* Fixed the mentee email overflow issue by allowing the email text to truncate within the profile card instead of overflowing outside its container.
* Preserved the existing mobile and large desktop layouts without affecting the current design.

### Before

* Stats cards became too narrow around **1024px–1279px**, causing content such as **"Tasks Completed"** and **"Backend Clan"** to overflow or wrap awkwardly.
* Long email addresses extended beyond the profile card boundary.

### After

* Stats cards are displayed in a **2×2 grid** on intermediate desktop widths, keeping all content readable.
* Email addresses remain inside the profile card and truncate gracefully when space is limited.
* Existing behavior on mobile and large desktop screens remains unchanged.

### Testing

Tested the Admin Mentee Profile page at multiple viewport widths, including:

* Mobile (<640px)
* Tablet (640px–1023px)
* Intermediate desktop (1024px–1279px)
* Large desktop (≥1280px)

Verified that:

* No content overflows its parent container.
* Stats cards remain readable across all tested screen sizes.
* Email addresses stay within the profile card.
* Existing layouts continue to behave as expected.

### Screenshot


https://github.com/user-attachments/assets/db6dc694-e40f-4f16-98a7-241142805596

Closes #525