### PR TITLE
Feature/submission image viewer

### DIFF
--- a/client-interface/app/mentee/feedback/[id]/page.tsx
+++ b/client-interface/app/mentee/feedback/[id]/page.tsx
@@ -22,6 +22,7 @@ import {
 import { useTaskDetail } from '@/lib/hooks/mentee';
 import { toExternalHref } from '@/lib/utils/url';
 import { RichContent } from '@/components/shared/RichContent';
+import { SubmissionFileList } from '@/components/shared/SubmissionFileList';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -283,6 +284,14 @@ export default function FeedbackView({ params }: PageProps) {
                 </div>
               </div>
             )}
+
+          {/* Attachments */}
+          {latestSubmission.files && latestSubmission.files.length > 0 && (
+            <div className="mb-6">
+              <h3 className="text-slate-700 text-sm font-medium mb-2">Attachments</h3>
+              <SubmissionFileList files={latestSubmission.files} />
+            </div>
+          )}
 
           {latestSubmission.submittedAt && (
             <p className="text-xs text-slate-400 flex items-center gap-1">

--- a/client-interface/app/mentee/tasks/[id]/page.tsx
+++ b/client-interface/app/mentee/tasks/[id]/page.tsx
@@ -22,6 +22,7 @@ import {
   ListChecks,
 } from 'lucide-react';
 import { ResourceLink } from '@/components/shared/ResourceLink';
+import { SubmissionFileList } from '@/components/shared/SubmissionFileList';
 import { useTaskDetail } from '@/lib/hooks/mentee';
 import { PageHeader, StatusBadge } from '@/components/admin/ui';
 import { useActivityTracker } from '@/lib/hooks/shared/useActivityTracker';
@@ -305,6 +306,14 @@ export default function TaskDetailsPage({ params }: PageProps) {
                       </li>
                     ))}
                   </ul>
+                </div>
+              )}
+
+              {/* Submission files */}
+              {latestSubmission.files && latestSubmission.files.length > 0 && (
+                <div>
+                  <p className="text-xs text-slate-500 mb-2">Attachments</p>
+                  <SubmissionFileList files={latestSubmission.files} />
                 </div>
               )}
 

