### PR TITLE
security: fix patch admin takeover

### DIFF
--- a/server/src/services/adminService.js
+++ b/server/src/services/adminService.js
@@ -647,6 +647,10 @@ class AdminService {
     const user = await models.User.findByPk(targetUserId);
     if (!user) throw new NotFoundError('User not found');
 
+    if (user.role === 'admin') {
+      throw new ValidationError('Admin accounts cannot be modified through the general user management endpoint.');
+    }
+
     const before = { firstName: user.firstName, lastName: user.lastName, email: user.email, role: user.role };
 
     if (updates.firstName !== undefined) user.firstName = String(updates.firstName).trim().slice(0, 100);
@@ -667,9 +671,6 @@ class AdminService {
       if (!['mentee', 'mentor'].includes(updates.role)) {
         throw new ValidationError('Base role must be mentee or mentor');
       }
-      if (user.role === 'admin') {
-        throw new ValidationError('Admin accounts cannot be re-roled here — manage them in Roles & Access');
-      }
       user.role = updates.role; // beforeSave hook adds it to capabilities
     }
 
@@ -678,7 +679,7 @@ class AdminService {
     await createAuditLog({
       userId: adminUserId, action: 'USER_UPDATED_BY_ADMIN', entityType: 'User', entityId: user.id,
       oldValues: before, newValues: { firstName: user.firstName, lastName: user.lastName, email: user.email, role: user.role },
-    }).catch(() => {});
+    }).catch(() => { });
 
     return {
       id: user.id, firstName: user.firstName, lastName: user.lastName,
@@ -704,7 +705,7 @@ class AdminService {
 
     await createAuditLog({
       userId: adminUserId, action: 'USER_PASSWORD_SET_BY_ADMIN', entityType: 'User', entityId: user.id,
-    }).catch(() => {});
+    }).catch(() => { });
 
     return { message: `Password updated for ${user.firstName} ${user.lastName}. They've been signed out.` };
   }
@@ -732,7 +733,7 @@ class AdminService {
     await securityService.disable2FA(targetUserId);
     await createAuditLog({
       userId: adminUserId, action: 'USER_2FA_DISABLED_BY_ADMIN', entityType: 'User', entityId: targetUserId,
-    }).catch(() => {});
+    }).catch(() => { });
     return { message: `Two-factor disabled for ${user.firstName} ${user.lastName}. They can log in without a code and re-enable it in Settings.` };
   }
 


### PR DESCRIPTION
## Description

This PR fixes a security vulnerability that could allow unauthorized modification or potential takeover of admin accounts. Previously, the validation check preventing admin account modifications was nested inside the role update block. This meant that while an admin's role couldn't be changed through the general user management endpoint, other critical details (like their email or name) could still be modified. 

The fix moves the admin check to the top of the update operation, immediately throwing a `ValidationError` and blocking *any* modifications to admin accounts through this endpoint.

## Related Issue

Discussed with Mentor

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed
