### PR TITLE
fix: stop copying task title into an empty description

### DIFF
--- a/client-interface/app/mentee/tasks/[id]/page.tsx
+++ b/client-interface/app/mentee/tasks/[id]/page.tsx
@@ -28,6 +28,7 @@ import { useActivityTracker } from '@/lib/hooks/shared/useActivityTracker';
 import { FrictionPanel } from '@/components/mentee/FrictionPanel';
 import { SubmitTaskDrawer } from '@/components/mentee/SubmitTaskDrawer';
 import { InterviewReviewDrawer } from '@/components/mentor/InterviewReviewDrawer';
+import { isMissingDescription } from '@/lib/utils/html';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -119,11 +120,13 @@ export default function TaskDetailsPage({ params }: PageProps) {
                 </span>
               )}
             </div>
-            {taskDescription && (descriptionIsHtml ? (
+            {isMissingDescription(taskDescription, taskTitle) ? (
+              <p className="text-sm text-slate-400">No description provided.</p>
+            ) : descriptionIsHtml ? (
               <div className="prose prose-sm max-w-none dark:prose-invert text-slate-600 dark:text-slate-300" dangerouslySetInnerHTML={{ __html: taskDescription }} />
             ) : (
               <p className="text-slate-600 whitespace-pre-wrap">{taskDescription}</p>
-            ))}
+            )}
             {task.mentorNote && (
               <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-500/10 dark:border-amber-500/30 px-3 py-2">
                 <StickyNote className="w-4 h-4 text-amber-600 shrink-0 mt-0.5" />

--- a/client-interface/components/mentor/AssignTaskDrawer.tsx
+++ b/client-interface/components/mentor/AssignTaskDrawer.tsx
@@ -288,7 +288,7 @@ export function AssignTaskDrawer({
         .map((r) => ({ title: r.title || r.url, url: r.url }));
       const base = {
         title: title.trim(),
-        description: cleanHtml(description) || title.trim(),
+        description: cleanHtml(description),
         type,
         difficulty,
         dueDate: dueISO(),
@@ -486,7 +486,7 @@ export function AssignTaskDrawer({
 
               <div>
                 <label className="block text-sm font-medium text-slate-700 mb-1">Brief</label>
-                <RichTextEditor content={description} onChange={setDescription} placeholder="What should they do? (defaults to the title)" minHeight="120px" />
+                <RichTextEditor content={description} onChange={setDescription} placeholder="Optional — what should they do?" minHeight="120px" />
               </div>
 
               <div className="grid grid-cols-2 gap-4">

--- a/client-interface/components/mentor/MenteeTaskDrawer.tsx
+++ b/client-interface/components/mentor/MenteeTaskDrawer.tsx
@@ -11,6 +11,7 @@ import taskApi from '@/lib/services/task-api';
 import { extractApiErrorMessage } from '@/lib/utils/api-error';
 import { useConfirm } from '@/lib/context/ConfirmContext';
 import { pointsForDifficulty } from '@/lib/config/points';
+import { isMissingDescription, looksLikeHtml } from '@/lib/utils/html';
 
 const STATUS_CLS: Record<string, string> = {
   assigned: 'bg-slate-100 text-slate-600', not_started: 'bg-slate-100 text-slate-600',
@@ -37,7 +38,8 @@ export function MenteeTaskDrawer({ task, onClose, onChanged }: { task: any; onCl
   const rt = task.roadmapTask || {};
   const title = rt.title || task.title || 'Task';
   const description = rt.description || task.description || '';
-  const isHtml = description ? /<[a-z][\s\S]*>/i.test(description) : false;
+  const isHtml = looksLikeHtml(description);
+  const missingDescription = isMissingDescription(description, title);
   const criteria: string[] = rt.acceptanceCriteria || task.acceptanceCriteria || [];
   const resources: any[] = rt.resources || [];
   const due = task.dueDate ? new Date(task.dueDate) : null;
@@ -124,9 +126,11 @@ export function MenteeTaskDrawer({ task, onClose, onChanged }: { task: any; onCl
             </div>
           )}
 
-          {description && (isHtml
+          {missingDescription
+            ? <p className="text-sm text-slate-400">No description provided.</p>
+            : isHtml
             ? <div className="prose prose-sm max-w-none dark:prose-invert text-slate-600 dark:text-slate-300" dangerouslySetInnerHTML={{ __html: description }} />
-            : <p className="text-sm text-slate-600 whitespace-pre-wrap">{description}</p>)}
+            : <p className="text-sm text-slate-600 whitespace-pre-wrap">{description}</p>}
 
           {rt.deliverable && (
             <div className="rounded-lg bg-blue-50 border border-blue-200 px-3 py-2">

--- a/client-interface/lib/utils/html.ts
+++ b/client-interface/lib/utils/html.ts
@@ -40,3 +40,12 @@ export function stripHtml(s: string | null | undefined): string {
     .replace(/\s+/g, ' ')
     .trim();
 }
+
+/** True when stored description is blank, a generic placeholder, or a silent copy of the title. */
+export function isMissingDescription(description: string | null | undefined, title?: string | null): boolean {
+  const plain = stripHtml(description);
+  if (!plain) return true;
+  if (/^no description provided\.?$/i.test(plain)) return true;
+  if (title && plain === title.trim()) return true;
+  return false;
+}

--- a/server/src/services/linearRoadmapService.js
+++ b/server/src/services/linearRoadmapService.js
@@ -181,8 +181,8 @@ class LinearRoadmapService {
     return {
       roadmapId,
       title,
-      // description is NOT NULL — fall back to the title when no detail is given.
-      description: desc || step.brief || title,
+      // description is NOT NULL — use a visible placeholder, never copy the title.
+      description: desc || step.brief || 'No description provided',
       type: step.type || 'project',
       difficulty: step.difficulty || 'medium',
       taskOrder: order,

--- a/server/src/services/taskService.js
+++ b/server/src/services/taskService.js
@@ -180,7 +180,7 @@ class TaskService {
       // Create custom roadmap task (not part of any roadmap - a one-off).
       roadmapTask = await models.RoadmapTask.create({
         title,
-        description: description || title || 'No description provided',
+        description: description || 'No description provided',
         type: type || 'custom',
         difficulty: difficulty || 'medium',
         taskOrder: 0,


### PR DESCRIPTION
Replaces #644 (closed for a clean timeline after an accidental CRLF rewrite on the fork).

## Description

Leaving the Brief field empty no longer copies the title into the stored description. The assign form, custom-task service, and roadmap step mapping now keep description empty (or a visible "No description provided" placeholder) instead of duplicating the title.

On view, a description that is blank, the placeholder, or an exact copy of the title shows a distinct **No description provided.** state.

## Related Issue

Closes #637

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [ ] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

N/A — empty Brief now stays empty rather than duplicating the title. View shows a muted "No description provided." when there is no real brief.
