### PR TITLE
fix(mentor): task-centric wording for roadmap assign

### DIFF
--- a/client-interface/components/mentor/AssignTaskDrawer.tsx
+++ b/client-interface/components/mentor/AssignTaskDrawer.tsx
@@ -198,13 +198,16 @@ export function AssignTaskDrawer({
         const res: any = await mentorApi.assignRoadmap(roadmapId, { menteeIds: targetIds, stepIndexes: [...selectedSteps], dueDate: dueExact || undefined, stepOverrides: Object.keys(stepOverrides).length ? stepOverrides : undefined });
         const assigned = res?.data?.assigned ?? targetIds.length;
         const failed = res?.data?.failed ?? 0;
+        // Each ticked step becomes a task — report tasks, not "a roadmap".
+        const taskCount = selectedSteps.size;
+        const taskLabel = taskCount === 1 ? 'Task' : `${taskCount} tasks`;
         if (assigned === 0) {
-          toast.error(res?.data?.results?.find((r: any) => !r.ok)?.error || 'Could not assign the roadmap');
+          toast.error(res?.data?.results?.find((r: any) => !r.ok)?.error || (taskCount === 1 ? 'Could not assign the task' : 'Could not assign the tasks'));
           setSaving(false);
           return;
         }
         if (failed) toast.error(`${failed} mentee${failed > 1 ? 's' : ''} couldn't be assigned`);
-        toast.success(`Roadmap assigned to ${assigned} mentee${assigned > 1 ? 's' : ''}`);
+        toast.success(mode === 'bulk' ? `${taskLabel} assigned to ${assigned} mentee${assigned > 1 ? 's' : ''}` : `${taskLabel} assigned to ${mentee?.name || 'the mentee'}`);
         setDone(assigned);
         onAssigned?.();
         return;
@@ -547,7 +550,7 @@ export function AssignTaskDrawer({
               <button onClick={submit} disabled={!canSubmit || saving} className="px-4 py-2 bg-brand-600 hover:bg-brand-700 text-white rounded-xl text-sm inline-flex items-center gap-2 disabled:opacity-50">
                 {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
                 {source === 'roadmap'
-                  ? (mode === 'bulk' ? `Assign roadmap to ${targetCount}` : 'Assign roadmap')
+                  ? (mode === 'bulk' ? `Assign to ${targetCount}` : (selectedSteps.size > 1 ? `Assign ${selectedSteps.size} tasks` : 'Assign task'))
                   : (mode === 'bulk' ? `Assign to ${selected.size}` : 'Assign task')}
               </button>
             </div>


### PR DESCRIPTION
Closes #546

## Problem
In the **From roadmap** tab, the UI says "Assign roadmap" / "Roadmap assigned". But there's no assign-whole-roadmap action — the mentor ticks individual steps, and each step becomes a **task**. The wording was misleading and ignored how many tasks were created.

## Change
Task-centric wording for the roadmap source (`client-interface/components/mentor/AssignTaskDrawer.tsx`):

| Case | Wording |
|---|---|
| 1 task → 1 mentee | `Task assigned to Maya` |
| 4 steps → 1 mentee | `4 tasks assigned to Maya` |
| bulk, 1 each → 3 mentees | `Task assigned to 3 mentees` |
| bulk, 4 each → 3 mentees | `4 tasks assigned to 3 mentees` |

- Submit button: `Assign roadmap` → `Assign task` / `Assign N tasks` (single), `Assign to N` (bulk)
- Success + error toasts updated to task-centric copy (count from `selectedSteps.size`)
- Source-picker labels ("From roadmap", "Pick a roadmap", "Steps to assign") left unchanged — they correctly describe picking *from* a roadmap.

## Test plan
- [ ] Roadmap tab, single mentee, 1 step → button "Assign task", toast "Task assigned to <name>"
- [ ] Roadmap tab, single mentee, 4 steps → button "Assign 4 tasks", toast "4 tasks assigned to <name>"
- [ ] Roadmap tab, bulk → toast "N task(s) assigned to M mentees"
- [ ] Custom tab wording unchanged

## Demo

Assigning from a roadmap now reads **"Assign 2 tasks"** on the button and the toast says **"2 tasks assigned to Maya Patel"** — no more "Assign roadmap" / "Roadmap assigned".

![assign-task task-centric wording demo](https://raw.githubusercontent.com/Wajahat43/pathment/pr-548-media/pr-media/assign-task-wording-after.gif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
