### PR TITLE
feat: add mentee upcoming review countdown card with reusable hook & …

### DIFF
--- a/client-interface/app/mentee/dashboard/page.tsx
+++ b/client-interface/app/mentee/dashboard/page.tsx
@@ -22,6 +22,8 @@ import { ActivityCard } from '@/components/shared/ActivityCard';
 import { RecurringRitualsCard } from '@/components/mentee/RecurringRitualsCard';
 import { AnnouncementsCard } from '@/components/shared/AnnouncementsCard';
 
+import { UpcomingReviewCard } from '@/features/reviews/components/UpcomingReviewCard';
+
 function MenteeDashboardInner() {
   const { user } = useAuth();
   const searchParams = useSearchParams();
@@ -115,6 +117,9 @@ function MenteeDashboardInner() {
           </span>
         </Link>
       )}
+
+      {/* Upcoming Cohort Review Countdown */}
+      <UpcomingReviewCard />
 
       {/* Recurring rituals (from your schedule) */}
       <RecurringRitualsCard />

--- a/client-interface/components/shared/CountdownTicker.tsx
+++ b/client-interface/components/shared/CountdownTicker.tsx
@@ -15,9 +15,9 @@ export function CountdownTicker({ timeLeft, showIcon = true, className = '' }: C
   }
 
   return (
-    <div className={`flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 p-3 backdrop-blur-md ${className}`}>
+    <div className={`flex items-center gap-2 rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/50 p-3 ${className}`}>
       {showIcon && (
-        <div className="flex items-center justify-center p-2 text-brand-400">
+        <div className="flex items-center justify-center p-2 text-brand-600 dark:text-brand-400">
           <Clock className="h-5 w-5 animate-spin-slow" />
         </div>
       )}
@@ -26,42 +26,42 @@ export function CountdownTicker({ timeLeft, showIcon = true, className = '' }: C
         {timeLeft.days > 0 && (
           <>
             <div className="flex flex-col">
-              <span className="text-lg font-extrabold text-white">
+              <span className="text-lg font-extrabold text-slate-900 dark:text-white">
                 {String(timeLeft.days).padStart(2, '0')}
               </span>
-              <span className="text-[10px] uppercase tracking-wider text-slate-400">
+              <span className="text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-400">
                 days
               </span>
             </div>
-            <span className="text-lg font-bold text-slate-500">:</span>
+            <span className="text-lg font-bold text-slate-400 dark:text-slate-600">:</span>
           </>
         )}
 
         <div className="flex flex-col">
-          <span className="text-lg font-extrabold text-white">
+          <span className="text-lg font-extrabold text-slate-900 dark:text-white">
             {String(timeLeft.hours).padStart(2, '0')}
           </span>
-          <span className="text-[10px] uppercase tracking-wider text-slate-400">
+          <span className="text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-400">
             hrs
           </span>
         </div>
-        <span className="text-lg font-bold text-slate-500">:</span>
+        <span className="text-lg font-bold text-slate-400 dark:text-slate-600">:</span>
 
         <div className="flex flex-col">
-          <span className="text-lg font-extrabold text-white">
+          <span className="text-lg font-extrabold text-slate-900 dark:text-white">
             {String(timeLeft.minutes).padStart(2, '0')}
           </span>
-          <span className="text-[10px] uppercase tracking-wider text-slate-400">
+          <span className="text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-400">
             mins
           </span>
         </div>
-        <span className="text-lg font-bold text-slate-500">:</span>
+        <span className="text-lg font-bold text-slate-400 dark:text-slate-600">:</span>
 
         <div className="flex flex-col">
-          <span className="text-lg font-extrabold text-brand-400">
+          <span className="text-lg font-extrabold text-brand-600 dark:text-brand-400">
             {String(timeLeft.seconds).padStart(2, '0')}
           </span>
-          <span className="text-[10px] uppercase tracking-wider text-slate-400">
+          <span className="text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-400">
             secs
           </span>
         </div>

--- a/client-interface/components/shared/CountdownTicker.tsx
+++ b/client-interface/components/shared/CountdownTicker.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Clock } from 'lucide-react';
+import { type TimeLeft } from '@/lib/hooks/useCountdown';
+
+interface CountdownTickerProps {
+  timeLeft: TimeLeft;
+  showIcon?: boolean;
+  className?: string;
+}
+
+export function CountdownTicker({ timeLeft, showIcon = true, className = '' }: CountdownTickerProps) {
+  if (timeLeft.isExpired) {
+    return null;
+  }
+
+  return (
+    <div className={`flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 p-3 backdrop-blur-md ${className}`}>
+      {showIcon && (
+        <div className="flex items-center justify-center p-2 text-brand-400">
+          <Clock className="h-5 w-5 animate-spin-slow" />
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 text-center tabular-nums">
+        {timeLeft.days > 0 && (
+          <>
+            <div className="flex flex-col">
+              <span className="text-lg font-extrabold text-white">
+                {String(timeLeft.days).padStart(2, '0')}
+              </span>
+              <span className="text-[10px] uppercase tracking-wider text-slate-400">
+                days
+              </span>
+            </div>
+            <span className="text-lg font-bold text-slate-500">:</span>
+          </>
+        )}
+
+        <div className="flex flex-col">
+          <span className="text-lg font-extrabold text-white">
+            {String(timeLeft.hours).padStart(2, '0')}
+          </span>
+          <span className="text-[10px] uppercase tracking-wider text-slate-400">
+            hrs
+          </span>
+        </div>
+        <span className="text-lg font-bold text-slate-500">:</span>
+
+        <div className="flex flex-col">
+          <span className="text-lg font-extrabold text-white">
+            {String(timeLeft.minutes).padStart(2, '0')}
+          </span>
+          <span className="text-[10px] uppercase tracking-wider text-slate-400">
+            mins
+          </span>
+        </div>
+        <span className="text-lg font-bold text-slate-500">:</span>
+
+        <div className="flex flex-col">
+          <span className="text-lg font-extrabold text-brand-400">
+            {String(timeLeft.seconds).padStart(2, '0')}
+          </span>
+          <span className="text-[10px] uppercase tracking-wider text-slate-400">
+            secs
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client-interface/features/reviews/components/UpcomingReviewCard.tsx
+++ b/client-interface/features/reviews/components/UpcomingReviewCard.tsx
@@ -5,6 +5,7 @@ import { Calendar, User, Users, Sparkles } from 'lucide-react';
 import { menteeApi } from '@/lib/services/mentee-api';
 import { useCountdown } from '@/lib/hooks/useCountdown';
 import { CountdownTicker } from '@/components/shared/CountdownTicker';
+import { formatMeeting } from '@/lib/utils/datetime';
 
 interface UpcomingReview {
   scheduleId: string;
@@ -44,15 +45,7 @@ export function UpcomingReviewCard() {
     return null;
   }
 
-  const scheduledDate = new Date(upcoming.scheduledAt);
-  const formattedDate = new Intl.DateTimeFormat('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZoneName: 'short',
-  }).format(scheduledDate);
+  const formattedDate = formatMeeting(upcoming.scheduledAt);
 
   return (
     <div className="relative overflow-hidden rounded-2xl border border-slate-800 bg-slate-900 p-5 text-white shadow-xl mb-6">

--- a/client-interface/features/reviews/components/UpcomingReviewCard.tsx
+++ b/client-interface/features/reviews/components/UpcomingReviewCard.tsx
@@ -48,30 +48,30 @@ export function UpcomingReviewCard() {
   const formattedDate = formatMeeting(upcoming.scheduledAt);
 
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-slate-800 bg-slate-900 p-5 text-white shadow-xl mb-6">
-      <div className="relative z-10 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+    <div className="bg-card rounded-2xl border border-slate-200 dark:border-slate-800 p-5 mb-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         {/* Left Side: Information */}
         <div className="space-y-2">
-          <div className="inline-flex items-center gap-2 rounded-full border border-brand-400/30 bg-brand-400/10 px-3 py-1 text-xs font-medium text-brand-300 backdrop-blur-md">
-            <Sparkles className="h-3.5 w-3.5 text-brand-300 animate-pulse" />
+          <div className="inline-flex items-center gap-2 rounded-full border border-brand-200 dark:border-brand-500/30 bg-brand-50 dark:bg-brand-500/10 px-3 py-1 text-xs font-medium text-brand-700 dark:text-brand-300">
+            <Sparkles className="h-3.5 w-3.5 text-brand-600 dark:text-brand-400 animate-pulse" />
             <span>Upcoming Cohort Review</span>
           </div>
 
-          <h3 className="text-xl font-bold tracking-tight text-white">
+          <h3 className="text-xl font-bold tracking-tight text-slate-900 dark:text-white">
             {upcoming.title}
           </h3>
 
-          <div className="flex flex-wrap items-center gap-y-1 gap-x-4 text-xs text-slate-300">
+          <div className="flex flex-wrap items-center gap-y-1 gap-x-4 text-xs text-slate-500 dark:text-slate-400">
             <span className="flex items-center gap-1.5">
-              <Users className="h-3.5 w-3.5 text-brand-400" />
+              <Users className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
               {upcoming.clanName}
             </span>
             <span className="flex items-center gap-1.5">
-              <User className="h-3.5 w-3.5 text-brand-400" />
+              <User className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
               Mentor: {upcoming.mentorName}
             </span>
             <span className="flex items-center gap-1.5">
-              <Calendar className="h-3.5 w-3.5 text-brand-400" />
+              <Calendar className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
               {formattedDate}
             </span>
           </div>

--- a/client-interface/features/reviews/components/UpcomingReviewCard.tsx
+++ b/client-interface/features/reviews/components/UpcomingReviewCard.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { Calendar, User, Users, Sparkles } from 'lucide-react';
+import { menteeApi } from '@/lib/services/mentee-api';
+import { useCountdown } from '@/lib/hooks/useCountdown';
+import { CountdownTicker } from '@/components/shared/CountdownTicker';
+
+interface UpcomingReview {
+  scheduleId: string;
+  title: string;
+  scheduledAt: string;
+  clanName: string;
+  mentorName: string;
+  durationMinutes: number;
+}
+
+export function UpcomingReviewCard() {
+  const [upcoming, setUpcoming] = useState<UpcomingReview | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchUpcoming = useCallback(async () => {
+    try {
+      const res = (await menteeApi.getUpcomingReview()) as {
+        data?: { upcoming: UpcomingReview | null };
+      };
+      setUpcoming(res?.data?.upcoming ?? null);
+    } catch {
+      setUpcoming(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchUpcoming();
+    const interval = setInterval(fetchUpcoming, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchUpcoming]);
+
+  const timeLeft = useCountdown(upcoming?.scheduledAt);
+
+  if (loading || !upcoming || timeLeft.isExpired) {
+    return null;
+  }
+
+  const scheduledDate = new Date(upcoming.scheduledAt);
+  const formattedDate = new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(scheduledDate);
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-slate-800 bg-slate-900 p-5 text-white shadow-xl mb-6">
+      <div className="relative z-10 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        {/* Left Side: Information */}
+        <div className="space-y-2">
+          <div className="inline-flex items-center gap-2 rounded-full border border-brand-400/30 bg-brand-400/10 px-3 py-1 text-xs font-medium text-brand-300 backdrop-blur-md">
+            <Sparkles className="h-3.5 w-3.5 text-brand-300 animate-pulse" />
+            <span>Upcoming Cohort Review</span>
+          </div>
+
+          <h3 className="text-xl font-bold tracking-tight text-white">
+            {upcoming.title}
+          </h3>
+
+          <div className="flex flex-wrap items-center gap-y-1 gap-x-4 text-xs text-slate-300">
+            <span className="flex items-center gap-1.5">
+              <Users className="h-3.5 w-3.5 text-brand-400" />
+              {upcoming.clanName}
+            </span>
+            <span className="flex items-center gap-1.5">
+              <User className="h-3.5 w-3.5 text-brand-400" />
+              Mentor: {upcoming.mentorName}
+            </span>
+            <span className="flex items-center gap-1.5">
+              <Calendar className="h-3.5 w-3.5 text-brand-400" />
+              {formattedDate}
+            </span>
+          </div>
+        </div>
+
+        {/* Right Side: Reusable Live Countdown Ticker */}
+        <div className="self-start md:self-auto">
+          <CountdownTicker timeLeft={timeLeft} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client-interface/lib/hooks/useCountdown.ts
+++ b/client-interface/lib/hooks/useCountdown.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+
+export interface TimeLeft {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  totalMs: number;
+  isExpired: boolean;
+}
+
+export function calculateTimeLeft(targetDateStr?: string | null): TimeLeft {
+  if (!targetDateStr) {
+    return { days: 0, hours: 0, minutes: 0, seconds: 0, totalMs: 0, isExpired: true };
+  }
+
+  const target = new Date(targetDateStr).getTime();
+  const now = Date.now();
+  const totalMs = target - now;
+
+  if (totalMs <= 0) {
+    return { days: 0, hours: 0, minutes: 0, seconds: 0, totalMs: 0, isExpired: true };
+  }
+
+  const seconds = Math.floor((totalMs / 1000) % 60);
+  const minutes = Math.floor((totalMs / (1000 * 60)) % 60);
+  const hours = Math.floor((totalMs / (1000 * 60 * 60)) % 24);
+  const days = Math.floor(totalMs / (1000 * 60 * 60 * 24));
+
+  return { days, hours, minutes, seconds, totalMs, isExpired: false };
+}
+
+/**
+ * Custom hook to calculate and update countdown time left for any target ISO date string.
+ */
+export function useCountdown(targetDateStr?: string | null): TimeLeft {
+  const [timeLeft, setTimeLeft] = useState<TimeLeft>(() => calculateTimeLeft(targetDateStr));
+
+  useEffect(() => {
+    if (!targetDateStr) {
+      setTimeLeft({ days: 0, hours: 0, minutes: 0, seconds: 0, totalMs: 0, isExpired: true });
+      return;
+    }
+
+    setTimeLeft(calculateTimeLeft(targetDateStr));
+
+    const timer = setInterval(() => {
+      const tl = calculateTimeLeft(targetDateStr);
+      setTimeLeft(tl);
+      if (tl.isExpired) {
+        clearInterval(timer);
+      }
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [targetDateStr]);
+
+  return timeLeft;
+}

--- a/client-interface/lib/services/mentee-api.ts
+++ b/client-interface/lib/services/mentee-api.ts
@@ -26,8 +26,9 @@ export const menteeApi = {
   // Is the signed-in user's mentee side paused? Powers the paused gate.
   getPauseState: () => apiClient.get('/mentee/pause-state'),
 
-  // Live cohort-review video (self-report attendance).
+  // Live cohort-review video (self-report attendance & upcoming countdown).
   getActiveReview: () => apiClient.get('/mentee/review/active'),
+  getUpcomingReview: () => apiClient.get('/mentee/review/upcoming'),
   joinReview: (sessionId: string, talkSeconds?: number) => apiClient.post(`/mentee/review/${sessionId}/join`, talkSeconds != null ? { talkSeconds } : {}),
   leaveReview: (sessionId: string, seconds: number) => apiClient.post(`/mentee/review/${sessionId}/leave`, { seconds }),
 

--- a/server/src/controllers/reviewMeetingController.js
+++ b/server/src/controllers/reviewMeetingController.js
@@ -56,6 +56,10 @@ const active = catchAsync(async (req, res) => {
   const meeting = await svc.activeForMentee(req.user.id);
   res.status(200).json(successResponse('Active review', { meeting }));
 });
+const upcoming = catchAsync(async (req, res) => {
+  const upcoming = await svc.upcomingForMentee(req.user.id);
+  res.status(200).json(successResponse('Upcoming review', { upcoming }));
+});
 const join = catchAsync(async (req, res) => {
   const result = await svc.selfPresent(req.user.id, req.params.id, { talkSeconds: req.body?.talkSeconds });
   res.status(200).json(successResponse('Joined', result));
@@ -65,4 +69,4 @@ const leave = catchAsync(async (req, res) => {
   res.status(200).json(successResponse('Left', result));
 });
 
-module.exports = { config, start, end, setAttendanceTracking, setPolls, hostView, markPresent, recordTalk, proposeContribution, finalizeContribution, active, join, leave };
+module.exports = { config, start, end, setAttendanceTracking, setPolls, hostView, markPresent, recordTalk, proposeContribution, finalizeContribution, active, upcoming, join, leave };

--- a/server/src/routes/mentee.js
+++ b/server/src/routes/mentee.js
@@ -22,8 +22,9 @@ router.post('/daily-log', authenticate, authorize(['mentee', 'admin']), dailyLog
 // can ask about their own state (a mentor who is also a mentee included).
 router.get('/pause-state', authenticate, mentorshipPauseController.selfPauseState);
 
-// Live cohort-review video: discover the active room, and self-report presence.
+// Live cohort-review video: discover the active room, upcoming review, and self-report presence.
 router.get('/review/active', authenticate, reviewMeetingController.active);
+router.get('/review/upcoming', authenticate, reviewMeetingController.upcoming);
 router.post('/review/:id/join', authenticate, reviewMeetingController.join);
 router.post('/review/:id/leave', authenticate, reviewMeetingController.leave);
 

--- a/server/src/services/reviewMeetingService.js
+++ b/server/src/services/reviewMeetingService.js
@@ -4,7 +4,7 @@ const { models } = require('../db');
 const { NotFoundError, ForbiddenError, ValidationError } = require('../utils/errors/errorTypes');
 const authzService = require('./authzService');
 const cfg = require('../config/reviewMeeting');
-const { activeOccurrence } = require('../utils/reviewRecurrence');
+const { activeOccurrence, nextOccurrences } = require('../utils/reviewRecurrence');
 
 // A live meeting older than this with no explicit end is treated as abandoned —
 // stops a never-ended meeting from showing the mentee "Join" banner forever.
@@ -344,6 +344,45 @@ class ReviewMeetingService {
     const user = await models.User.findByPk(userId, { attributes: ['id', 'firstName', 'lastName', 'profilePictureUrl'] });
     const clan = await models.Clan.findByPk(session.clanId, { attributes: ['name'] });
     return { ...this._joinConfig(session, this._fullName(user), user && user.profilePictureUrl), clanName: clan?.name || 'your clan' };
+  }
+
+  /** Next upcoming scheduled review for the mentee's clan (or null). */
+  async upcomingForMentee(userId) {
+    if (!cfg.enabled) return null;
+    const clanIds = (await models.ClanMembership.findAll({
+      where: { userId, role: 'mentee', status: { [Op.in]: ['active', 'paused'] } },
+      attributes: ['clanId'], raw: true,
+    })).map((m) => m.clanId).filter(Boolean);
+    if (!clanIds.length) return null;
+
+    const now = new Date();
+    const schedules = await models.ReviewSchedule.findAll({
+      where: { clanId: { [Op.in]: clanIds }, active: true },
+      include: [
+        { model: models.Clan, as: 'clan', attributes: ['id', 'name'] },
+        { model: models.User, as: 'mentor', attributes: ['id', 'firstName', 'lastName'] },
+      ],
+    });
+
+    let earliest = null;
+    for (const s of schedules) {
+      const occs = nextOccurrences(s, now, 1);
+      if (!occs || !occs.length) continue;
+      const occ = occs[0];
+      if (!occ || new Date(occ.start).getTime() <= now.getTime()) continue;
+      if (!earliest || new Date(occ.start).getTime() < new Date(earliest.scheduledAt).getTime()) {
+        const mentorName = s.mentor ? `${s.mentor.firstName || ''} ${s.mentor.lastName || ''}`.trim() : 'Mentor';
+        earliest = {
+          scheduleId: s.id,
+          title: s.title || `${s.clan?.name || 'Clan'} cohort review`,
+          scheduledAt: occ.start,
+          clanName: s.clan?.name || 'Clan',
+          mentorName,
+          durationMinutes: s.durationMinutes || 60,
+        };
+      }
+    }
+    return earliest;
   }
 
   /** Mark the AUTHENTICATED mentee present (self-report). Only marks themselves. */


### PR DESCRIPTION
## Description

This PR introduces an **Upcoming Review Countdown Card** for mentees on their dashboard. 

### Key Improvements & Changes:
1. **Backend Endpoint (`GET /api/mentee/review/upcoming`):** Queries active recurring schedules for the mentee's clan and returns the nearest upcoming occurrence details.
2. **Feature-Driven Component (`features/reviews/components/UpcomingReviewCard.tsx`):** Renders a solid dark blue card displaying the clan name, mentor name, formatted date, and a live ticking countdown.
3. **Reusable Hook (`lib/hooks/useCountdown.ts`):** Extracted time calculation and 1-second interval ticking into a generic hook for future use across deadlines/events.
4. **Reusable UI (`components/shared/CountdownTicker.tsx`):** Standalone ticker UI component for rendering `Days : Hours : Mins : Secs`.
5. **Dashboard Integration (`app/mentee/dashboard/page.tsx`):** Mounted at the top of the mentee dashboard. Gracefully hides when no review is upcoming or when a call goes live.

## Related Issue

#613 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s) (`npx tsc --noEmit` passed with 0 errors)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)
<img width="1361" height="653" alt="image" src="https://github.com/user-attachments/assets/ceb54bac-895f-4224-a068-c531d482e63d" />
