### PR TITLE
feat: add CI pipelines for lint, build, and secrets scanning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,8 @@
 
 ## Validation Checklist
 
+CI also runs build, a secrets scan, and (advisory) lint on the PR. Still run the impacted app(s) locally:
+
 - [ ] I ran lint checks for impacted app(s)
 - [ ] I ran build checks for impacted app(s)
 - [ ] I ran tests for impacted app(s), or confirmed no test suite exists for this change

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /server
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: npm
+    directory: /client-interface
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,188 @@
+# Lint, build, and secrets gates for PRs into staging/main.
+# Standard `pull_request` (not pull_request_target) so fork PRs cannot read
+# repo secrets. Jobs are path-filtered; a final `CI` job is always reported
+# so it can be set as a required status check.
+name: CI
+
+on:
+  pull_request:
+    branches: [staging, main]
+  push:
+    branches: [staging, main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  NEXT_TELEMETRY_DISABLED: '1'
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      client: ${{ steps.filter.outputs.client }}
+      server: ${{ steps.filter.outputs.server }}
+      ci: ${{ steps.filter.outputs.ci }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            client:
+              - 'client-interface/**'
+            server:
+              - 'server/**'
+            ci:
+              - '.github/**'
+              - '.gitleaks.toml'
+
+  secrets:
+    name: Secrets scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Block tracked env / key files
+        run: |
+          set -euo pipefail
+          tracked="$(git ls-files | grep -E '(^|/)\.env($|\.|rc)|(^|/).+\.pem$|(^|/)credentials\.json$|(^|/)id_rsa$' || true)"
+          # Allow committed templates only.
+          bad="$(printf '%s\n' "$tracked" | grep -vE '\.env\.example$' | grep -v '^$' || true)"
+          if [ -n "$bad" ]; then
+            echo "These secret-like files must not be committed:"
+            printf '%s\n' "$bad"
+            exit 1
+          fi
+          echo "No tracked env/key files (other than .env.example)."
+      - name: Install Gitleaks
+        env:
+          GITLEAKS_VERSION: '8.24.3'
+        run: |
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      - name: Gitleaks
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            git fetch --no-tags --prune origin "${GITHUB_BASE_REF}"
+            gitleaks detect --source . --verbose --redact --no-banner \
+              --config .gitleaks.toml --exit-code 1 \
+              --log-opts="--no-merges origin/${GITHUB_BASE_REF}..HEAD"
+          else
+            BEFORE="${{ github.event.before }}"
+            if [ -z "${BEFORE}" ] || [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
+              gitleaks detect --source . --verbose --redact --no-banner \
+                --config .gitleaks.toml --exit-code 1 --log-opts="-1"
+            else
+              gitleaks detect --source . --verbose --redact --no-banner \
+                --config .gitleaks.toml --exit-code 1 --log-opts="${BEFORE}..${GITHUB_SHA}"
+            fi
+          fi
+
+  actionlint:
+    name: Workflow lint
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install actionlint
+        run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Lint workflow files
+        run: ./actionlint -color
+
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: critical
+          comment-summary-in-pr: false
+
+  client:
+    name: Client lint + build
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.client == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client-interface
+    env:
+      NEXT_PUBLIC_API_URL: http://localhost:5000/api
+      NEXT_PUBLIC_APP_NAME: Pathment
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: client-interface/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Lint (advisory)
+        # The tree currently has a large ESLint debt (~400 errors). Keep the
+        # job visible in CI; do not block merge until that baseline is cleaned.
+        continue-on-error: true
+        run: npm run lint
+      - name: Build
+        run: npm run build
+      - name: Audit (critical)
+        continue-on-error: true
+        run: npm audit --audit-level=critical
+
+  server:
+    name: Server lint
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.server == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Syntax check
+        run: npm run lint
+      - name: Audit (critical)
+        continue-on-error: true
+        run: npm audit --audit-level=critical
+
+  ci:
+    name: CI
+    if: always() && !cancelled()
+    needs: [changes, secrets, actionlint, dependency-review, client, server]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require blocking jobs
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json, os, sys
+          needs = json.loads(os.environ['NEEDS'])
+          failed = [f"{name}={job.get('result')}" for name, job in needs.items()
+                    if job.get('result') in ('failure', 'cancelled')]
+          if failed:
+              print('Blocking jobs did not succeed:', ', '.join(failed))
+              sys.exit(1)
+          print('All jobs passed or were skipped.')
+          PY

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+# Placeholders that look like secrets but are not real credentials.
+[allowlist]
+paths = [
+  '''(^|/)\.env\.example$''',
+]
+regexes = [
+  '''postgres://(USER:PASSWORD|user:password|postgres:password|pathment:pathment)@''',
+  '''your[-_ ]?(api[-_ ]?key|resend_api_key|refresh-secret-key|groq-api-key|openai-api-key)''',
+  '''fake-key''',
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,8 @@ cd client-interface
 npm install
 ```
 
+(`client-interface/.npmrc` sets `legacy-peer-deps=true` so installs match CI.)
+
 Create `.env.local`:
 
 ```env
@@ -112,7 +114,23 @@ By default:
 - Follow existing project patterns and folder structure.
 - Avoid unrelated refactors in feature/bug-fix PRs.
 - Update docs when behavior or workflow changes.
-- Run relevant lint/build/test checks for the changed app(s) before opening a PR.
+- Run relevant lint/build/test checks for the changed app(s) before opening a PR. CI repeats those gates on every pull request to `staging` / `main`.
+
+## CI
+
+GitHub Actions (`.github/workflows/ci.yml`) runs on pull requests and on pushes to `staging` and `main`. Jobs are path-filtered (`client-interface/**`, `server/**`, `.github/**`).
+
+| Check | Local command | Blocking? |
+| --- | --- | --- |
+| Client production build | `cd client-interface && npm run build` | Yes |
+| Client ESLint | `cd client-interface && npm run lint` | Advisory until the existing lint debt is cleaned up |
+| Server syntax | `cd server && npm run lint` | Yes |
+| Server tests | `cd server && npm test` (needs a `DATABASE_URL` containing `test`) | Not in CI yet |
+| Secrets scan | — (Gitleaks + a check that `.env` / `*.pem` / `credentials.json` are not tracked) | Yes |
+
+Never commit `server/.env`, `client-interface/.env.local`, or other secret files. Templates such as `server/.env.example` are fine.
+
+A final job named **CI** aggregates the others so it can be set as a required status check on `staging`.
 
 ## Architecture Notes for Contributors
 

--- a/client-interface/.npmrc
+++ b/client-interface/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,8 @@
     "check:tables": "node scripts/checkTables.js",
     "test": "jest --runInBand",
     "test:watch": "jest --runInBand --watch",
-    "test:coverage": "jest --runInBand --coverage"
+    "test:coverage": "jest --runInBand --coverage",
+    "lint": "node scripts/syntaxCheck.js"
   },
   "dependencies": {
     "axios": "^1.13.2",

--- a/server/scripts/syntaxCheck.js
+++ b/server/scripts/syntaxCheck.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Cheap syntax gate for CI: parse every application JS file.
+ * Not a style linter — the server has no ESLint config yet; this still
+ * catches truncated files and parse errors before a PR is merged.
+ */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SKIP_DIRS = new Set(['node_modules', 'coverage', 'logs', 'uploads', '.git']);
+
+function walk(dir, acc = []) {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(ent.name)) continue;
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) walk(full, acc);
+    else if (ent.isFile() && ent.name.endsWith('.js')) acc.push(full);
+  }
+  return acc;
+}
+
+const roots = ['src', 'scripts', 'tests'].filter((d) => fs.existsSync(path.join(process.cwd(), d)));
+const files = roots.flatMap((d) => walk(d));
+let failed = 0;
+for (const file of files) {
+  const source = fs.readFileSync(file, 'utf8');
+  try {
+    new vm.Script(source, { filename: file });
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    failed += 1;
+  }
+}
+
+if (failed) {
+  console.error(`syntax-check: ${failed}/${files.length} file(s) failed`);
+  process.exit(1);
+}
+console.log(`syntax-check: ${files.length} files ok`);


### PR DESCRIPTION
Replaces #648 (closed for a clean timeline after an accidental CRLF rewrite on the fork).

## Summary

- Adds a GitHub Actions pipeline (`.github/workflows/ci.yml`) on PRs and pushes to `staging` / `main`: path-filtered client lint+build, server syntax check, Gitleaks + tracked-env/key file block, dependency review, actionlint, and a final **CI** job maintainers can mark required.
- Client ESLint is **advisory** (`continue-on-error`) because the tree currently has a large lint debt (~400 errors). The Next.js production build is blocking. Server `npm run lint` is a `node` parse check (`server/scripts/syntaxCheck.js`) until ESLint exists.
- `client-interface/.npmrc` sets `legacy-peer-deps=true` so `npm ci` matches local installs. Dependabot is enabled for npm + Actions. CONTRIBUTING.md maps CI jobs to local commands.

Closes #647

## Test plan

- [ ] Confirm this PR’s **CI** check goes green (client build, secrets scan, server syntax, actionlint).
- [ ] Confirm client ESLint is visible but does not fail the required **CI** job.
- [ ] After merge, maintainers: Settings → Branches → `staging` required checks → select the job named **CI**.
- [ ] Optional: open a tiny follow-up that adds a dummy `.env` and confirm the secrets job fails.
