### PR TITLE
feat: send automated check-in notification to absent mentees when rev…

### DIFF
--- a/server/src/services/cohortReviewService.js
+++ b/server/src/services/cohortReviewService.js
@@ -291,7 +291,7 @@ class CohortReviewService {
           recipients: [{ userId: entry.menteeId, email: entry.mentee?.email }],
           payload: {
             title: `We missed you at today's review!`,
-            message: `Hi ${menteeName}, you were missed during today's cohort review session for ${clanName}. Be sure to check your dashboard for notes and stay on track for the next session!`,
+            message: `Hi ${menteeName}, you were missed during today's cohort review session for ${clanName}. Be sure to check your dashboard and stay on track for the next session!`,
             actionUrl: '/mentee/dashboard',
             actionLabel: 'View Dashboard',
             relatedEntityType: 'review_session',

--- a/server/src/services/cohortReviewService.js
+++ b/server/src/services/cohortReviewService.js
@@ -259,11 +259,57 @@ class CohortReviewService {
     return this._entryJson(fresh);
   }
 
+  /**
+   * Notify absent mentees when a cohort review session is completed.
+   * Sends an automated email and in-app check-in message.
+   */
+  async _notifyAbsentMentees(session) {
+    if (!session || !session.id) return;
+    try {
+      await this._reconcileEntries(session);
+      const absentEntries = await models.CohortReviewEntry.findAll({
+        where: {
+          sessionId: session.id,
+          [Op.or]: [{ attendance: 'absent' }, { attendance: null }],
+        },
+        include: [{ model: models.User, as: 'mentee', attributes: ['id', 'email', 'firstName', 'lastName'] }],
+      });
+
+      if (!absentEntries.length) return;
+
+      const clan = session.clanId ? await models.Clan.findByPk(session.clanId, { attributes: ['name'] }) : null;
+      const clanName = clan?.name || 'your clan';
+
+      const notificationOrchestrator = require('./notificationOrchestrator');
+      const { NOTIFICATION_EVENTS } = require('../config/notificationMatrix');
+
+      for (const entry of absentEntries) {
+        if (!entry.menteeId) continue;
+        const menteeName = entry.mentee?.firstName || 'Mentee';
+        await notificationOrchestrator.dispatch({
+          eventKey: NOTIFICATION_EVENTS.REVIEW_REMINDER,
+          recipients: [{ userId: entry.menteeId, email: entry.mentee?.email }],
+          payload: {
+            title: `We missed you at today's review!`,
+            message: `Hi ${menteeName}, you were missed during today's cohort review session for ${clanName}. Be sure to check your dashboard for notes and stay on track for the next session!`,
+            actionUrl: '/mentee/dashboard',
+            actionLabel: 'View Dashboard',
+            relatedEntityType: 'review_session',
+          },
+          channelOverrides: { inApp: true, email: true },
+        }).catch((e) => console.error(`[review] absent notify failed for mentee ${entry.menteeId}:`, e.message));
+      }
+    } catch (err) {
+      console.error('[review] _notifyAbsentMentees failed (non-fatal):', err.message);
+    }
+  }
+
   async finishSession(mentorId, sessionId) {
     const session = await this._canAccess(mentorId, sessionId);
     session.status = 'finished';
     session.finishedAt = new Date();
     await session.save();
+    this._notifyAbsentMentees(session).catch(() => {});
     return this._withEntries(session);
   }
 

--- a/server/src/services/reviewMeetingService.js
+++ b/server/src/services/reviewMeetingService.js
@@ -176,6 +176,7 @@ class ReviewMeetingService {
       patch.finishedAt = session.finishedAt || new Date();
     }
     if (Object.keys(patch).length) await session.update(patch);
+    require('./cohortReviewService')._notifyAbsentMentees(session).catch(() => {});
     return this._joinConfig(session, null);
   }
 


### PR DESCRIPTION
## Description

This PR introduces an automated check-in system for mentees who miss live cohort review sessions. Previously, if a mentee didn't attend a review, they wouldn't receive any targeted follow-up unless a mentor manually reached out.

**Changes included:**
- Added `_notifyAbsentMentees(session)` helper in `cohortReviewService.js` to query for any mentees in a session's clan with an `absent` or `null` attendance record.
- Dispatches a friendly, empathetic email and in-app bell notification via `notificationOrchestrator` ("We missed you at today's review!").
- Hooked up this logic to trigger automatically when a mentor finishes a review (`finishSession`) or ends a live video meeting (`endMeeting`).
- Designed to execute non-blockingly (`.catch()`) to prevent any delay or failure in the mentor's UI response.

## Related Issue

 Closes #615 
 
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [x] I updated documentation where needed

## Screenshots (Required for UI changes)

N/A - Backend logic only (Email/In-App Notifications dispatched by existing worker system).
