### PR TITLE
Fix: gate program completion sign-off on roadmap completion, not assigned-task count

### DIFF
--- a/client-interface/app/mentor/mentees/[id]/page.tsx
+++ b/client-interface/app/mentor/mentees/[id]/page.tsx
@@ -325,7 +325,7 @@ export default function MenteeDetail() {
             <div>
               <p className="text-amber-900 font-medium text-sm">
                 {enrollment.completionRequestedByRole === 'system'
-                  ? `${mentee?.firstName} ${mentee?.lastName} has finished every task - ready for your sign-off`
+                  ? `${mentee?.firstName} ${mentee?.lastName} has finished their roadmap - ready for your sign-off`
                   : `${mentee?.firstName} ${mentee?.lastName} has requested completion`}
               </p>
               <p className="text-amber-700 text-xs mt-1">

--- a/server/src/services/taskService.js
+++ b/server/src/services/taskService.js
@@ -606,10 +606,43 @@ class TaskService {
   }
 
   /**
+   * Has the mentee finished the program's ROADMAP(s)? This — not "every assigned
+   * task is done" — is what makes an enrollment ready for completion sign-off.
+   *
+   * A mentee is auto-nominated for completion when the linear roadmap they're
+   * working through is finished. RoadmapProgress.completed flips true the moment
+   * the LAST roadmap step is approved (see linearRoadmapService.advanceOnApproval),
+   * which is the same thing as "all roadmap tasks completed" — so it covers both
+   * nomination scenarios. We require at least one tracked program roadmap and that
+   * ALL of them are completed, so a mid-chain roadmap (a next one auto-assigned)
+   * keeps the enrollment active.
+   *
+   * Custom one-off tasks have no roadmap (roadmapId is null) and therefore never
+   * trigger this. That's the fix for the bug where assigning a single custom task
+   * and approving it read 100% and prematurely flagged the whole program complete.
+   * A mentor signs off a custom-only / ahead-of-schedule path manually instead
+   * (the "Complete level" button → requestCompletion / approveCompletion).
+   */
+  async _isProgramRoadmapComplete(enrollment) {
+    if (!enrollment) return false;
+    const progresses = await models.RoadmapProgress.findAll({
+      where: { menteeId: enrollment.menteeId },
+      include: [{ model: models.Roadmap, as: 'roadmap', attributes: ['programId'], required: true }]
+    });
+    const programProgresses = progresses.filter(
+      (p) => p.roadmap && p.roadmap.programId === enrollment.programId
+    );
+    if (!programProgresses.length) return false;
+    return programProgresses.every((p) => p.completed === true);
+  }
+
+  /**
    * Update enrollment task statistics.
-   * tasksTotal is the FULL program roadmap task count (not just assigned tasks)
-   * so the percentage reflects true progress through the whole program from day 1.
-   * Also auto-advances week/level and marks program_completed when all done.
+   * tasksCompleted/tasksTotal/overallProgressPercentage track the mentee's
+   * assigned workload (the progress bar). Completion sign-off, however, is gated
+   * on finishing the program ROADMAP (see _isProgramRoadmapComplete) — NOT on the
+   * assigned-task ratio — so a lone custom task can't prematurely flag the program
+   * as complete. Flags the enrollment ready for the mentor's sign-off when done.
    */
   async updateEnrollmentTaskStats(enrollmentId) {
     // Load enrollment to know which program we're in
@@ -647,16 +680,19 @@ class TaskService {
       ? Math.round((tasksCompleted / tasksTotal) * 100)
       : 0;
 
-    // Completion is the MENTOR's call. When every program task (roadmap + custom)
-    // is done we don't silently complete - we flag the enrollment as ready for
-    // sign-off ('pending_completion', marked system-requested) so the mentor is
-    // prompted to confirm. If work reopens, only the system-flagged ones revert.
-    const allProgramTasksDone = tasksTotal > 0 && tasksCompleted >= tasksTotal;
+    // Completion is the MENTOR's call, and it's gated on finishing the program
+    // ROADMAP — not on "every assigned task is done". When the roadmap is complete
+    // (its last step approved, or all steps completed) we don't silently complete:
+    // we flag the enrollment as ready for sign-off ('pending_completion', marked
+    // system-requested) so the mentor is prompted to confirm. If the roadmap is no
+    // longer complete (e.g. a next roadmap got chained in), only the system-flagged
+    // ones revert — a mentor's own manual nomination is left untouched.
+    const roadmapComplete = await this._isProgramRoadmapComplete(enrollment);
     const currentEnrollment = await models.Enrollment.findByPk(enrollmentId);
     const current = currentEnrollment?.status;
 
     let statusUpdate = {};
-    if (allProgramTasksDone) {
+    if (roadmapComplete) {
       if (current === 'active' || current === 'matched') {
         statusUpdate = {
           status: 'pending_completion',
@@ -667,7 +703,7 @@ class TaskService {
         };
       }
     } else if (current === 'pending_completion' && currentEnrollment?.completionRequestedByRole === 'system') {
-      // Auto-flagged as ready, but new work appeared - send it back to active.
+      // Auto-flagged as ready, but the roadmap is no longer complete - send it back.
       statusUpdate = {
         status: 'active',
         completionRequestedAt: null,
@@ -697,7 +733,7 @@ class TaskService {
     }
 
     // Auto-advance week / level when the current week's tasks are all done
-    if (!allProgramTasksDone) {
+    if (!roadmapComplete) {
       await this._checkAndAdvanceProgress(enrollment, assignedTasks);
     }
 


### PR DESCRIPTION
## Summary
Approving a single **custom task** prematurely flagged the whole enrollment as ready for
program completion — firing the "ready to complete the program" in-app notification **and
email** — even though the mentee had not finished the program roadmap (e.g. Full-Stack AI
Engineering).

This PR gates completion sign-off on **finishing the program roadmap** instead of on the
assigned-task count.

Closes #526 

## Root cause
`updateEnrollmentTaskStats()` decided the program was done by comparing the **assigned**
task counts:

```js
const allProgramTasksDone = tasksTotal > 0 && tasksCompleted >= tasksTotal;
```

When the only assigned task is a completed custom task, `tasksTotal === tasksCompleted`
→ reads 100% → enrollment flips to `pending_completion` → `COMPLETION_READY_FOR_SIGNOFF`
notification + email. The assigned-task set is not the full roadmap, so this fired far
too early.

## Fix
- **New helper `_isProgramRoadmapComplete(enrollment)`** (`server/src/services/taskService.js`):
  loads the mentee's `RoadmapProgress` rows for the enrollment's program and returns `true`
  only when at least one program roadmap is tracked **and all of them are `completed`**.
- `RoadmapProgress.completed` flips `true` the moment the **last roadmap step** is approved
  (`linearRoadmapService.advanceOnApproval`), so this covers both nomination scenarios:
  *"all roadmap tasks completed"* and *"completed the last roadmap task"*.
- Custom one-off tasks have `roadmapId = null` (no `RoadmapProgress`) and can no longer
  trigger nomination on their own.
- A mid-chain roadmap (a next one auto-assigned) keeps the enrollment `active`.
- Progress-bar fields (`tasksCompleted` / `tasksTotal` / `overallProgressPercentage`) are
  unchanged — only the completion **gate** moved.

### Manual mentor nomination (unchanged)
A mentor can still sign a mentee off at any point via the **"Complete level"** button
(shown while the enrollment is `active`/`matched`). The auto-revert only undoes
**system**-flagged nominations, so a mentor's manual nomination is never clobbered by a
later task update.

### UI copy
The system sign-off banner now reads *"has finished their roadmap — ready for your
sign-off"* instead of *"has finished every task"*, matching the new behavior.

## Behavior after the fix
Assign custom task → mentee completes → mentor approves → **no `pending_completion`, no
email, no premature "ready to complete" message**. Nomination happens only once the
roadmap is actually finished, or when a mentor signs off manually.

## Files changed
| File | Change |
|------|--------|
| `server/src/services/taskService.js` | New `_isProgramRoadmapComplete`; completion trigger now roadmap-gated |
| `client-interface/app/mentor/mentees/[id]/page.tsx` | Sign-off banner copy |

## Testing
- `node --check` passes on the changed service.
- ⚠️ Not run live: fresh clone with no `node_modules` and no Postgres test DB.
- ⚠️ **No automated regression test added.** The existing test harness
  (`tests/helpers/seed.js`) is stale against the current schema — it references removed
  models (`RoadmapWeek`, `ProgramLevel`) and columns (`levelId`, `currentLevelId`,
  `createdBy`) and has no `RoadmapProgress` helper. CI does not run the suite. Adding a
  meaningful test first requires modernizing the seed helpers; tracked as a follow-up.

### Suggested follow-up test coverage
1. Approving a lone **custom** task → enrollment stays `active` (no `pending_completion`).
2. Approving the **last roadmap step** (`RoadmapProgress.completed = true`) → enrollment
   flips to `pending_completion` with `completionRequestedByRole: 'system'`.