### PR TITLE
feat: add reusable clan invite-via-link

### DIFF
--- a/client-interface/app/(public)/join/[slug]/page.tsx
+++ b/client-interface/app/(public)/join/[slug]/page.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import { Loader2, Lock, Users, UserPlus, LogIn, Mail } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { publicApi, type ClanJoinInfo } from '@/lib/services/public-api';
+import { extractApiErrorMessage } from '@/lib/utils/api-error';
+import { useAuth } from '@/lib/context/AuthContext';
+
+const CLOSED: Record<string, { label: string; copy: string }> = {
+  disabled: { label: 'Closed', copy: 'This join link is currently turned off.' },
+  inactive: { label: 'Not accepting members', copy: 'This clan is not active.' },
+  full: { label: 'Clan full', copy: 'This clan has reached its mentee limit.' },
+  not_found: { label: 'Not found', copy: 'This join link is not valid.' },
+};
+
+export default function ClanJoinPage() {
+  const params = useParams();
+  const router = useRouter();
+  const slug = String(params?.slug || '');
+  const { user, isLoading: authLoading, isAuthenticated } = useAuth();
+
+  const [info, setInfo] = useState<ClanJoinInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [joining, setJoining] = useState(false);
+  const [email, setEmail] = useState('');
+  const [requesting, setRequesting] = useState(false);
+  const [requestMsg, setRequestMsg] = useState('');
+
+  useEffect(() => {
+    if (!slug) return;
+    publicApi.getClanInvite(slug)
+      .then(setInfo)
+      .catch(() => setError('This join link is not valid.'))
+      .finally(() => setLoading(false));
+  }, [slug]);
+
+  const join = async () => {
+    setJoining(true);
+    try {
+      const result = await publicApi.joinClan(slug);
+      toast.success(result.alreadyMember ? 'You are already in this clan' : `Joined ${result.clan?.name || 'the clan'}`);
+      router.push('/mentee/dashboard');
+    } catch (e) {
+      toast.error(extractApiErrorMessage(e, 'Could not join this clan'));
+    } finally {
+      setJoining(false);
+    }
+  };
+
+  const requestInvite = async () => {
+    if (!email.trim()) { toast.error('Enter your email'); return; }
+    setRequesting(true);
+    try {
+      const r = await publicApi.requestClanInvite(slug, email.trim());
+      setRequestMsg(r?.message || 'If that email can join, we\'ve sent a registration link.');
+    } catch (e) {
+      toast.error(extractApiErrorMessage(e, 'Could not send a registration link'));
+    } finally {
+      setRequesting(false);
+    }
+  };
+
+  if (loading || authLoading) {
+    return <div className="py-24 flex justify-center"><Loader2 className="w-8 h-8 animate-spin text-brand-600" /></div>;
+  }
+
+  if (error || !info) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-16 text-center">
+        <div className="inline-flex w-12 h-12 rounded-2xl bg-slate-100 items-center justify-center mb-4"><Lock className="w-5 h-5 text-slate-500" /></div>
+        <h1 className="text-xl font-semibold text-slate-900 mb-2">Join link not valid</h1>
+        <p className="text-sm text-slate-500">{error || 'This clan invite could not be found.'}</p>
+      </div>
+    );
+  }
+
+  const reason = info.reasons[0];
+  const closed = !info.open ? (CLOSED[reason] || { label: 'Closed', copy: 'This clan is not accepting join-link members right now.' }) : null;
+  const spots = info.maxMentees != null ? `${info.menteeCount}/${info.maxMentees} mentees` : `${info.menteeCount} mentee${info.menteeCount === 1 ? '' : 's'}`;
+  const next = `/join/${encodeURIComponent(slug)}`;
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-12">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-400 mb-2">{info.program?.name || 'Pathment'}</p>
+      <h1 className="text-2xl font-semibold text-slate-900">{info.clan.name}</h1>
+      {info.clan.description && <p className="mt-2 text-sm text-slate-600 whitespace-pre-wrap">{info.clan.description}</p>}
+      <p className="mt-3 text-sm text-slate-500 inline-flex items-center gap-1.5"><Users className="w-4 h-4" />{spots}</p>
+
+      {closed ? (
+        <div className="mt-8 rounded-2xl border border-slate-200 bg-card p-6">
+          <p className="text-sm font-medium text-slate-900">{closed.label}</p>
+          <p className="text-sm text-slate-500 mt-1">{closed.copy}</p>
+        </div>
+      ) : isAuthenticated && user ? (
+        <div className="mt-8 rounded-2xl border border-slate-200 bg-card p-6 space-y-4">
+          <p className="text-sm text-slate-600">Signed in as <span className="font-medium text-slate-900">{user.email}</span>. Join this clan as a mentee.</p>
+          <button onClick={join} disabled={joining} className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-brand-600 hover:bg-brand-700 text-white text-sm font-medium disabled:opacity-50">
+            {joining ? <Loader2 className="w-4 h-4 animate-spin" /> : <UserPlus className="w-4 h-4" />}
+            Join {info.clan.name}
+          </button>
+        </div>
+      ) : (
+        <div className="mt-8 rounded-2xl border border-slate-200 bg-card p-6 space-y-5">
+          <div>
+            <p className="text-sm font-medium text-slate-900 mb-2">Already have an account?</p>
+            <Link href={`/login?next=${encodeURIComponent(next)}`} className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-brand-600 hover:bg-brand-700 text-white text-sm font-medium">
+              <LogIn className="w-4 h-4" /> Log in to join
+            </Link>
+          </div>
+          <div className="pt-4 border-t border-slate-100">
+            <p className="text-sm font-medium text-slate-900 mb-1">New here?</p>
+            <p className="text-xs text-slate-500 mb-3">Enter your email and we&apos;ll send a registration link that places you in this clan.</p>
+            {requestMsg ? (
+              <p className="text-sm text-emerald-700 bg-emerald-50 rounded-lg px-3 py-2">{requestMsg}</p>
+            ) : (
+              <div className="flex gap-2">
+                <input value={email} onChange={(e) => setEmail(e.target.value)} type="email" placeholder="you@example.com"
+                  onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); requestInvite(); } }}
+                  className="flex-1 px-3 py-2 border border-slate-200 rounded-lg text-sm bg-card focus:outline-none focus:ring-2 focus:ring-brand-500" />
+                <button onClick={requestInvite} disabled={requesting} className="px-3 py-2 rounded-lg border border-slate-200 text-slate-700 text-sm font-medium hover:bg-slate-50 disabled:opacity-50 inline-flex items-center gap-1.5">
+                  {requesting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Mail className="w-4 h-4" />} Send link
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client-interface/app/mentor/clan-team/page.tsx
+++ b/client-interface/app/mentor/clan-team/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Check, Crown, HeartHandshake, Loader2, Search, Shield, SlidersHorizontal, Trash2, UserPlus, Users2, X } from 'lucide-react';
+import { Check, Copy, Crown, HeartHandshake, Link2, Loader2, Search, Shield, SlidersHorizontal, Trash2, UserPlus, Users2, X } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { apiClient } from '@/lib/services/api-client';
@@ -230,6 +230,7 @@ function ClanTeamCard({ clanId, myRole }: { clanId: string; myRole: string }) {
       </div>
 
       <div className="mt-5 space-y-5">
+        {(canManageTeam || canAddMentees) && <ClanInviteLinkPanel clanId={clanId} />}
         <Section icon={<Crown className="w-3.5 h-3.5" />} title="Lead mentor" items={lead} removable={false} />
         <Section icon={<Shield className="w-3.5 h-3.5" />} title="Co-mentors" items={co} removable managePerms />
         <Section icon={<Users2 className="w-3.5 h-3.5" />} title="Core team" items={core} removable />
@@ -244,6 +245,79 @@ function ClanTeamCard({ clanId, myRole }: { clanId: string; myRole: string }) {
       {canManageTeam && adding && <AddTeamMemberDrawer clanId={clanId} onClose={() => setAdding(false)} onAdded={() => { setAdding(false); load(); }} />}
       {canAddMentees && addingMentees && <AddMenteesDrawer clanId={clanId} clanName={clan.name} onClose={() => setAddingMentees(false)} onChanged={() => load()} />}
       {canManageTeam && permMember && <CoMentorPermissionsDrawer clanId={clanId} userId={permMember.user.id} name={name(permMember.user)} onClose={() => setPermMember(null)} onSaved={load} />}
+    </div>
+  );
+}
+
+function ClanInviteLinkPanel({ clanId }: { clanId: string }) {
+  const [link, setLink] = useState<{ enabled: boolean; slug: string | null; joinUrl: string | null } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(() => {
+    clanApi.getInviteLink(clanId)
+      .then((r: any) => setLink(r.data?.link || r.data || null))
+      .catch(() => setLink(null))
+      .finally(() => setLoading(false));
+  }, [clanId]);
+  useEffect(load, [load]);
+
+  const enable = async () => {
+    setBusy(true);
+    try {
+      const r: any = await clanApi.enableInviteLink(clanId);
+      setLink(r.data?.link || r.data);
+      toast.success('Join link enabled');
+    } catch (e) { toast.error(extractApiErrorMessage(e, 'Could not enable the join link')); }
+    finally { setBusy(false); }
+  };
+
+  const disable = async () => {
+    setBusy(true);
+    try {
+      const r: any = await clanApi.disableInviteLink(clanId);
+      setLink(r.data?.link || r.data);
+      toast.success('Join link turned off');
+    } catch (e) { toast.error(extractApiErrorMessage(e, 'Could not disable the join link')); }
+    finally { setBusy(false); }
+  };
+
+  const copy = async () => {
+    if (!link?.joinUrl) return;
+    try {
+      await navigator.clipboard.writeText(link.joinUrl);
+      setCopied(true);
+      toast.success('Join link copied');
+      setTimeout(() => setCopied(false), 1500);
+    } catch { toast.error('Could not copy'); }
+  };
+
+  if (loading) return null;
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50/60 dark:bg-slate-900/40 px-3 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-400 inline-flex items-center gap-1.5"><Link2 className="w-3.5 h-3.5" /> Invite via link</p>
+          <p className="text-xs text-slate-500 mt-0.5">Share one reusable link. Anyone with it can join this clan as a mentee — no per-email invite.</p>
+        </div>
+        {link?.enabled ? (
+          <button onClick={disable} disabled={busy} className="shrink-0 px-2.5 py-1 rounded-lg border border-slate-200 text-xs text-slate-600 hover:bg-white disabled:opacity-50">Turn off</button>
+        ) : (
+          <button onClick={enable} disabled={busy} className="shrink-0 px-2.5 py-1 rounded-lg bg-brand-600 text-white text-xs font-medium hover:bg-brand-700 disabled:opacity-50 inline-flex items-center gap-1">
+            {busy && <Loader2 className="w-3 h-3 animate-spin" />} Enable link
+          </button>
+        )}
+      </div>
+      {link?.enabled && link.joinUrl && (
+        <div className="mt-2 flex items-center gap-2">
+          <input readOnly value={link.joinUrl} className="flex-1 min-w-0 px-2.5 py-1.5 rounded-lg border border-slate-200 bg-white text-xs text-slate-700 truncate" />
+          <button onClick={copy} className="shrink-0 p-1.5 rounded-lg border border-slate-200 text-slate-600 hover:bg-white" aria-label="Copy join link">
+            {copied ? <Check className="w-4 h-4 text-emerald-600" /> : <Copy className="w-4 h-4" />}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/client-interface/lib/services/clan-api.ts
+++ b/client-interface/lib/services/clan-api.ts
@@ -49,6 +49,9 @@ export const clanApi = {
   // candidate pool for adding a co-mentor / core-team member (incl. re-adding a removed one).
   candidates: (id: string, q?: string) => apiClient.get(`/clans/${id}/candidates`, { params: q ? { q } : {} }),
   inviteToClan: (id: string, email: string) => apiClient.post(`/clans/${id}/invite`, { email }),
+  getInviteLink: (id: string) => apiClient.get(`/clans/${id}/invite-link`),
+  enableInviteLink: (id: string) => apiClient.post(`/clans/${id}/invite-link`),
+  disableInviteLink: (id: string) => apiClient.delete(`/clans/${id}/invite-link`),
   /** Move a mentee to a different clan (admin). Same program keeps progress; a
    *  different program wipes the old enrollment + tasks (clean transfer). */
   reassign: (menteeId: string, toClanId: string) => apiClient.post('/clans/reassign', { menteeId, toClanId }),

--- a/client-interface/lib/services/public-api.ts
+++ b/client-interface/lib/services/public-api.ts
@@ -43,6 +43,15 @@ export interface ApplyInfo {
   assessment: { required: boolean } | null;
 }
 
+export interface ClanJoinInfo {
+  open: boolean;
+  reasons: string[];
+  clan: { name: string; description?: string | null };
+  program: { name: string } | null;
+  menteeCount: number;
+  maxMentees: number | null;
+}
+
 export interface PublicAssessmentQuestion {
   id: string;
   type: 'mcq' | 'multi_select' | 'short_text' | 'long_text' | 'file_upload' | 'external_link';
@@ -95,6 +104,21 @@ export const publicApi = {
 
   withdraw: (token: string) =>
     apiClient.post<any>(`/public/applications/${encodeURIComponent(token)}/withdraw`, {}).then((r) => r.data as { ok: boolean }),
+
+  getClanInvite: (slug: string) =>
+    apiClient.get<any>(`/public/clans/${encodeURIComponent(slug)}`).then((r) => r.data as ClanJoinInfo),
+
+  joinClan: (slug: string) =>
+    apiClient.post<any>(`/public/clans/${encodeURIComponent(slug)}/join`, {}).then((r) => r.data as {
+      alreadyMember?: boolean;
+      clan?: { id: string; name: string };
+    }),
+
+  requestClanInvite: (slug: string, email: string) =>
+    apiClient.post<any>(`/public/clans/${encodeURIComponent(slug)}/request-invite`, { email }).then((r) => r.data as {
+      ok: boolean;
+      message: string;
+    }),
 
   uploadFile: (token: string, file: File) => {
     const fd = new FormData();

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -283,6 +283,8 @@ erDiagram
         int maxMentees
         string status "active | inactive | archived"
         string healthStatus "green | amber | red"
+        string inviteSlug "shareable /join/<slug>"
+        boolean inviteEnabled
     }
     CLAN_MEMBERSHIP {
         uuid id PK
@@ -962,6 +964,7 @@ with `up`/`down`, run with `--rollback` to reverse). The latest is **053**. Nota
 | 051 | Scheduling timezones (`starts_at`/`timezone` on slots & meetings; `timezone` on templates/mentee schedules) |
 | 052 | Email-queue resilience (retry/backoff, DLQ, idempotency, `provider_message_id`) + `suppressed_emails` |
 | 053 | Roadmap chaining (`roadmap_links` graph + `enrollments.auto_advance_roadmaps`) |
+| 093 | Clan reusable invite link (`invite_slug` + `invite_enabled`) |
 
 > **First deploy note:** `npm run db:sync` builds the full schema from the models in one
 > shot (the models already encode every migration's end state), so a brand-new database does

--- a/docs/features/programs-cohorts-clans.md
+++ b/docs/features/programs-cohorts-clans.md
@@ -10,7 +10,7 @@ into clans led by mentors, within a program, admitted via a cohort.
 ## Data model
 `Program` (type, status `draft|published|archived`, visibility `private|public`,
 enrollments). `Cohort` (intake season - see [Intake](./intake-and-assessments.md)). `Clan`
-(programId, leadMentorId, maxMentees, healthStatus). `ClanMembership` (clanId, userId, role
+(programId, leadMentorId, maxMentees, healthStatus, optional `inviteSlug` + `inviteEnabled` for a reusable join link). `ClanMembership` (clanId, userId, role
 `lead_mentor|co_mentor|mentee|core_team`, status, enrollmentId). `ClanChangeRequest`
 (permanent move between clans). `CrossClanAssignment` (temporary cross-clan help:
 `cover|specialist|co_mentee_access`, with `status` `pending|active|declined` - only
@@ -18,17 +18,19 @@ enrollments). `Cohort` (intake season - see [Intake](./intake-and-assessments.md
 
 ## Backend
 - **Programs (`/api/programs`):** list (public sees published+public; admins/creators see all), detail, create/clone (mentor+admin), update/delete (ownership-checked), stats, enrollments.
-- **Clans (`/api/clans`):** list, detail, `me/memberships`, `mentor/programs`, `health` + `insights` (`analytics.view`), create (`clan.create`), update + member add/remove (`clan.manage_members` scoped to the clan). `clanService.addMember(clanId,{userId,role})` is how a co-mentor/core-team member is added - and the authz engine derives that person's clan permissions from the membership.
+- **Clans (`/api/clans`):** list, detail, `me/memberships`, `mentor/programs`, `health` + `insights` (`analytics.view`), create (`clan.create`), update + member add/remove (`clan.manage_members` scoped to the clan). `GET/POST/DELETE /:id/invite-link` (lead mentor or `mentee.add`) mints a reusable `/join/<slug>` URL. `clanService.addMember(clanId,{userId,role})` is how a co-mentor/core-team member is added - and the authz engine derives that person's clan permissions from the membership.
+- **Public clan join (`/api/public/clans/:slug`):** preview; `POST .../join` (authenticated) auto-joins as a mentee; `POST .../request-invite` emails a clan-scoped registration invite for new accounts.
 - **Clan requests (`/api/clan-requests`):** change-request create (mentee) + resolve (admin); **cross-clan list/create/remove** gated by `clan.manage_members` *scoped to the target clan* - so admins manage org-wide **and a clan's lead mentor self-serves cover for their own clan**. **Consent-first:** `cross-clan/mine` (the addressee's inbox) + `cross-clan/:id/respond` (accept/decline) - a lead's request is `pending` until the person accepts; an admin-created assignment is `active` at once.
 
 ## Frontend
 - **Admin:** `/admin/programs/list` + `/admin/programs/[id]`, `/admin/clans`, `/admin/requests` (change requests, cross-clan), `/admin/insights` (clan health/fairness).
-- **Mentor:** `/mentor/programs` (+ `[id]`) - programs they run; **`/mentor/clan-team`** - manage their clan's co-mentors/core-team **and request cross-clan cover/specialist help** for their clan (lead mentors only).
+- **Mentor:** `/mentor/programs` (+ `[id]`) - programs they run; **`/mentor/clan-team`** - manage their clan's co-mentors/core-team **and request cross-clan cover/specialist help** for their clan (lead mentors only). Lead mentors can also **enable a shareable join link** from Clan Team.
+- **Public:** `/join/[slug]` — anyone with the link can log in to join, or request a registration email that places them in that clan.
 - **Mentee:** sees their clan implicitly (via enrollment + community space).
 
 ## Role flows
 - **Admin:** creates programs, opens cohorts, creates clans, assigns lead mentors, places mentees (via accept/enrollment), resolves clan change requests, and sets up cross-clan help (cover/specialist).
-- **Lead mentor:** runs their clan - adds **co-mentors / core-team** on the Clan Team page, **requests cross-clan cover** (e.g. while on leave), renames the clan; reviews/mentors its members. Requesting cover **notifies the person to accept** (in-app + email, `cross_clan_assigned`) and sends **admins an in-app oversight notification** (`/admin/requests?tab=cross`); access is granted only once the person accepts, and the requester is notified of the accept/decline.
+- **Lead mentor:** runs their clan - adds **co-mentors / core-team** on the Clan Team page, can **enable a shareable join link** (`/join/<slug>`) so people can join without a per-email invite, **requests cross-clan cover** (e.g. while on leave), renames the clan; reviews/mentors its members. Requesting cover **notifies the person to accept** (in-app + email, `cross_clan_assigned`) and sends **admins an in-app oversight notification** (`/admin/requests?tab=cross`); access is granted only once the person accepts, and the requester is notified of the accept/decline.
 - **Covering person:** sees pending requests at the top of their **Clan Team** page (and via the notification) and **accepts or declines**; on accept they gain temporary co-mentor access to that clan until it's removed (they're notified then too).
 - **Co-mentor:** mentors within the clan (review tasks, see mentees) but **cannot** change membership.
 - **Mentee:** belongs to one clan; can request a clan change (admin resolves).
@@ -38,6 +40,7 @@ enrollments). `Cohort` (intake season - see [Intake](./intake-and-assessments.md
 - Clan roles are the clan-scoped half of [RBAC](./authorization-rbac.md) - membership *is* the grant.
 - **Clan change request = permanent move; cross-clan assignment = temporary, revocable help.** Don't confuse them.
 - A clan has one lead mentor (`leadMentorId`); the first mentor added becomes lead.
+- A clan join link only works while `inviteEnabled` is true and the clan is `active`; disabling keeps the same slug so re-enabling doesn't break already-shared URLs. New users still register via a clan-scoped `RegistrationInvite` (email-proven); existing accounts auto-join.
 
 ## Related
 [Intake & Assessments](./intake-and-assessments.md) · [Enrollment & Progress](./enrollment-and-progress.md) · [Matching & Placement](./matching-and-placement.md) · [Authorization](./authorization-rbac.md)

--- a/server/scripts/migrations/093_clan_invite_link.js
+++ b/server/scripts/migrations/093_clan_invite_link.js
@@ -1,0 +1,82 @@
+/**
+ * Migration: 093_clan_invite_link
+ *
+ * Adds a reusable, shareable clan-join link (`invite_slug` + `invite_enabled`)
+ * so a lead mentor can copy one URL for Slack/WhatsApp instead of issuing a
+ * per-email RegistrationInvite for every person.
+ *
+ * Run:      node server/scripts/migrations/093_clan_invite_link.js
+ * Rollback: node server/scripts/migrations/093_clan_invite_link.js --rollback
+ */
+const { Sequelize } = require('sequelize');
+const sequelize = require('./_db');
+
+async function columnExists(table, column, t) {
+  const [r] = await sequelize.query(
+    `SELECT 1 FROM information_schema.columns WHERE table_name='${table}' AND column_name='${column}'`, { transaction: t });
+  return r.length > 0;
+}
+
+async function indexExists(name, t) {
+  const [r] = await sequelize.query(
+    `SELECT 1 FROM pg_indexes WHERE indexname='${name}'`, { transaction: t });
+  return r.length > 0;
+}
+
+async function up() {
+  const qi = sequelize.getQueryInterface();
+  console.log('▶ Running migration 093: clan invite link');
+  await sequelize.transaction(async (t) => {
+    if (await columnExists('clans', 'invite_slug', t)) {
+      console.log('  ℹ clans.invite_slug exists, skipping');
+    } else {
+      await qi.addColumn('clans', 'invite_slug', { type: Sequelize.STRING(64), allowNull: true }, { transaction: t });
+      console.log('  ✓ Added clans.invite_slug');
+    }
+    if (await columnExists('clans', 'invite_enabled', t)) {
+      console.log('  ℹ clans.invite_enabled exists, skipping');
+    } else {
+      await qi.addColumn('clans', 'invite_enabled', {
+        type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false,
+      }, { transaction: t });
+      console.log('  ✓ Added clans.invite_enabled');
+    }
+    if (await indexExists('clans_invite_slug_unique', t)) {
+      console.log('  ℹ clans_invite_slug_unique exists, skipping');
+    } else {
+      await sequelize.query(
+        'CREATE UNIQUE INDEX clans_invite_slug_unique ON clans (invite_slug) WHERE invite_slug IS NOT NULL',
+        { transaction: t }
+      );
+      console.log('  ✓ Added unique index clans_invite_slug_unique');
+    }
+  });
+  console.log('✅ Migration 093 complete');
+}
+
+async function down() {
+  const qi = sequelize.getQueryInterface();
+  console.log('▶ Rolling back migration 093');
+  await sequelize.transaction(async (t) => {
+    if (await indexExists('clans_invite_slug_unique', t)) {
+      await sequelize.query('DROP INDEX IF EXISTS clans_invite_slug_unique', { transaction: t });
+      console.log('  ✓ Dropped clans_invite_slug_unique');
+    }
+    if (await columnExists('clans', 'invite_enabled', t)) {
+      await qi.removeColumn('clans', 'invite_enabled', { transaction: t });
+      console.log('  ✓ Dropped clans.invite_enabled');
+    }
+    if (await columnExists('clans', 'invite_slug', t)) {
+      await qi.removeColumn('clans', 'invite_slug', { transaction: t });
+      console.log('  ✓ Dropped clans.invite_slug');
+    }
+  });
+  console.log('✅ Rollback 093 complete');
+}
+
+if (require.main === module) {
+  const isRollback = process.argv.slice(2).some((a) => a === '--rollback' || a === '-r');
+  (async () => { try { await (isRollback ? down() : up()); process.exit(0); } catch (e) { console.error('❌ Migration failed:', e.message); process.exit(1); } })();
+}
+
+module.exports = { up, down };

--- a/server/src/controllers/clanController.js
+++ b/server/src/controllers/clanController.js
@@ -219,6 +219,31 @@ const inviteToClan = catchAsync(async (req, res) => {
   res.status(201).json(successResponse('Invite sent', { invite }, 201));
 });
 
+/**
+ * GET /api/clans/:id/invite-link
+ * Current reusable join-link state (lead mentor / mentee.add).
+ */
+const getInviteLink = catchAsync(async (req, res) => {
+  const link = await clanService.getInviteLink(req.params.id);
+  res.status(200).json(successResponse('Invite link retrieved', { link }));
+});
+
+/**
+ * POST /api/clans/:id/invite-link  — enable (mint slug on first use).
+ */
+const enableInviteLink = catchAsync(async (req, res) => {
+  const link = await clanService.enableInviteLink(req.params.id);
+  res.status(200).json(successResponse('Invite link enabled', { link }));
+});
+
+/**
+ * DELETE /api/clans/:id/invite-link  — disable (slug is kept so re-enable is stable).
+ */
+const disableInviteLink = catchAsync(async (req, res) => {
+  const link = await clanService.disableInviteLink(req.params.id);
+  res.status(200).json(successResponse('Invite link disabled', { link }));
+});
+
 module.exports = {
   listClans,
   clanHealth,
@@ -238,5 +263,8 @@ module.exports = {
   reassignClan,
   grantClanRole,
   revokeClanRole,
-  inviteToClan
+  inviteToClan,
+  getInviteLink,
+  enableInviteLink,
+  disableInviteLink
 };

--- a/server/src/controllers/publicController.js
+++ b/server/src/controllers/publicController.js
@@ -1,6 +1,8 @@
 const { catchAsync } = require('../middlewares/errorHandler');
 const { successResponse } = require('../utils/responses');
 const publicIntakeService = require('../services/publicIntakeService');
+const clanService = require('../services/clanService');
+const { ConflictError } = require('../utils/errors/errorTypes');
 
 // ─── Catalog ─────────────────────────────────────────────────────────────────
 const listPrograms = catchAsync(async (req, res) => {
@@ -57,6 +59,29 @@ const uploadFile = catchAsync(async (req, res) => {
   res.status(201).json(successResponse('File uploaded', result, 201));
 });
 
+// ─── Clan join link ──────────────────────────────────────────────────────────
+const getClanInvite = catchAsync(async (req, res) => {
+  const info = await clanService.getPublicInviteInfo(req.params.slug);
+  res.status(200).json(successResponse('Clan join info retrieved', info));
+});
+
+const joinClan = catchAsync(async (req, res) => {
+  const result = await clanService.joinViaInviteLink(req.params.slug, req.user);
+  const message = result.alreadyMember ? 'You are already in this clan' : 'Joined clan';
+  res.status(200).json(successResponse(message, result));
+});
+
+const requestClanInvite = catchAsync(async (req, res) => {
+  const generic = { ok: true, message: 'If that email can join, we\'ve sent a registration link.' };
+  try {
+    await clanService.requestInviteViaLink(req.params.slug, req.body?.email);
+  } catch (err) {
+    // Don't leak whether the address already has an account or an active invite.
+    if (!(err instanceof ConflictError)) throw err;
+  }
+  res.status(200).json(successResponse('Invite requested', generic));
+});
+
 module.exports = {
   listPrograms,
   getProgram,
@@ -67,5 +92,8 @@ module.exports = {
   submitAssessment,
   updateInfo,
   withdraw,
-  uploadFile
+  uploadFile,
+  getClanInvite,
+  joinClan,
+  requestClanInvite
 };

--- a/server/src/models/programs/Clan.js
+++ b/server/src/models/programs/Clan.js
@@ -32,6 +32,21 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: true,
       field: 'whatsapp_group_link'
     },
+    // Reusable multi-use join link (`/join/<slug>`). Minted the first time a
+    // lead mentor enables it; `inviteEnabled` gates whether the slug currently
+    // accepts joins. Unlike RegistrationInvite this is not email-locked.
+    inviteSlug: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
+      unique: true,
+      field: 'invite_slug'
+    },
+    inviteEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+      field: 'invite_enabled'
+    },
     // Optional lead mentor (the "clan leader"). Co-mentors are tracked as
     // ClanMembership rows with role 'co_mentor'.
     leadMentorId: {
@@ -92,7 +107,8 @@ module.exports = (sequelize, DataTypes) => {
     indexes: [
       { fields: ['program_id'] },
       { fields: ['lead_mentor_id'] },
-      { fields: ['status'] }
+      { fields: ['status'] },
+      { unique: true, fields: ['invite_slug'] }
     ]
   });
 

--- a/server/src/routes/clans.js
+++ b/server/src/routes/clans.js
@@ -52,6 +52,9 @@ router.post('/reassign', authenticate, requirePermissionMinScope(PERMISSIONS.CLA
 // Co-mentors with mentee.add may use these too.
 router.get('/:id/available', authenticate, requireAnyPermission([PERMISSIONS.CLAN_MANAGE_MEMBERS, PERMISSIONS.MENTEE_ADD], scope.clan('id')), clanController.availableMembers);
 router.post('/:id/invite', authenticate, requireAnyPermission([PERMISSIONS.CLAN_MANAGE_MEMBERS, PERMISSIONS.MENTEE_ADD], scope.clan('id')), clanController.inviteToClan);
+router.get('/:id/invite-link', authenticate, requireAnyPermission([PERMISSIONS.CLAN_MANAGE_MEMBERS, PERMISSIONS.MENTEE_ADD], scope.clan('id')), clanController.getInviteLink);
+router.post('/:id/invite-link', authenticate, requireAnyPermission([PERMISSIONS.CLAN_MANAGE_MEMBERS, PERMISSIONS.MENTEE_ADD], scope.clan('id')), clanController.enableInviteLink);
+router.delete('/:id/invite-link', authenticate, requireAnyPermission([PERMISSIONS.CLAN_MANAGE_MEMBERS, PERMISSIONS.MENTEE_ADD], scope.clan('id')), clanController.disableInviteLink);
 
 // Candidates for co-mentor / core-team (anyone active, not already in the clan).
 router.get('/:id/candidates', authenticate, requirePermission(PERMISSIONS.CLAN_MANAGE_MEMBERS, scope.clan('id')), clanController.candidates);

--- a/server/src/routes/public.js
+++ b/server/src/routes/public.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const publicController = require('../controllers/publicController');
 const upload = require('../middlewares/upload');
 const { publicIntakeLimiter } = require('../middlewares/rateLimiter');
+const { authenticate } = require('../middlewares/auth');
 
 /**
  * Public, UNAUTHENTICATED intake surface. Nothing here requires a login - it
@@ -35,5 +36,11 @@ router.post(
   upload.singleSafe('file'),
   publicController.uploadFile
 );
+
+// Reusable clan join link (`/join/<slug>`). Preview is public; joining requires
+// a logged-in account. New users request a clan-scoped registration invite.
+router.get('/clans/:slug', publicController.getClanInvite);
+router.post('/clans/:slug/join', authenticate, publicIntakeLimiter, publicController.joinClan);
+router.post('/clans/:slug/request-invite', publicIntakeLimiter, publicController.requestClanInvite);
 
 module.exports = router;

--- a/server/src/services/clanService.js
+++ b/server/src/services/clanService.js
@@ -1,4 +1,5 @@
 const { models, sequelize } = require('../db');
+const crypto = require('crypto');
 const { NotFoundError, ValidationError, ConflictError, AuthorizationError } = require('../utils/errors/errorTypes');
 const { createAuditLog } = require('../utils/auditContext');
 const { ROLES } = require('../config/roles');
@@ -191,6 +192,10 @@ class ClanService {
       }
     }
     out.memberships = memberships;
+    // Join-link fields are only returned from the dedicated invite-link endpoints
+    // so a generic clan fetch doesn't advertise a shareable token.
+    delete out.inviteSlug;
+    delete out.inviteEnabled;
     return out;
   }
 
@@ -706,6 +711,145 @@ class ClanService {
       name: `${u.firstName} ${u.lastName}`.trim() || u.email,
       email: u.email, role: u.role, profilePictureUrl: u.profilePictureUrl || null
     }));
+  }
+
+  buildJoinUrl(slug) {
+    const base = (process.env.CLIENT_URL || 'http://localhost:3000').split(',')[0].replace(/\/$/, '');
+    return `${base}/join/${slug}`;
+  }
+
+  _inviteLinkPayload(clan) {
+    return {
+      enabled: Boolean(clan.inviteEnabled && clan.inviteSlug),
+      slug: clan.inviteSlug || null,
+      joinUrl: clan.inviteSlug ? this.buildJoinUrl(clan.inviteSlug) : null,
+    };
+  }
+
+  async getInviteLink(clanId) {
+    const clan = await models.Clan.findByPk(clanId);
+    if (!clan) throw new NotFoundError('Clan not found');
+    return this._inviteLinkPayload(clan);
+  }
+
+  /**
+   * Turn the reusable clan-join link on, minting a slug the first time.
+   * Re-enabling a previously disabled link keeps the same URL.
+   */
+  async enableInviteLink(clanId) {
+    const clan = await models.Clan.findByPk(clanId);
+    if (!clan) throw new NotFoundError('Clan not found');
+    if (clan.status !== 'active') throw new ValidationError('Only an active clan can share a join link');
+
+    if (!clan.inviteSlug) {
+      let slug = null;
+      for (let i = 0; i < 5; i += 1) {
+        slug = crypto.randomBytes(9).toString('base64url');
+        const clash = await models.Clan.findOne({ where: { inviteSlug: slug } });
+        if (!clash) break;
+        slug = null;
+      }
+      if (!slug) throw new ValidationError('Could not generate a unique link, try again');
+      clan.inviteSlug = slug;
+    }
+    clan.inviteEnabled = true;
+    await clan.save();
+    return this._inviteLinkPayload(clan);
+  }
+
+  async disableInviteLink(clanId) {
+    const clan = await models.Clan.findByPk(clanId);
+    if (!clan) throw new NotFoundError('Clan not found');
+    clan.inviteEnabled = false;
+    await clan.save();
+    return this._inviteLinkPayload(clan);
+  }
+
+  async _openClanByInviteSlug(slug) {
+    if (!slug) return { clan: null, reasons: ['missing'] };
+    const clan = await models.Clan.findOne({
+      where: { inviteSlug: slug },
+      include: [{ model: models.Program, as: 'program', attributes: ['id', 'name'] }],
+    });
+    if (!clan) return { clan: null, reasons: ['not_found'] };
+    const reasons = [];
+    if (!clan.inviteEnabled) reasons.push('disabled');
+    if (clan.status !== 'active') reasons.push('inactive');
+    return { clan, reasons };
+  }
+
+  async getPublicInviteInfo(slug) {
+    const { clan, reasons } = await this._openClanByInviteSlug(slug);
+    if (!clan) throw new NotFoundError('This join link is not valid');
+
+    const menteeCount = await models.ClanMembership.count({
+      where: { clanId: clan.id, role: 'mentee', status: 'active' },
+    });
+    const maxMentees = clan.maxMentees || null;
+    const full = maxMentees != null && menteeCount >= maxMentees;
+    if (full) reasons.push('full');
+
+    return {
+      open: reasons.length === 0,
+      reasons,
+      clan: { name: clan.name, description: clan.description || null },
+      program: clan.program ? { name: clan.program.name } : null,
+      menteeCount,
+      maxMentees,
+    };
+  }
+
+  /**
+   * Logged-in user joins the clan as a mentee via the shareable link.
+   */
+  async joinViaInviteLink(slug, user) {
+    if (!user?.id) throw new ValidationError('You must be logged in to join this clan');
+    const { clan, reasons } = await this._openClanByInviteSlug(slug);
+    if (!clan) throw new NotFoundError('This join link is not valid');
+    if (reasons.length) {
+      throw new ValidationError(
+        reasons.includes('disabled') ? 'This join link is currently turned off'
+          : 'This clan is not accepting join-link members right now'
+      );
+    }
+
+    const existing = await models.ClanMembership.findOne({
+      where: { clanId: clan.id, userId: user.id, role: 'mentee', status: 'active' },
+    });
+    if (existing) {
+      return { clan: { id: clan.id, name: clan.name }, alreadyMember: true };
+    }
+
+    const menteeCount = await models.ClanMembership.count({
+      where: { clanId: clan.id, role: 'mentee', status: 'active' },
+    });
+    if (clan.maxMentees != null && menteeCount >= clan.maxMentees) {
+      throw new ValidationError('This clan is full');
+    }
+
+    await this.addMember(clan.id, { userId: user.id, role: 'mentee' });
+    return { clan: { id: clan.id, name: clan.name }, alreadyMember: false };
+  }
+
+  /**
+   * Self-serve: someone without an account requests a clan-scoped registration
+   * invite from the public join page. Failures that would leak whether an email
+   * is already on the platform are swallowed by the controller.
+   */
+  async requestInviteViaLink(slug, email) {
+    if (!email || !String(email).trim()) throw new ValidationError('Email is required');
+    const { clan, reasons } = await this._openClanByInviteSlug(slug);
+    if (!clan || reasons.length) throw new NotFoundError('This join link is not valid');
+
+    const menteeCount = await models.ClanMembership.count({
+      where: { clanId: clan.id, role: 'mentee', status: 'active' },
+    });
+    if (clan.maxMentees != null && menteeCount >= clan.maxMentees) {
+      throw new ValidationError('This clan is full');
+    }
+
+    const invitedBy = clan.leadMentorId || clan.createdBy;
+    return this.inviteToClan(clan.id, email, invitedBy);
   }
 
   /**

--- a/server/tests/mentor/clan-invite-link.test.js
+++ b/server/tests/mentor/clan-invite-link.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+/**
+ * Reusable clan invite link: enable/disable, public preview, join, and
+ * self-serve registration-invite request.
+ */
+
+const { models } = require('../../src/db');
+const clanService = require('../../src/services/clanService');
+const { NotFoundError, ValidationError, ConflictError } = require('../../src/utils/errors/errorTypes');
+const { cleanDb, createMentor, createMentee, createProgram } = require('../helpers/seed');
+
+describe('clan invite link', () => {
+  let lead, mentee, program, clan;
+
+  beforeEach(async () => {
+    await cleanDb();
+    lead = await createMentor({ email: 'lead-link@test.com' });
+    mentee = await createMentee({ email: 'joiner@test.com' });
+    program = await createProgram({ createdBy: lead.id });
+    clan = await models.Clan.create({
+      programId: program.id,
+      name: 'Invite Clan',
+      leadMentorId: lead.id,
+      createdBy: lead.id,
+      maxMentees: 25,
+    });
+    await clanService.addMember(clan.id, { userId: lead.id, role: 'lead_mentor' });
+  });
+
+  it('mints a slug on first enable and keeps it after disable', async () => {
+    const enabled = await clanService.enableInviteLink(clan.id);
+    expect(enabled.enabled).toBe(true);
+    expect(enabled.slug).toBeTruthy();
+    expect(enabled.joinUrl).toContain(`/join/${enabled.slug}`);
+
+    const disabled = await clanService.disableInviteLink(clan.id);
+    expect(disabled.enabled).toBe(false);
+    expect(disabled.slug).toBe(enabled.slug);
+
+    const again = await clanService.enableInviteLink(clan.id);
+    expect(again.slug).toBe(enabled.slug);
+    expect(again.enabled).toBe(true);
+  });
+
+  it('does not advertise the slug on a generic clan fetch', async () => {
+    await clanService.enableInviteLink(clan.id);
+    const detail = await clanService.getClanById(clan.id);
+    expect(detail.inviteSlug).toBeUndefined();
+    expect(detail.inviteEnabled).toBeUndefined();
+  });
+
+  it('lets a logged-in mentee join, and is idempotent', async () => {
+    const { slug } = await clanService.enableInviteLink(clan.id);
+    const first = await clanService.joinViaInviteLink(slug, mentee);
+    expect(first.alreadyMember).toBe(false);
+    const row = await models.ClanMembership.findOne({
+      where: { clanId: clan.id, userId: mentee.id, role: 'mentee', status: 'active' },
+    });
+    expect(row).toBeTruthy();
+
+    const second = await clanService.joinViaInviteLink(slug, mentee);
+    expect(second.alreadyMember).toBe(true);
+  });
+
+  it('rejects joins when the link is disabled', async () => {
+    const { slug } = await clanService.enableInviteLink(clan.id);
+    await clanService.disableInviteLink(clan.id);
+    await expect(clanService.joinViaInviteLink(slug, mentee)).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('hides a disabled or unknown slug from the public preview', async () => {
+    await expect(clanService.getPublicInviteInfo('no-such-slug')).rejects.toBeInstanceOf(NotFoundError);
+
+    const { slug } = await clanService.enableInviteLink(clan.id);
+    const open = await clanService.getPublicInviteInfo(slug);
+    expect(open.open).toBe(true);
+    expect(open.clan.name).toBe('Invite Clan');
+
+    await clanService.disableInviteLink(clan.id);
+    const closed = await clanService.getPublicInviteInfo(slug);
+    expect(closed.open).toBe(false);
+    expect(closed.reasons).toContain('disabled');
+  });
+
+  it('requests a clan-scoped registration invite for a new email', async () => {
+    const { slug } = await clanService.enableInviteLink(clan.id);
+    const invite = await clanService.requestInviteViaLink(slug, 'newcomer@test.com');
+    expect(invite.email).toBe('newcomer@test.com');
+    expect(invite.clanId).toBe(clan.id);
+    expect(invite.programId).toBe(program.id);
+    expect(invite.role).toBe('mentee');
+  });
+
+  it('refuses a second active invite for the same email', async () => {
+    const { slug } = await clanService.enableInviteLink(clan.id);
+    await clanService.requestInviteViaLink(slug, 'once@test.com');
+    await expect(clanService.requestInviteViaLink(slug, 'once@test.com')).rejects.toBeInstanceOf(ConflictError);
+  });
+});


### PR DESCRIPTION
## Description

Adds a reusable **invite-to-clan-via-link** flow, modeled on cohort public apply links.

Lead mentors (and anyone with `mentee.add`) can enable a shareable `/join/<slug>` URL from Clan Team, copy it, and turn it off without changing the slug.

- Logged-in users join the clan as a mentee immediately (idempotent if they are already in it).
- New users enter their email on the public page and receive a clan-scoped registration invite — no per-person invite from an admin.

## Related Issue

Closes #636

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [ ] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [x] I updated documentation where needed

## Screenshots (Required for UI changes)

Clan Team now has an **Invite via link** panel (Enable / copy / Turn off). Public `/join/<slug>` shows clan name, login-to-join, or request-a-registration-email.

Migration: `093_clan_invite_link` (`invite_slug`, `invite_enabled`).
