### PR TITLE
feat(mentee tasks): split My Tasks into Active and Completed views

### DIFF
--- a/client-interface/app/mentee/tasks/page.tsx
+++ b/client-interface/app/mentee/tasks/page.tsx
@@ -19,9 +19,13 @@ export default function MenteeTasks() {
     selectedEnrollmentId,
     filterStatus,
     searchTerm,
+    view,
+    activeCount,
+    completedCount,
     setSelectedEnrollmentId,
     setFilterStatus,
     setSearchTerm,
+    setView,
     handleStartTask,
     fetchTasks,
   } = useMenteeTasks();
@@ -129,24 +133,63 @@ export default function MenteeTasks() {
         <StatsCard icon={AlertCircle}   label="Overdue"        value={stats?.overdue || 0}     colorClass="text-red-600 bg-red-50" />
       </div>
 
+      {/* Active / Completed toggle */}
+      <div className="inline-flex rounded-xl border border-slate-200 bg-card p-1">
+        <button
+          onClick={() => setView('active')}
+          aria-pressed={view === 'active'}
+          className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+            view === 'active'
+              ? 'bg-brand-600 text-white shadow-sm'
+              : 'text-slate-600 hover:text-brand-600'
+          }`}
+        >
+          <Clock className="w-4 h-4" />
+          Active
+          {loading ? null : (
+            <span className={`text-xs tabular-nums ${view === 'active' ? 'text-white/80' : 'text-slate-400'}`}>
+              {activeCount}
+            </span>
+          )}
+        </button>
+        <button
+          onClick={() => setView('completed')}
+          aria-pressed={view === 'completed'}
+          className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+            view === 'completed'
+              ? 'bg-brand-600 text-white shadow-sm'
+              : 'text-slate-600 hover:text-brand-600'
+          }`}
+        >
+          <CheckCircle2 className="w-4 h-4" />
+          Completed
+          {loading ? null : (
+            <span className={`text-xs tabular-nums ${view === 'completed' ? 'text-white/80' : 'text-slate-400'}`}>
+              {completedCount}
+            </span>
+          )}
+        </button>
+      </div>
+
       {/* Filters */}
       <SearchAndFilterBar
         search={searchTerm}
         onSearch={setSearchTerm}
-        placeholder="Search tasks..."
+        placeholder={view === 'completed' ? 'Search completed tasks...' : 'Search tasks...'}
         filters={[
-          {
-            value: filterStatus,
-            onChange: setFilterStatus,
-            options: [
-              { value: 'all', label: 'All Tasks' },
-              { value: 'assigned', label: 'New Tasks' },
-              { value: 'in_progress', label: 'In Progress' },
-              { value: 'submitted', label: 'Submitted' },
-              { value: 'revision_needed', label: 'Needs Revision' },
-              { value: 'completed', label: 'Completed' },
-            ],
-          },
+          ...(view === 'active'
+            ? [{
+                value: filterStatus,
+                onChange: setFilterStatus,
+                options: [
+                  { value: 'all', label: 'All Tasks' },
+                  { value: 'assigned', label: 'New Tasks' },
+                  { value: 'in_progress', label: 'In Progress' },
+                  { value: 'submitted', label: 'Submitted' },
+                  { value: 'revision_needed', label: 'Needs Revision' },
+                ],
+              }]
+            : []),
         ]}
       />
 
