### PR TITLE
fix(auth): Bug Fix: Preserve **"Keep me logged in for 30 days"** for 2FA Users

### DIFF
--- a/client-interface/lib/context/AuthContext.tsx
+++ b/client-interface/lib/context/AuthContext.tsx
@@ -179,7 +179,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       const response = await apiClient.post<any>(
         apiConfig.endpoints.verify2FALogin,
-        { code },
+        { code, rememberMe },
         {
           headers: {
             Authorization: `Bearer ${temporaryToken}`,


### PR DESCRIPTION
## Summary

This fix resolves an issue where users with **Two-Factor Authentication (2FA)** enabled were not receiving the advertised 30-day session when selecting **"Keep me logged in for 30 days"** during login.

Although the frontend preserved the checkbox state, the `rememberMe` value was not forwarded during the 2FA verification step. As a result, the backend always generated a **1-day refresh token**, causing affected users to be logged out after one day instead of thirty.

---

## Environment

| Property | Value |
|----------|-------|
| **App** | Client Interface / Server |
| **OS** | Ubuntu 24.04 LTS |
| **Browser** | Google Chrome (Latest) |

---

## Expected Behavior

When **"Keep me logged in for 30 days"** is selected, the user's session should remain valid for **30 days**, regardless of whether 2FA is enabled.

---

## Actual Behavior

For users with **2FA enabled**, the session expired after **1 day**, even when **"Keep me logged in for 30 days"** was selected.

---

## Root Cause

The login flow correctly stored the `rememberMe` value after the initial authentication step. However, during the subsequent **`/auth/verify-2fa-login`** request, the frontend did not include the `rememberMe` flag in the request payload.

Because the backend received `rememberMe` as `undefined`, it defaulted to `false` in `authController.verify2FALogin`. Consequently, `authService.verify2FADuringLogin` generated a **1-day (`1d`) refresh token** instead of the intended **30-day (`30d`) refresh token**.

### Flow

```text
Login
   ↓
rememberMe = true ✅
   ↓
2FA Verification
   ↓
rememberMe omitted ❌
   ↓
Server defaults to false
   ↓
Refresh Token = 1d
```

---

## Solution

Updated the 2FA verification request in **`AuthContext.tsx`** to include the `rememberMe` flag when calling:

```ts
apiConfig.endpoints.verify2FALogin
```

This ensures the backend receives the correct value and generates the appropriate refresh token duration.

---

## Testing

### Reproduction

1. Enable **Two-Factor Authentication** for a user.
2. Navigate to the login page.
3. Check **"Keep me logged in for 30 days"**.
4. Complete the login flow, including 2FA verification.

### Verification

- Confirm the `verify2FALogin` request includes:

```json
{
  "rememberMe": true
}
```

- Verify the server issues a **30-day refresh token**.
- Confirm the user remains authenticated according to the selected session duration.

---

## Result

✅ The **"Keep me logged in for 30 days"** option now works consistently for both standard and 2FA login flows, ensuring the correct refresh token expiration is applied.

## Issue closes : #606 

