### PR TITLE
fix(mentor): close assign-task drawer on success instead of inline confirmation

### DIFF
--- a/client-interface/components/mentor/AssignTaskDrawer.tsx
+++ b/client-interface/components/mentor/AssignTaskDrawer.tsx
@@ -89,7 +89,6 @@ export function AssignTaskDrawer({
   const [search, setSearch] = useState('');
 
   const [saving, setSaving] = useState(false);
-  const [done, setDone] = useState<number | null>(null);
 
   const drawerRef = useRef<HTMLDivElement>(null);
   const titleRef = useRef<HTMLInputElement>(null);
@@ -204,8 +203,8 @@ export function AssignTaskDrawer({
         }
         if (failed) toast.error(`${failed} mentee${failed > 1 ? 's' : ''} couldn't be assigned`);
         toast.success(`Roadmap assigned to ${assigned} mentee${assigned > 1 ? 's' : ''}`);
-        setDone(assigned);
         onAssigned?.();
+        onClose();
         return;
       }
 
@@ -236,13 +235,12 @@ export function AssignTaskDrawer({
         }
         if (failed.length) toast.error(`${failed.length} mentee${failed.length > 1 ? 's' : ''} couldn't be assigned`);
         toast.success(`Task assigned to ${assigned} mentee${assigned > 1 ? 's' : ''}`);
-        setDone(assigned);
       } else {
         await taskApi.createCustomTask({ ...base, menteeId: mentee!.id, trackId: trackId || undefined });
         toast.success(`Task assigned to ${mentee?.name || 'the mentee'}`);
-        setDone(1);
       }
       onAssigned?.();
+      onClose();
     } catch (error: any) {
       toast.error(extractApiErrorMessage(error, 'Could not assign'));
     } finally {
@@ -276,19 +274,7 @@ export function AssignTaskDrawer({
           <button onClick={onClose} aria-label="Close" className="p-1.5 text-slate-400 hover:bg-slate-100 rounded-lg"><X className="w-5 h-5" /></button>
         </div>
 
-        {done !== null ? (
-          <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
-            <div className="w-14 h-14 rounded-full bg-green-100 flex items-center justify-center mb-4">
-              <Check className="w-7 h-7 text-green-600" />
-            </div>
-            <p className="text-slate-900 font-semibold">Task assigned</p>
-            <p className="text-slate-500 text-sm mt-1">
-              {mode === 'bulk' ? `${done} mentee${done === 1 ? '' : 's'} notified.` : `${mentee?.name ?? 'Mentee'} has a new task.`}
-            </p>
-            <button onClick={onClose} className="mt-6 px-5 py-2 bg-brand-600 hover:bg-brand-700 text-white rounded-xl text-sm">Done</button>
-          </div>
-        ) : (
-          <>
+        <>
             {/* Source tabs - custom task vs assign from a roadmap */}
             <div className="px-6 pt-4">
               <div className="grid grid-cols-2 gap-1 p-1 bg-slate-100 rounded-xl">
@@ -547,7 +533,6 @@ export function AssignTaskDrawer({
               </button>
             </div>
           </>
-        )}
       </div>
       {viewSteps && selectedRoadmap && <RoadmapStepsDrawer roadmap={selectedRoadmap} onClose={() => setViewSteps(false)} />}
       {customizeStep && (


### PR DESCRIPTION
## Problem
After assigning a task or roadmap, the side drawer stayed open on an inline "Task assigned" success screen, forcing the mentor to click **Done** just to dismiss it — an extra click for no added value.

## Change
On successful assignment, close the drawer immediately and rely on the existing Sonner toast for confirmation. Applies to all success paths: roadmap, custom single, and custom bulk. Error paths are unchanged — the drawer stays open so the mentor can retry.

## Implementation
`client-interface/components/mentor/AssignTaskDrawer.tsx`
- Removed the `done` state and the inline success UI block (green check + "Done" button).
- Each success path now calls `onAssigned?.()` then `onClose()`.

## Testing
- Verified locally as a mentor (assign drawer on a mentee detail page): on success the drawer closes and the success toast appears; on error the drawer stays open.
- `tsc --noEmit` passes.

Closes #545
