### PR TITLE
fix: open assigned tasks in the edit form on click

### DIFF
--- a/client-interface/components/mentor/MenteeTaskDrawer.tsx
+++ b/client-interface/components/mentor/MenteeTaskDrawer.tsx
@@ -32,7 +32,9 @@ const DIFF_CLS: Record<string, string> = {
 export function MenteeTaskDrawer({ task, onClose, onChanged }: { task: any; onClose: () => void; onChanged: () => void }) {
   const router = useRouter();
   const confirm = useConfirm();
-  const [editing, setEditing] = useState(false);
+  // Open in the edit form directly (one click from the review list). Closing
+  // the editor returns to this read-only view so Unassign / Review stay available.
+  const [editing, setEditing] = useState(true);
   const [busy, setBusy] = useState(false);
   const rt = task.roadmapTask || {};
   const title = rt.title || task.title || 'Task';
@@ -63,7 +65,7 @@ export function MenteeTaskDrawer({ task, onClose, onChanged }: { task: any; onCl
 
   return (
     <>
-      <Drawer open onClose={onClose} title={title} subtitle="Assigned task · this mentee"
+      {!editing && <Drawer open onClose={onClose} title={title} subtitle="Assigned task · this mentee"
         footer={
           <div className="flex flex-wrap justify-end gap-2">
             {canUnassign && (
@@ -155,7 +157,7 @@ export function MenteeTaskDrawer({ task, onClose, onChanged }: { task: any; onCl
             </div>
           )}
         </div>
-      </Drawer>
+      </Drawer>}
 
       {editing && <TaskEditDrawer task={task} onClose={() => setEditing(false)} onSaved={() => { onChanged(); onClose(); }} />}
     </>


### PR DESCRIPTION
Replaces #643 (closed for a clean timeline after an accidental CRLF rewrite on the fork).

## Description

Clicking a task on the mentor Review page (and via `TaskDrawerById` deep links) now opens the edit form immediately instead of a read-only view that required a second "Edit / add note" click.

Closing the editor still returns to the read-only drawer so Unassign / Reassign / Review remain available.

## Related Issue

Closes #635

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [ ] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

N/A — navigation/behavior change. Clicking a task row now shows TaskEditDrawer first.
