### PR TITLE
fix: resolve clan selection bug for single-clan mentors

### DIFF
--- a/client-interface/components/mentor/ReviewScheduleDrawer.tsx
+++ b/client-interface/components/mentor/ReviewScheduleDrawer.tsx
@@ -103,14 +103,15 @@ export function ReviewScheduleDrawer({ open, onClose, clans, defaultClanId }: Pr
   const clanName = (id: string) => clans.find((c) => c.id === id)?.name || 'Clan';
 
   const submit = async () => {
-    if (!clanId) { toast.error('Pick a clan'); return; }
+    const finalClanId = clanId || defaultClanId || clans[0]?.id;
+    if (!finalClanId) { toast.error('Pick a clan'); return; }
     if (!/^\d{2}:\d{2}$/.test(timeLocal)) { toast.error('Pick a time'); return; }
     if (!startsOn) { toast.error('Pick a start date'); return; }
     if (endsOn && endsOn < startsOn) { toast.error('End date must be after the start date'); return; }
     try {
       setCreating(true);
       await mentorApi.createReviewSchedule({
-        clanId,
+        clanId: finalClanId,
         title: title.trim() || undefined,
         dayOfWeek: Number(dayOfWeek),
         timeLocal,


### PR DESCRIPTION
## Description

This PR fixes a bug in the `ReviewScheduleDrawer` component where single-clan mentors were unable to schedule recurring cohort reviews. 

Previously, when a mentor only had one clan, the "Clan" select dropdown was correctly hidden (`multiClan === false`), but the submit handler strictly checked the local `clanId` state. If the context loaded asynchronously, the state remained empty and blocked the submission with a "Pick a clan" toast error. 

This fix updates the submit handler to safely fallback to the `defaultClanId` or `clans[0]?.id` when the local state is empty, allowing single-clan mentors to schedule reviews smoothly.

## Related Issue
Closes #611

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

*(No UI changes were made. This is purely a validation logic fix for hidden fields.)*
