### PR TITLE
fix: exclude completed tasks from task list in the daily log view

### DIFF
--- a/client-interface/app/mentee/daily-log/page.tsx
+++ b/client-interface/app/mentee/daily-log/page.tsx
@@ -62,7 +62,7 @@ export default function MenteeDailyLog() {
     setNote(e?.note ?? '');
   }, [activeKey, entryByKey]);
 
-  const activeTasks = (tasks || []).filter((t: any) => !['cancelled'].includes(t.status));
+  const activeTasks = (tasks || []).filter((t: any) => !['completed', 'cancelled'].includes(t.status));
   const taskTitle = (t: any) => t?.roadmapTask?.title || t?.title || 'Task';
 
   const toggle = (id: string) =>


### PR DESCRIPTION
## Description

Small update to the filtering logic in `MenteeDailyLog` page. Tasks with status `'completed'` are now excluded from the active tasks list alongside `'cancelled'` tasks, so mentees only see tasks they are still working on.

Closes #573 

## Type of Change

- [x] Bug fix

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [x] I updated documentation where needed