@@ -158,10 +201,22 @@ export default function MenteeTasks() {
           </div>
         ) : filteredTasks.length === 0 ? (
           <div className="text-center py-12">
-            <CheckCircle2 className="w-12 h-12 text-slate-300 mx-auto mb-3" />
-            <p className="text-slate-600 mb-2">No tasks found</p>
+            {view === 'completed' ? (
+              <CheckCircle2 className="w-12 h-12 text-slate-300 mx-auto mb-3" />
+            ) : (
+              <ClipboardList className="w-12 h-12 text-slate-300 mx-auto mb-3" />
+            )}
+            <p className="text-slate-600 mb-2">
+              {view === 'completed' ? 'No completed tasks yet' : 'No active tasks'}
+            </p>
             <p className="text-slate-500 text-sm">
-              {searchTerm ? 'Try a different search term' : filterStatus !== 'all' ? 'No tasks in this category' : 'Tasks will appear here when assigned'}
+              {searchTerm
+                ? 'Try a different search term'
+                : filterStatus !== 'all'
+                  ? 'No tasks in this category'
+                  : view === 'completed'
+                    ? 'Completed tasks will appear here when you finish them'
+                    : 'Tasks will appear here when assigned'}
             </p>
           </div>
         ) : (

--- a/client-interface/lib/hooks/mentee/useMenteeTasks.ts
+++ b/client-interface/lib/hooks/mentee/useMenteeTasks.ts
@@ -7,6 +7,8 @@ import { enrollmentApi } from '@/lib/services/enrollment-api';
 import { toast } from 'sonner';
 import { useAuth } from '@/lib/context/AuthContext';
 
+export type TaskView = 'active' | 'completed';
+
 export interface UseMenteeTasksReturn {
   tasks: any[];
   filteredTasks: any[];
@@ -16,9 +18,13 @@ export interface UseMenteeTasksReturn {
   selectedEnrollmentId: string | null;
   filterStatus: string;
   searchTerm: string;
+  view: TaskView;
+  activeCount: number;
+  completedCount: number;
   setSelectedEnrollmentId: (id: string | null) => void;
   setFilterStatus: (status: string) => void;
   setSearchTerm: (term: string) => void;
+  setView: (view: TaskView) => void;
   handleStartTask: (taskId: string) => Promise<void>;
   fetchTasks: () => Promise<void>;
 }
@@ -34,6 +40,7 @@ export function useMenteeTasks(): UseMenteeTasksReturn {
   const [enrollmentsReady, setEnrollmentsReady] = useState(false);
   const [filterStatus, setFilterStatus] = useState<string>('all');
   const [searchTerm, setSearchTerm] = useState('');
+  const [view, setView] = useState<TaskView>('active');
 
   const fetchEnrollments = useCallback(async () => {
     if (!user?.id) return;
@@ -96,15 +103,50 @@ export function useMenteeTasks(): UseMenteeTasksReturn {
     }
   }, [fetchTasks]);
 
+  const changeView = useCallback((next: TaskView) => {
+    setView(next);
+    // A completed/active split is meaningless if a conflicting status filter is
+    // still applied, so clear it whenever the view flips.
+    setFilterStatus('all');
+  }, []);
+
+  const isActiveStatus = (status: string) =>
+    ['assigned', 'in_progress', 'submitted', 'revision_needed'].includes(status);
+
   const filteredTasks = useMemo(() => {
-    if (!searchTerm.trim()) return tasks;
-    const lower = searchTerm.toLowerCase();
-    return tasks.filter(
-      (task) =>
-        task.roadmapTask?.title?.toLowerCase().includes(lower) ||
-        task.roadmapTask?.description?.toLowerCase().includes(lower)
-    );
-  }, [tasks, searchTerm]);
+    let list = tasks;
+    if (view === 'completed') {
+      list = list.filter((task) => task.status === 'completed');
+    } else {
+      list = list.filter((task) => isActiveStatus(task.status));
+    }
+    if (searchTerm.trim()) {
+      const lower = searchTerm.toLowerCase();
+      list = list.filter(
+        (task) =>
+          task.roadmapTask?.title?.toLowerCase().includes(lower) ||
+          task.roadmapTask?.description?.toLowerCase().includes(lower)
+      );
+    }
+    // Active view: actionable, due-soonest tasks first (overdue > due date > none).
+    if (view === 'active') {
+      list = [...list].sort((a: any, b: any) => {
+        const aDate = a.dueDate ? new Date(a.dueDate).getTime() : Infinity;
+        const bDate = b.dueDate ? new Date(b.dueDate).getTime() : Infinity;
+        return aDate - bDate;
+      });
+    }
+    return list;
+  }, [tasks, view, searchTerm]);
+
+  const activeCount = useMemo(
+    () => tasks.filter((task) => isActiveStatus(task.status)).length,
+    [tasks]
+  );
+  const completedCount = useMemo(
+    () => tasks.filter((task) => task.status === 'completed').length,
+    [tasks]
+  );
 
   return {
     tasks,
@@ -115,9 +157,13 @@ export function useMenteeTasks(): UseMenteeTasksReturn {
     selectedEnrollmentId,
     filterStatus,
     searchTerm,
+    view,
+    activeCount,
+    completedCount,
     setSelectedEnrollmentId,
     setFilterStatus,
     setSearchTerm,
+    setView: changeView,
     handleStartTask,
     fetchTasks,
   };


### PR DESCRIPTION
Closes #622  

## Description

The mentee My Tasks screen mixed completed work into the same track-grouped list as actionable tasks, so finished tasks buried what actually needed attention and completed history wasn't separately reviewable.

Add an Active/Completed toggle below the stats row with live per-view counts:
- Active (default): only assigned / in_progress / submitted / revision_needed tasks, grouped by track, sorted overdue-first then by due date. Cancelled tasks (which rendered "No action needed") no longer clutter the list.
- Completed (opt-in): finished tasks only, keeping their star ratings/points.

View switching clears any conflicting status filter, the status dropdown is hidden in Completed view (search still applies), and empty states are distinct per view ("No active tasks" vs "No completed tasks yet").

## Related Issue

Closes #<!-- add issue number once created -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s) — `npx eslint lib/hooks/mentee/useMenteeTasks.ts app/mentee/tasks/page.tsx` (only pre-existing `no-explicit-any` errors in untouched lines remain)
- [x] I ran build checks for impacted app(s) — `npx tsc --noEmit` (only stale `.next/types` artifacts; source files clean), dev server compiles and serves /mentee/tasks
- [ ] I ran tests for impacted app(s), or confirmed no test suite exists for this change — no frontend test suite exists for the mentee tasks page
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

<!-- Add before/after screenshots or a short screen recording for frontend changes -->

Before: single track-grouped list with completed and active tasks mixed together.

After: Active view (default) shows only actionable tasks; Completed toggle shows finished tasks with counts.


### Before 
<img width="1920" height="891" alt="image" src="https://github.com/user-attachments/assets/00da7683-1687-4713-8a55-98b38516a2f3" />


### After


<img width="1920" height="891" alt="image" src="https://github.com/user-attachments/assets/a316529e-66c5-49b2-af2f-22724a713ccb" />


<img width="1920" height="891" alt="image" src="https://github.com/user-attachments/assets/1d2fdd00-aa8c-4552-ace2-5049a447aa95" />
