### PR TITLE
feat(scoring): implement 2D task weight matrix (task type x difficulty)

### DIFF
--- a/server/src/config/scoring.js
+++ b/server/src/config/scoring.js
@@ -68,6 +68,31 @@ const DIFFICULTY_WEIGHT = Object.freeze({
 const DEFAULT_DIFFICULTY_WEIGHT = DIFFICULTY_WEIGHT.medium;
 
 /**
+ * 2D Task Weight Matrix combining Task Type and Difficulty.
+ * Prevents task farming (e.g. 15 easy exercises outranking 1 hard project).
+ */
+const TASK_WEIGHT_MATRIX = Object.freeze({
+  exercise:   { easy: 0.2, medium: 1.0, hard: 2.5, expert: 4.0 },
+  assignment: { easy: 0.3, medium: 1.2, hard: 2.8, expert: 4.5 },
+  practical:  { easy: 0.5, medium: 1.5, hard: 3.0, expert: 5.0 },
+  project:    { easy: 2.0, medium: 4.0, hard: 6.0, expert: 8.0 },
+  assessment: { easy: 1.0, medium: 2.0, hard: 4.0, expert: 6.0 },
+  quiz:       { easy: 0.1, medium: 0.4, hard: 1.0, expert: 1.5 },
+  reading:    { easy: 0.1, medium: 0.3, hard: 0.6, expert: 1.0 },
+  video:      { easy: 0.1, medium: 0.3, hard: 0.6, expert: 1.0 },
+  discussion: { easy: 0.2, medium: 0.5, hard: 1.0, expert: 1.5 },
+  interview:  { easy: 1.0, medium: 2.5, hard: 5.0, expert: 7.5 },
+  custom:     { easy: 0.5, medium: 1.0, hard: 2.5, expert: 4.0 }
+});
+
+function taskOutputWeight(type, difficulty) {
+  const tKey = String(type || 'exercise').toLowerCase();
+  const dKey = String(difficulty || 'medium').toLowerCase();
+  const row = TASK_WEIGHT_MATRIX[tKey] || TASK_WEIGHT_MATRIX.exercise;
+  return row[dKey] ?? row.medium;
+}
+
+/**
  * How long a piece of work was expected to take.
  *
  * Two generations of roadmap authoring are in the database and they are
@@ -224,6 +249,8 @@ module.exports = {
   DIMENSIONS,
   DIMENSION_KEYS,
   DIFFICULTY_WEIGHT,
+  TASK_WEIGHT_MATRIX,
+  taskOutputWeight,
   EFFORT_HOURS,
   effortHours,
   ELIGIBILITY,

--- a/server/src/services/cohortService.js
+++ b/server/src/services/cohortService.js
@@ -316,7 +316,7 @@ class CohortService {
       tasks = await models.AssignedTask.findAll({
         where: taskWhere,
         attributes: ['id', 'status', 'isLate', 'completedAt', 'dueDate', 'enrollmentId', 'pointsAwarded'],
-        include: [{ model: models.RoadmapTask, as: 'roadmapTask', attributes: ['difficulty'], required: false }]
+        include: [{ model: models.RoadmapTask, as: 'roadmapTask', attributes: ['difficulty', 'type'], required: false }]
       });
 
       delays = await models.DelayEvent.findAll({
@@ -385,6 +385,7 @@ class CohortService {
       lastAttendance, // { status, date } | null — most recent review attendance
       taskCount: tasks.length, // total assigned tasks — 0 = never been given work
       tasksCompleted: tasks.filter((t) => t.status === 'completed').length, // real output, for effort-weighted leaderboard
+      completedTasks: tasks.filter((t) => t.status === 'completed'),
       pointsEarned: tasks.filter((t) => t.status === 'completed').reduce((s, t) => s + (t.pointsAwarded || 0), 0),
       // Per-difficulty counts on completed tasks — drives the leaderboard breakdown and AI report brief.
       tasksEasy:   tasks.filter((t) => t.status === 'completed' && (t.roadmapTask?.difficulty || '').toLowerCase() === 'easy').length,
@@ -787,7 +788,7 @@ class CohortService {
       models.AssignedTask.findAll({
         where: { menteeId: inIds },
         attributes: ['id', 'status', 'isLate', 'completedAt', 'dueDate', 'menteeId', 'enrollmentId', 'pointsAwarded'],
-        include: [{ model: models.RoadmapTask, as: 'roadmapTask', attributes: ['difficulty'], required: false }]
+        include: [{ model: models.RoadmapTask, as: 'roadmapTask', attributes: ['difficulty', 'type'], required: false }]
       }),
       models.DelayEvent.findAll({
         where: { menteeId: inIds },

--- a/server/src/services/performanceService.js
+++ b/server/src/services/performanceService.js
@@ -4,6 +4,7 @@ const cohortService = require('./cohortService');
 const scoringSettingsService = require('./scoringSettingsService');
 const {
   DIFFICULTY_WEIGHT,
+  taskOutputWeight,
   EFFORT_HOURS,
   ELIGIBILITY,
   attendanceScore,
@@ -162,8 +163,16 @@ class PerformanceService {
     return out;
   }
 
-  /** Difficulty-weighted count of finished work. */
+  /** Task Type x Difficulty-weighted count of finished work. */
   weightedOutput(row) {
+    if (Array.isArray(row.completedTasks)) {
+      return row.completedTasks.reduce((sum, task) => {
+        const type = task.type || task.roadmapTask?.type || 'custom';
+        const difficulty = task.difficulty || task.roadmapTask?.difficulty || 'medium';
+        return sum + taskOutputWeight(type, difficulty);
+      }, 0);
+    }
+
     return (
       (row.tasksEasy || 0) * DIFFICULTY_WEIGHT.easy +
       (row.tasksMedium || 0) * DIFFICULTY_WEIGHT.medium +

--- a/server/tests/scoring/performance-service.test.js
+++ b/server/tests/scoring/performance-service.test.js
@@ -30,6 +30,28 @@ describe('weightedOutput', () => {
     expect(threeHard).toBeGreaterThan(sixEasy);
   });
 
+  it('ranks 1 hard project above 15 easy exercises using 2D matrix', () => {
+    const fifteenEasyExercises = perf.weightedOutput({
+      completedTasks: Array(15).fill({ type: 'exercise', difficulty: 'easy' })
+    });
+    const oneHardProject = perf.weightedOutput({
+      completedTasks: [{ type: 'project', difficulty: 'hard' }]
+    });
+
+    expect(fifteenEasyExercises).toBeCloseTo(3.0); // 15 * 0.2
+    expect(oneHardProject).toBeCloseTo(6.0);       // 1 * 6.0
+    expect(oneHardProject).toBeGreaterThan(fifteenEasyExercises);
+  });
+
+  it('safely handles custom one-off tasks with null roadmapTask', () => {
+    const customTask = perf.weightedOutput({
+      completedTasks: [{ roadmapTask: null }]
+    });
+
+    // Falls back to type 'custom' and difficulty 'medium' -> weight 1.0
+    expect(customTask).toBeCloseTo(1.0);
+  });
+
   it('is zero for somebody who has finished nothing', () => {
     expect(perf.weightedOutput({})).toBe(0);
   });


### PR DESCRIPTION
## Description

This PR fixes a fundamental scoring flaw in the leaderboard calculation engine where difficulty weights were 1-dimensional (`easy: 0.6`, `medium: 1.0`, `hard: 1.6`). Because task types were ignored, completing 15 Easy Exercises ($15 \times 0.6 = 9.0$) outranked 1 Hard Project ($1 \times 1.6 = 1.6$), enabling task farming and down-ranking high-impact project work across 3000+ mentees.

**What was changed:**
1. **2D Matrix Config (`server/src/config/scoring.js`)**: Introduced `TASK_WEIGHT_MATRIX` combining 11 Task Types (`project`, `exercise`, `assignment`, `interview`, etc.) × 4 Difficulty levels (`easy`, `medium`, `hard`, `expert`). Added `taskOutputWeight(type, difficulty)` lookup helper.
2. **Query Enrichment (`server/src/services/cohortService.js`)**: Eager-loaded task `type` in `RoadmapTask` model includes and attached `completedTasks` to mentee rows.
3. **Calculation & Defensive Fallbacks (`server/src/services/performanceService.js`)**: Updated `weightedOutput(row)` to sum individual task weights using 2D matrix multipliers. Added defensive fallbacks (`custom` type / `medium` difficulty) for one-off tasks with null `roadmapTask`.
4. **Unit Tests (`server/tests/scoring/performance-service.test.js`)**: Added test cases verifying 1 Hard Project ($6.0$) outranks 15 Easy Exercises ($3.0$), as well as non-roadmap custom task handling.

## Related Issue

Closes #630 

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [x] I updated documentation where needed

## Screenshots (Required for UI changes)

N/A (Backend scoring engine logic change)
