### PR TITLE
Feature:mentee clan change request flow

### DIFF
--- a/client-interface/app/mentee/clan-request/page.tsx
+++ b/client-interface/app/mentee/clan-request/page.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ArrowRight, CheckCircle2, Clock3, GitPullRequest, Loader2, Send } from 'lucide-react';
+import { toast } from 'sonner';
+import { clanApi } from '@/lib/services/clan-api';
+import { clanRequestsApi } from '@/lib/services/clan-requests-api';
+import { SelectMenu } from '@/components/shared/SelectMenu';
+
+type Membership = {
+  role: string;
+  clan: { id: string; name: string; programId: string; status: string };
+};
+
+type ClanOption = { id: string; name: string };
+
+type ClanChangeRow = {
+  id: string;
+  fromClan: string | null;
+  toClan: string | null;
+  reason: string | null;
+  status: 'pending' | 'approved' | 'denied';
+  resolutionNote: string | null;
+  at: string;
+};
+
+const STATUS_META: Record<ClanChangeRow['status'], { label: string; className: string; icon: typeof Clock3 }> = {
+  pending: { label: 'Pending', className: 'bg-amber-100 text-amber-700', icon: Clock3 },
+  approved: { label: 'Approved', className: 'bg-emerald-100 text-emerald-700', icon: CheckCircle2 },
+  denied: { label: 'Denied', className: 'bg-slate-100 text-slate-500', icon: Clock3 },
+};
+
+export default function MenteeClanRequestPage() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [memberships, setMemberships] = useState<Membership[]>([]);
+  const [targetClans, setTargetClans] = useState<ClanOption[]>([]);
+  const [requests, setRequests] = useState<ClanChangeRow[]>([]);
+  const [targetClanId, setTargetClanId] = useState('');
+  const [reason, setReason] = useState('');
+
+  const currentClan = useMemo(
+    () => memberships.find((m) => m.role === 'mentee' && m.clan)?.clan ?? null,
+    [memberships]
+  );
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const [membershipRes, requestRes] = await Promise.all([
+        clanApi.myMemberships(),
+        clanRequestsApi.listMyRequests(),
+      ]);
+
+      const nextMemberships = membershipRes?.data?.memberships ?? [];
+      setMemberships(nextMemberships);
+
+      const nextRequests = requestRes?.data?.requests ?? [];
+      setRequests(nextRequests);
+
+      const menteeMembership = nextMemberships.find((m: Membership) => m.role === 'mentee' && m.clan);
+      const programId = menteeMembership?.clan?.programId;
+      const currentClanId = menteeMembership?.clan?.id;
+
+      if (programId) {
+        const clanRes = await clanApi.list({ programId });
+        const clans = clanRes?.data?.clans ?? clanRes?.clans ?? clanRes ?? [];
+        setTargetClans(
+          clans
+            .map((c: { id: string; name: string }) => ({ id: c.id, name: c.name }))
+            .filter((c: ClanOption) => c.id !== currentClanId)
+        );
+      } else {
+        setTargetClans([]);
+      }
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || 'Could not load clan requests');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const submit = async () => {
+    if (!currentClan) {
+      toast.error('You need to be assigned to a clan first');
+      return;
+    }
+    if (!targetClanId) {
+      toast.error('Choose the clan you want to move to');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      await clanRequestsApi.createRequest({
+        toClanId: targetClanId,
+        fromClanId: currentClan.id,
+        reason: reason.trim() || undefined,
+      });
+      toast.success('Clan change request submitted');
+      setTargetClanId('');
+      setReason('');
+      await load();
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || 'Could not submit the request');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const field = 'border border-slate-300 rounded-xl px-3 py-2 text-sm bg-card focus:outline-none focus:ring-2 focus:ring-brand-500';
+
+  return (
+    <div className="space-y-6 max-w-5xl">
+      <div>
+        <h1 className="text-slate-900 mb-2">Request clan change</h1>
+        <p className="text-slate-600">
+          Ask the admin team to move you to another clan. Your request will appear in their review queue.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="w-8 h-8 animate-spin text-brand-600" />
+        </div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-[1.25fr_0.95fr] items-start">
+          <section className="space-y-4">
+            <div className="bg-card rounded-2xl border border-slate-200 p-6">
+              <div className="flex items-start gap-3">
+                <div className="w-11 h-11 rounded-xl bg-brand-50 flex items-center justify-center shrink-0">
+                  <GitPullRequest className="w-5 h-5 text-brand-600" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h2 className="text-slate-900">New request</h2>
+                  <p className="text-sm text-slate-500 mt-1">
+                    Select the clan you want to move into, then add a short reason so admins have context.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-6 space-y-4">
+                <div className="grid md:grid-cols-2 gap-4">
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                    <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Current clan</p>
+                    <p className="text-sm font-medium text-slate-900 mt-1">{currentClan?.name ?? 'No clan assigned yet'}</p>
+                  </div>
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                    <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">How it works</p>
+                    <p className="text-sm text-slate-600 mt-1">Admin reviews your request and will approve or deny it.</p>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium text-slate-500 mb-1">Target clan</label>
+                  <SelectMenu
+                    value={targetClanId}
+                    onChange={setTargetClanId}
+                    options={targetClans.map((c) => ({ value: c.id, label: c.name }))}
+                    placeholder={targetClans.length ? 'Choose a clan…' : 'No other clans available'}
+                    ariaLabel="Target clan"
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium text-slate-500 mb-1">Reason</label>
+                  <textarea
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                    rows={5}
+                    className={`${field} w-full resize-none`}
+                    placeholder="Tell admins why you want to move"
+                  />
+                </div>
+
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pt-2">
+                  <p className="text-xs text-slate-400">
+                    Keep it short and factual. This helps the admin team review faster.
+                  </p>
+                  <button
+                    onClick={submit}
+                    disabled={saving || !currentClan || !targetClans.length}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-50"
+                  >
+                    {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+                    Submit request
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <aside className="space-y-4">
+            <div className="bg-card rounded-2xl border border-slate-200 p-6">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-slate-900">Request history</h2>
+                <button onClick={load} className="text-sm text-brand-600 hover:text-brand-700">Refresh</button>
+              </div>
+
+              {requests.length === 0 ? (
+                <div className="mt-4 rounded-xl border border-dashed border-slate-200 p-4 text-sm text-slate-500">
+                  You have not submitted any clan change requests yet.
+                </div>
+              ) : (
+                <div className="mt-4 space-y-3">
+                  {requests.map((r) => {
+                    const meta = STATUS_META[r.status];
+                    const Icon = meta.icon;
+                    return (
+                      <div key={r.id} className="rounded-xl border border-slate-200 p-4">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-slate-900 truncate">
+                              {r.fromClan ?? 'Current clan'} <ArrowRight className="inline-block w-3.5 h-3.5 text-slate-300 mx-1" /> {r.toClan ?? 'Target clan'}
+                            </p>
+                            <p className="text-xs text-slate-500 mt-1">{r.reason || 'No reason provided'}</p>
+                          </div>
+                          <span className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${meta.className}`}>
+                            <Icon className="w-3.5 h-3.5" />
+                            {meta.label}
+                          </span>
+                        </div>
+                        {r.resolutionNote && (
+                          <p className="mt-2 text-xs text-slate-500">Admin note: {r.resolutionNote}</p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-2xl border border-brand-200 bg-brand-50/70 p-5">
+              <p className="text-sm font-semibold text-slate-900">Need a different clan for a good reason?</p>
+              <p className="text-sm text-slate-600 mt-1">
+                Submit a clear request. The admin team will review it and keep the decision visible in your history.
+              </p>
+            </div>
+          </aside>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client-interface/app/mentee/dashboard/page.tsx
+++ b/client-interface/app/mentee/dashboard/page.tsx
@@ -7,6 +7,7 @@ import {
   BookOpen,
   CheckCircle2,
   Clock,
+  GitPullRequest,
   ListTodo,
   Loader2,
   TrendingUp,
@@ -121,6 +122,23 @@ function MenteeDashboardInner() {
 
       {/* Latest announcements */}
       <AnnouncementsCard href="/mentee/announcements" />
+
+      <div className="rounded-2xl border border-brand-200 bg-brand-50/70 p-5">
+        <div className="flex items-start gap-3">
+          <div className="w-10 h-10 rounded-xl bg-white/80 flex items-center justify-center shrink-0">
+            <GitPullRequest className="w-5 h-5 text-brand-600" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold text-slate-900">Need to change clans?</p>
+            <p className="text-sm text-slate-600 mt-1">
+              Submit a request and the admin team will review it.
+            </p>
+            <Link href="/mentee/clan-request" className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-brand-700">
+              Open request form <ArrowRight className="w-4 h-4" />
+            </Link>
+          </div>
+        </div>
+      </div>
 
       {/* This week's tasks */}
       {weekTasks.length > 0 && (

--- a/client-interface/lib/config/navigation.ts
+++ b/client-interface/lib/config/navigation.ts
@@ -177,6 +177,7 @@ export const navigationConfig: Record<string, NavLink[]> = {
         { path: '/mentee/library', icon: BookOpen, label: 'Library' },
       ],
     },
+    { path: '/mentee/clan-request', icon: GitPullRequest, label: 'Change clan' },
     { path: '/mentee/settings', icon: Settings, label: 'Settings' },
   ],
 } as const;

--- a/client-interface/lib/services/clan-requests-api.ts
+++ b/client-interface/lib/services/clan-requests-api.ts
@@ -6,6 +6,9 @@ export const clanRequestsApi = {
   listCrossClan: (clanId: string) => apiClient.get('/clan-requests/cross-clan', { params: { clanId } }),
   resolveRequest: (id: string, status: 'approved' | 'denied', note?: string) =>
     apiClient.patch(`/clan-requests/requests/${id}/resolve`, { status, note }),
+  createRequest: (data: { toClanId: string; fromClanId?: string; reason?: string }) =>
+    apiClient.post('/clan-requests/requests', data),
+  listMyRequests: () => apiClient.get('/clan-requests/requests/mine'),
   createCrossClan: (data: { kind: string; userId: string; toClanId: string; fromClanId?: string; note?: string }) =>
     apiClient.post('/clan-requests/cross-clan', data),
   removeCrossClan: (id: string) => apiClient.delete(`/clan-requests/cross-clan/${id}`),

--- a/client-interface/package-lock.json
+++ b/client-interface/package-lock.json
@@ -58,7 +58,7 @@
         "next": "^16.2.2",
         "next-themes": "^0.4.6",
         "react": "19.2.0",
-        "react-day-picker": "^8.10.1",
+        "react-day-picker": "^10.0.1",
         "react-dom": "19.2.0",
         "react-dropzone": "^14.3.8",
         "react-hook-form": "^7.55.0",
@@ -529,6 +529,12 @@
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.7.0",
@@ -4100,7 +4106,6 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4110,7 +4115,6 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -8769,17 +8773,39 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
-      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
+      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
       "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
-        "date-fns": "^2.28.0 || ^3.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-day-picker/node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/react-dom": {

--- a/client-interface/package.json
+++ b/client-interface/package.json
@@ -59,7 +59,7 @@
     "next": "^16.2.2",
     "next-themes": "^0.4.6",
     "react": "19.2.0",
-    "react-day-picker": "^8.10.1",
+    "react-day-picker": "^10.0.1",
     "react-dom": "19.2.0",
     "react-dropzone": "^14.3.8",
     "react-hook-form": "^7.55.0",

--- a/server/src/config/notificationMatrix.js
+++ b/server/src/config/notificationMatrix.js
@@ -25,6 +25,8 @@ EXTENSION_HANDLED: 'extension_handled',
   MENTOR_FEEDBACK_REQUESTED: 'mentor_feedback_requested',
   MEETING_CANCELLED: 'meeting_cancelled',
   MEETING_BOOKED: 'meeting_booked',
+  CLAN_CHANGE_REQUESTED: 'clan_change_requested',
+  CLAN_CHANGE_HANDLED: 'clan_change_handled',
   CROSS_CLAN_ASSIGNED: 'cross_clan_assigned',
   NEW_MENTEE_IN_CLAN: 'new_mentee_in_clan',
   PROMOTION_NOMINATED: 'promotion_nominated',
@@ -195,6 +197,16 @@ const NOTIFICATION_MATRIX = {
     preferenceKey: 'meeting_booked',
     channels: { inApp: true, email: true, chat: false }
   },
+  [NOTIFICATION_EVENTS.CLAN_CHANGE_REQUESTED]: {
+    type: 'system',
+    preferenceKey: 'clan_change_requested',
+    channels: { inApp: true, email: true, chat: false }
+  },
+  [NOTIFICATION_EVENTS.CLAN_CHANGE_HANDLED]: {
+    type: 'system',
+    preferenceKey: 'clan_change_handled',
+    channels: { inApp: true, email: true, chat: false }
+  },
   [NOTIFICATION_EVENTS.CROSS_CLAN_ASSIGNED]: {
     type: 'system',
     preferenceKey: 'cross_clan_assigned',
@@ -262,6 +274,8 @@ const EMAIL_PREFERENCE_CATEGORIES = [
   { group: 'Program', key: 'program_updates', label: 'Program updates' },
   { group: 'Program', key: 'meeting_booked', label: 'A 1:1 is booked' },
   { group: 'Program', key: 'meeting_cancelled', label: 'A 1:1 is cancelled' },
+  { group: 'Program', key: 'clan_change_requested', label: 'A clan change request is submitted' },
+  { group: 'Program', key: 'clan_change_handled', label: 'My clan change request is handled' },
   { group: 'Program', key: 'cross_clan_assigned', label: 'I\'m asked to cover or help another clan' },
   { group: 'Program', key: 'new_mentee_in_clan', label: 'A new mentee joins my clan' },
   { group: 'Program', key: 'promotion_nominated', label: 'A mentee is nominated for promotion (admins)' },

--- a/server/src/controllers/clanRequestsController.js
+++ b/server/src/controllers/clanRequestsController.js
@@ -8,8 +8,13 @@ const overview = catchAsync(async (req, res) => {
 });
 
 const createRequest = catchAsync(async (req, res) => {
-  const request = await clanRequestsService.createRequest(req.body, req.user.id);
+  const request = await clanRequestsService.createRequest({ ...req.body, menteeId: req.user.id }, req.user.id);
   res.status(201).json(successResponse('Request created', { request }, 201));
+});
+
+const listMyRequests = catchAsync(async (req, res) => {
+  const requests = await clanRequestsService.listMyRequests(req.user.id);
+  res.status(200).json(successResponse('My clan change requests', { requests }));
 });
 
 const resolveRequest = catchAsync(async (req, res) => {
@@ -41,4 +46,4 @@ const respondCrossClan = catchAsync(async (req, res) => {
   res.status(200).json(successResponse('Response recorded', result));
 });
 
-module.exports = { overview, createRequest, resolveRequest, listCrossClan, createCrossClan, removeCrossClan, listMyCrossClan, respondCrossClan };
+module.exports = { overview, createRequest, listMyRequests, resolveRequest, listCrossClan, createCrossClan, removeCrossClan, listMyCrossClan, respondCrossClan };

--- a/server/src/routes/clanRequests.js
+++ b/server/src/routes/clanRequests.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const c = require('../controllers/clanRequestsController');
-const { authenticate } = require('../middlewares/auth');
+const { authenticate, authorize } = require('../middlewares/auth');
 const { requirePermission, requirePermissionMinScope } = require('../middlewares/authz');
 const { PERMISSIONS } = require('../config/permissions');
 const authzService = require('../services/authzService');
@@ -17,7 +17,8 @@ const onTargetClan = (getClanId) => requirePermission(
 router.get('/', adminOnly, c.overview);
 
 // Change requests: a mentee may create one; admin resolves.
-router.post('/requests', authenticate, c.createRequest);
+router.post('/requests', authenticate, authorize(['mentee']), c.createRequest);
+router.get('/requests/mine', authenticate, authorize(['mentee']), c.listMyRequests);
 router.patch('/requests/:id/resolve', adminOnly, c.resolveRequest);
 
 // The covering person's own surface: see + accept/decline cover requests for them.

--- a/server/src/services/clanRequestsService.js
+++ b/server/src/services/clanRequestsService.js
@@ -57,7 +57,35 @@ class ClanRequestsService {
 
   async createRequest({ menteeId, toClanId, fromClanId, reason }, createdBy) {
     if (!menteeId || !toClanId) throw new ValidationError('menteeId and toClanId are required');
-    return models.ClanChangeRequest.create({ menteeId, toClanId, fromClanId: fromClanId || null, reason: reason || null, createdBy });
+    const request = await models.ClanChangeRequest.create({ menteeId, toClanId, fromClanId: fromClanId || null, reason: reason || null, createdBy });
+
+    await this._notifyClanChangeRequested(request).catch((e) =>
+      console.error('[clanRequests] clan-change request notify failed:', e.message)
+    );
+
+    return request;
+  }
+
+  async listMyRequests(userId) {
+    if (!userId) return [];
+    const rows = await models.ClanChangeRequest.findAll({
+      where: { menteeId: userId },
+      order: [['created_at', 'DESC']],
+      include: [
+        { model: models.Clan, as: 'fromClan', attributes: ['name'] },
+        { model: models.Clan, as: 'toClan', attributes: ['name'] }
+      ]
+    });
+
+    return rows.map((r) => ({
+      id: r.id,
+      fromClan: r.fromClan?.name || null,
+      toClan: r.toClan?.name || null,
+      reason: r.reason,
+      status: r.status,
+      resolutionNote: r.resolutionNote,
+      at: r.createdAt
+    }));
   }
 
   async resolveRequest(id, { status, note }) {
@@ -82,7 +110,56 @@ class ClanRequestsService {
       if (status === 'approved') {
         await clanService.addMember(req.toClanId, { userId: req.menteeId, role: 'mentee' });
       }
+      await this._notifyClanChangeHandled(req, status, note).catch((e) =>
+        console.error('[clanRequests] clan-change handled notify failed:', e.message)
+      );
       return req;
+    });
+  }
+
+  async _notifyClanChangeRequested(request) {
+    const admins = await models.User.findAll({
+      where: { role: 'admin', status: 'active' },
+      attributes: ['id']
+    });
+
+    if (!admins.length) return;
+
+    await notificationOrchestrator.dispatch({
+      eventKey: NOTIFICATION_EVENTS.CLAN_CHANGE_REQUESTED,
+      recipients: admins.map((admin) => ({ userId: admin.id })),
+      payload: {
+        title: 'Clan change request submitted',
+        message: 'A mentee submitted a clan change request. Open Clan Requests to review it.',
+        actionUrl: '/admin/requests',
+        actionLabel: 'Review request',
+        relatedEntityType: 'clan_change_request',
+        relatedEntityId: request.id,
+        emailSubject: 'Pathment: clan change request submitted'
+      },
+      dedupe: { relatedEntityType: 'clan_change_request_admin', relatedEntityId: request.id }
+    });
+  }
+
+  async _notifyClanChangeHandled(request, status, note) {
+    const toClan = await models.Clan.findByPk(request.toClanId, { attributes: ['name'] });
+    const outcome = status === 'approved' ? 'approved' : 'rejected';
+
+    await notificationOrchestrator.dispatch({
+      eventKey: NOTIFICATION_EVENTS.CLAN_CHANGE_HANDLED,
+      recipients: [{ userId: request.menteeId }],
+      payload: {
+        title: `Your clan change request was ${outcome}`,
+        message: status === 'approved'
+          ? `Your request to move to ${toClan?.name || 'your target clan'} was approved. Open the request page to see the updated status.`
+          : `Your request to move to ${toClan?.name || 'your target clan'} was rejected.${note ? ` Admin note: ${note}` : ''}`,
+        actionUrl: '/mentee/clan-request',
+        actionLabel: 'View request',
+        relatedEntityType: 'clan_change_request',
+        relatedEntityId: request.id,
+        emailSubject: `Pathment: your clan change request was ${outcome}`
+      },
+      dedupe: { relatedEntityType: 'clan_change_request', relatedEntityId: request.id }
     });
   }
 


### PR DESCRIPTION
## Description

This PR introduces a complete **mentee clan change request workflow**, allowing mentees to submit clan change requests directly from the mentee portal while reusing the existing admin review process.


### Behavior

* Mentees can submit clan change requests directly from the mentee portal.
* Submitted requests appear in the existing **Admin → Requests** page without changing the current admin workflow.
* Administrators receive notifications for newly submitted requests.
* Mentees receive notifications when their request is approved or rejected.
* Request history remains accessible from the mentee portal.

### Files Changed

#### Frontend

* `client-interface/app/mentee/clan-request/page.tsx`
* `client-interface/app/mentee/dashboard/page.tsx`
* `client-interface/lib/config/navigation.ts`
* `client-interface/lib/services/clan-requests-api.ts`

#### Backend

* `server/src/routes/clanRequests.js`
* `server/src/controllers/clanRequestsController.js`
* `server/src/services/clanRequestsService.js`
* `server/src/config/notificationMatrix.js`

Closes #560

### Test Cases

* ✅ Mentee can access the clan change request page.
* ✅ Mentee can submit a clan change request with a target clan and reason.
* ✅ Clan change requests are created successfully.
* ✅ Administrators receive in-app notifications for new requests.
* ✅ Notification action opens the Admin Requests page.
* ✅ Administrators can approve or reject requests through the existing workflow.
* ✅ Mentees receive notifications when requests are resolved.
* ✅ Notification action opens the Clan Change Request page.
* ✅ Request history correctly displays pending, approved, and rejected states.
* ✅ No validation, linting, or type errors introduced by the changes.

### Screenshot

https://github.com/user-attachments/assets/c94229eb-28db-4996-89b9-23811b8a45f9

