### PR TITLE
fix: keep attendance sheet open after save

### DIFF
--- a/client-interface/components/mentor/attendance/AttendanceModal.tsx
+++ b/client-interface/components/mentor/attendance/AttendanceModal.tsx
@@ -56,7 +56,7 @@ export function AttendanceModal({ isOpen, onClose, mentees, initialAttendance, o
             onClick={onClose}
             className="px-4 py-2 border border-slate-200 text-slate-700 rounded-xl text-sm hover:bg-slate-50"
           >
-            Cancel
+            Done
           </button>
           <button
             onClick={handleSave}

--- a/client-interface/components/mentor/attendance/AttendanceSection.tsx
+++ b/client-interface/components/mentor/attendance/AttendanceSection.tsx
@@ -54,11 +54,6 @@ export function AttendanceSection({
     });
   }, [cohort, attendance, currentFilter]);
 
-  const handleSave = async (updates: Record<string, Attendance>) => {
-    await onSaveAttendance(updates);
-    setIsModalOpen(false);
-  };
-
   return (
     <div className="space-y-3 mb-6">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
@@ -112,7 +107,7 @@ export function AttendanceSection({
         onClose={() => setIsModalOpen(false)}
         mentees={cohort}
         initialAttendance={attendance}
-        onSave={handleSave}
+        onSave={onSaveAttendance}
         isSaving={isSaving}
       />
     </div>


### PR DESCRIPTION
## Description

Saving attendance no longer closes the Attendance Sheet drawer. Mentors can keep marking other mentees without reopening the sheet; the drawer only closes via **Done**, the backdrop, or Escape.

## Related Issue

Closes #638

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [ ] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

N/A — behavior-only change (drawer stays open after Save). Cancel renamed to Done to match the new close path.