--- a/client-interface/app/mentor/tasks/[id]/feedback/page.tsx
+++ b/client-interface/app/mentor/tasks/[id]/feedback/page.tsx
@@ -7,8 +7,6 @@ import {
   CheckCircle2,
   AlertCircle,
   ExternalLink,
-  FileText,
-  Download,
   User,
   Calendar,
   RotateCw,
@@ -16,9 +14,9 @@ import {
   Loader2
 } from 'lucide-react';
 import RichTextEditor from '@/components/shared/RichTextEditor';
+import { SubmissionFileList } from '@/components/shared/SubmissionFileList';
 import { useMentorTaskFeedback } from '@/lib/hooks/mentor';
 import { PageHeader } from '@/components/admin/ui';
-import { formatFileSize } from '@/lib/utils/formatting';
 import { pointsForDifficulty } from '@/lib/config/points';
 
 interface PageProps {
@@ -219,33 +217,7 @@ export default function FeedbackProvision({ params }: PageProps) {
         {submission.files && submission.files.length > 0 && (
           <div>
             <h4 className="text-sm text-slate-700 mb-3">File Attachments</h4>
-            <div className="space-y-2">
-              {submission.files.map((file: any) => (
-                <div
-                  key={file.id}
-                  className="flex items-center justify-between p-3 bg-slate-50 border border-slate-200 rounded-lg"
-                >
-                  <div className="flex items-center gap-3">
-                    <FileText className="w-5 h-5 text-slate-600" />
-                    <div>
-                      <p className="text-sm text-slate-900">{file.fileName}</p>
-                      {Number(file.fileSizeBytes) > 0 && (
-                        <p className="text-xs text-slate-500">{formatFileSize(Number(file.fileSizeBytes))}</p>
-                      )}
-                    </div>
-                  </div>
-                  <a
-                    href={file.fileUrl}
-                    download
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="p-2 hover:bg-slate-200 rounded transition-colors"
-                  >
-                    <Download className="w-4 h-4 text-slate-600" />
-                  </a>
-                </div>
-              ))}
-            </div>
+            <SubmissionFileList files={submission.files} />
           </div>
         )}
       </div>

--- a/client-interface/components/mentor/ReviewDrawer.tsx
+++ b/client-interface/components/mentor/ReviewDrawer.tsx
@@ -9,6 +9,7 @@ import { FeedbackAssist } from '@/components/mentor/FeedbackAssist';
 import { looksLikeHtml } from '@/lib/utils/html';
 import { toExternalHref } from '@/lib/utils/url';
 import { RichContent } from '@/components/shared/RichContent';
+import { SubmissionFileList } from '@/components/shared/SubmissionFileList';
 import type { ApprovalItem } from '@/lib/hooks/mentor';
 
 type Decision = 'approved' | 'approved_notes' | 'changes' | 'rejected';
@@ -169,6 +170,12 @@ export function ReviewDrawer({
             html={item.submissionText}
             className="rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 p-4 text-slate-700 dark:text-slate-300"
           />
+          {item.files.length > 0 && (
+            <div className="mt-3">
+              <p className="text-xs font-medium text-slate-500 mb-1.5">Attachments</p>
+              <SubmissionFileList files={item.files} />
+            </div>
+          )}
           {item.submissionUrls.length > 0 && (
             <div className="mt-2 space-y-1">
               {item.submissionUrls.map((u, i) => (

--- a/client-interface/components/shared/ImageLightbox.tsx
+++ b/client-interface/components/shared/ImageLightbox.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import type { SubmissionFile } from '@/lib/types/submission';
+
+interface ImageLightboxProps {
+  file: SubmissionFile;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Move to the previous image in the submission. */
+  onPrev?: () => void;
+  /** Move to the next image in the submission. */
+  onNext?: () => void;
+  /** Hide/disable the previous arrow (first image). */
+  canPrev?: boolean;
+  /** Hide/disable the next arrow (last image). */
+  canNext?: boolean;
+  /** Position indicator, e.g. "2 / 5". */
+  positionLabel?: string;
+}
+
+/**
+ * Full-size viewer for a submission image. Fully controlled: the parent owns
+ * the open state and current image. Arrows navigate through the submission's
+ * images; the parent supplies the callbacks.
+ */
+export function ImageLightbox({
+  file,
+  open,
+  onOpenChange,
+  onPrev,
+  onNext,
+  canPrev = true,
+  canNext = true,
+  positionLabel,
+}: ImageLightboxProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl bg-slate-950 border-slate-800 p-0 overflow-hidden">
+        <DialogTitle className="sr-only">Image preview</DialogTitle>
+        <DialogDescription className="sr-only">
+          Preview of {file.fileName}
+        </DialogDescription>
+
+        <div className="relative flex items-center justify-center bg-black/60 min-h-[50vh] max-h-[80vh] p-4">
+          {onPrev && (
+            <button
+              type="button"
+              onClick={onPrev}
+              disabled={!canPrev}
+              aria-label="Previous image"
+              className="absolute left-3 z-10 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 disabled:opacity-0 disabled:pointer-events-none transition-opacity"
+            >
+              <ChevronLeft className="w-6 h-6" />
+            </button>
+          )}
+
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={file.fileUrl}
+            alt={file.fileName}
+            className="max-w-full max-h-[78vh] rounded-lg object-contain"
+          />
+
+          {onNext && (
+            <button
+              type="button"
+              onClick={onNext}
+              disabled={!canNext}
+              aria-label="Next image"
+              className="absolute right-3 z-10 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 disabled:opacity-0 disabled:pointer-events-none transition-opacity"
+            >
+              <ChevronRight className="w-6 h-6" />
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between px-4 py-3 bg-slate-900 border-t border-slate-800">
+          <p className="text-sm text-slate-200 truncate">{file.fileName}</p>
+          {positionLabel && <span className="text-xs text-slate-400 shrink-0">{positionLabel}</span>}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client-interface/components/shared/SubmissionFileList.tsx
+++ b/client-interface/components/shared/SubmissionFileList.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+import { Download, FileText } from 'lucide-react';
+import { formatFileSize } from '@/lib/utils/formatting';
+import { isImageFile } from '@/lib/utils/file-type';
+import { ImageLightbox } from '@/components/shared/ImageLightbox';
+import type { SubmissionFile } from '@/lib/types/submission';
+
+interface SubmissionFileListProps {
+  files: SubmissionFile[];
+}
+
+/**
+ * Renders a submission's attached files.
+ *
+ * - Images render inline with a click-to-zoom lightbox (plus download).
+ * - Everything else renders as an icon row with a download link.
+ *
+ * Open/closed: rendering per file kind is delegated so new kinds (video, pdf
+ * previews, …) can be added without touching the list itself.
+ */
+export function SubmissionFileList({ files }: SubmissionFileListProps) {
+  const images = files.filter((file) => isImageFile(file.fileType));
+  const [zoomIndex, setZoomIndex] = useState<number | null>(null);
+
+  const renderImage = (file: SubmissionFile) => (
+    <div
+      key={file.id}
+      className="rounded-lg border border-slate-200 overflow-hidden bg-slate-50 w-24"
+    >
+      <button
+        type="button"
+        onClick={() => setZoomIndex(images.findIndex((f) => f.id === file.id))}
+        className="block w-full group cursor-zoom-in"
+        title="Click to zoom"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={file.fileUrl}
+          alt={file.fileName}
+          className="w-full h-20 object-cover bg-slate-100 group-hover:opacity-95 transition-opacity"
+        />
+      </button>
+      <div className="flex items-center justify-between gap-1 px-2 py-1.5 bg-card">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <div className="min-w-0">
+            <p className="text-xs text-slate-900 truncate">{file.fileName}</p>
+            {Number(file.fileSizeBytes) > 0 && (
+              <p className="text-[11px] text-slate-500">{formatFileSize(Number(file.fileSizeBytes))}</p>
+            )}
+          </div>
+        </div>
+        <a
+          href={file.fileUrl}
+          download
+          target="_blank"
+          rel="noopener noreferrer"
+          className="p-1.5 hover:bg-slate-200 rounded transition-colors shrink-0"
+          title="Download"
+        >
+          <Download className="w-3.5 h-3.5 text-slate-600" />
+        </a>
+      </div>
+    </div>
+  );
+
+  const renderOther = (file: SubmissionFile) => (
+    <div
+      key={file.id}
+      className="flex items-center justify-between p-3 bg-slate-50 border border-slate-200 rounded-lg"
+    >
+      <div className="flex items-center gap-3 min-w-0">
+        <FileText className="w-5 h-5 text-slate-600 shrink-0" />
+        <div className="min-w-0">
+          <p className="text-sm text-slate-900 truncate">{file.fileName}</p>
+          {Number(file.fileSizeBytes) > 0 && (
+            <p className="text-xs text-slate-500">{formatFileSize(Number(file.fileSizeBytes))}</p>
+          )}
+        </div>
+      </div>
+      <a
+        href={file.fileUrl}
+        download
+        target="_blank"
+        rel="noopener noreferrer"
+        className="p-2 hover:bg-slate-200 rounded transition-colors shrink-0"
+        title="Download"
+      >
+        <Download className="w-4 h-4 text-slate-600" />
+      </a>
+    </div>
+  );
+
+  if (files.length === 0) return null;
+
+  const zoomed = zoomIndex !== null ? images[zoomIndex] : null;
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-1.5">
+        {files.map((file) => (isImageFile(file.fileType) ? renderImage(file) : renderOther(file)))}
+      </div>
+
+      {zoomed && zoomIndex !== null && (
+        <ImageLightbox
+          file={zoomed}
+          open
+          onOpenChange={(open) => !open && setZoomIndex(null)}
+          onPrev={() => setZoomIndex((i) => (i === null ? i : Math.max(0, i - 1)))}
+          onNext={() => setZoomIndex((i) => (i === null ? i : Math.min(images.length - 1, i + 1)))}
+          canPrev={zoomIndex > 0}
+          canNext={zoomIndex < images.length - 1}
+          positionLabel={`${zoomIndex + 1} / ${images.length}`}
+        />
+      )}
+    </>
+  );
+}

--- a/client-interface/lib/hooks/mentor/useMentorApprovals.ts
+++ b/client-interface/lib/hooks/mentor/useMentorApprovals.ts
@@ -3,6 +3,7 @@ import { useClan, ALL_CLANS } from '@/lib/context/ClanContext';
 import { mentorApi } from '@/lib/services/mentor-api';
 import { notifyApprovalsChanged } from '@/lib/utils/approvals-badge';
 import { submissionService } from '@/lib/services/submissionService';
+import type { SubmissionFile } from '@/lib/types/submission';
 
 export interface BulkReviewPayload {
   decision: 'approved' | 'approved_notes' | 'changes' | 'rejected';
@@ -26,6 +27,7 @@ export interface ApprovalItem {
   version: number;
   submissionText: string;
   submissionUrls: string[];
+  files: SubmissionFile[];
   submittedAt: string;
   isLate: boolean;
   title: string;

--- a/client-interface/lib/types/submission.ts
+++ b/client-interface/lib/types/submission.ts
@@ -1,0 +1,17 @@
+// Submission-related types.
+
+/**
+ * A file attached to a task submission.
+ *
+ * This is the minimal shape every submission-file source must satisfy (task
+ * submissions, review queue items, …). Components depend on this abstraction
+ * rather than on concrete API response shapes.
+ */
+export interface SubmissionFile {
+  id: string | number;
+  fileName: string;
+  fileUrl: string;
+  /** MIME type, e.g. "image/png". May be absent for legacy rows. */
+  fileType?: string | null;
+  fileSizeBytes?: number | null;
+}

--- a/client-interface/lib/utils/file-type.ts
+++ b/client-interface/lib/utils/file-type.ts
@@ -1,0 +1,9 @@
+/**
+ * Pure file-type helpers. Keep these framework-free so any module (components,
+ * hooks, utilities) can classify a file without coupling to rendering.
+ */
+
+/** True when the MIME type is an image we can preview inline. */
+export function isImageFile(fileType?: string | null): boolean {
+  return Boolean(fileType && fileType.startsWith('image/'));
+}

--- a/server/src/services/submissionService.js
+++ b/server/src/services/submissionService.js
@@ -980,6 +980,12 @@ class SubmissionService {
           { model: models.RoadmapTask, as: 'roadmapTask', attributes: ['title', 'type', 'description', 'deliverable', 'acceptanceCriteria', 'pointsBase', 'difficulty'] },
           { model: models.User, as: 'mentee', attributes: ['id', 'firstName', 'lastName', 'profilePictureUrl'] }
         ]
+      },
+      {
+        model: models.TaskSubmissionFile,
+        as: 'files',
+        required: false,
+        attributes: ['id', 'fileName', 'fileUrl', 'fileType', 'fileSizeBytes']
       }],
       order: [['submittedAt', 'ASC']]
     });
@@ -1032,6 +1038,13 @@ class SubmissionService {
         version: s.version,
         submissionText: s.submissionText,
         submissionUrls: s.submissionUrls || [],
+        files: (s.files || []).map((f) => ({
+          id: f.id,
+          fileName: f.fileName,
+          fileUrl: f.fileUrl,
+          fileType: f.fileType,
+          fileSizeBytes: f.fileSizeBytes,
+        })),
         submittedAt: s.submittedAt,
         isLate: t.isLate,
         // Extension-request fields — lets the client split the queue into a


### PR DESCRIPTION
### Closes #633  

## Description

Adds inline preview + lightbox for images attached to task submissions, on both the mentee and mentor sides.

- New shared `SubmissionFileList` component: images render as small thumbnails (click to zoom), other files as a download row.
- New `ImageLightbox` modal with prev/next arrows + position counter to flip through all images in a submission.
- New `SubmissionFile` type + `isImageFile` helper so components depend on one abstraction.


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

Before: submitted images showed only as a plain filename/download link.
After: images show as small thumbnails; clicking opens a full-size lightbox with prev/next arrows.

(Add before/after screenshots here)


<img width="1345" height="840" alt="image" src="https://github.com/user-attachments/assets/1d6d3e23-6ef5-4611-8945-d4fe7e365445" />
<img width="1345" height="840" alt="image" src="https://github.com/user-attachments/assets/d4c3bbf1-9e94-4816-9a40-528e34ce48c8" />
