### PR TITLE
fix: resolve infinite loading when assigning interview kits

### DIFF
--- a/client-interface/components/mentor/AssignTaskDrawer.tsx
+++ b/client-interface/components/mentor/AssignTaskDrawer.tsx
@@ -99,7 +99,7 @@ export function AssignTaskDrawer({
 
   // Load the mentor's interview kits the first time they pick the Interview type.
   useEffect(() => {
-    if (type !== 'interview' || kits.length || kitsLoading) return;
+    if (type !== 'interview' || kits.length > 0 || kitsLoading) return;
     let active = true;
     setKitsLoading(true);
     interviewApi.listKits()
@@ -107,7 +107,8 @@ export function AssignTaskDrawer({
       .catch(() => { if (active) setKits([]); })
       .finally(() => { if (active) setKitsLoading(false); });
     return () => { active = false; };
-  }, [type, kits.length, kitsLoading]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [type]);
 
   // When a kit is chosen, seed the option toggles from its defaults.
   useEffect(() => {

--- a/client-interface/components/shared/RichTextEditor.tsx
+++ b/client-interface/components/shared/RichTextEditor.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
@@ -30,20 +31,22 @@ export default function RichTextEditor({
   placeholder = 'Start typing...',
   minHeight = '200px'
 }: RichTextEditorProps) {
+  const extensions = useMemo(() => [
+    StarterKit,
+    Link.configure({
+      openOnClick: false,
+      HTMLAttributes: {
+        class: 'text-blue-600 underline'
+      }
+    }),
+    Placeholder.configure({
+      placeholder
+    })
+  ], [placeholder]);
+
   const editor = useEditor({
     immediatelyRender: false,
-    extensions: [
-      StarterKit,
-      Link.configure({
-        openOnClick: false,
-        HTMLAttributes: {
-          class: 'text-blue-600 underline'
-        }
-      }),
-      Placeholder.configure({
-        placeholder
-      })
-    ],
+    extensions,
     content,
     onUpdate: ({ editor }) => {
       onChange(editor.getHTML());

--- a/server/src/services/interviewKitService.js
+++ b/server/src/services/interviewKitService.js
@@ -97,7 +97,7 @@ class InterviewKitService {
     const kits = await models.InterviewKit.findAll({
       where: { createdBy: userId },
       include: [{ model: models.InterviewQuestion, as: 'questions', attributes: ['id', 'kind', 'points'] }],
-      order: [['updated_at', 'DESC']],
+      order: [['updatedAt', 'DESC']],
     });
     return kits.map((k) => {
       const questions = k.questions || [];


### PR DESCRIPTION
## Description

This PR fixes an issue where the "Interview kit" dropdown gets stuck in a permanent loading state when attempting to assign an interview task.

Two underlying bugs were resolved:
1. **Frontend**: Removed `kitsLoading` from the `AssignTaskDrawer`'s `useEffect` dependency array. Previously, the fetch trigger flipped the loading state to `true`, which immediately triggered the effect's cleanup and set `active = false`. This blocked the `finally` block from turning the loading state back to `false` when the API responded.
2. **Backend**: Corrected a Sequelize order clause in `interviewKitService.js` to use the model attribute name `updatedAt` instead of the database column name `updated_at`, preventing a potential 500 server error when listing kits.

## Related Issue

Closes #554 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

<img width="469" height="328" alt="image" src="https://github.com/user-attachments/assets/f5586e2a-50d3-4f85-81ef-11ed8ba57186" />