### PR TITLE
feat(feedback): add drag and drop and paste clipboard support

### DIFF
--- a/client-interface/components/shared/FeedbackDrawer.tsx
+++ b/client-interface/components/shared/FeedbackDrawer.tsx
@@ -33,6 +33,7 @@ export function FeedbackDrawer({ open, onClose }: { open: boolean; onClose: () =
   const [submitting, setSubmitting] = useState(false);
   const [mine, setMine] = useState<FeedbackReport[]>([]);
   const [loadingMine, setLoadingMine] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
 
   const loadMine = useCallback(async () => {
     setLoadingMine(true);
@@ -43,11 +44,41 @@ export function FeedbackDrawer({ open, onClose }: { open: boolean; onClose: () =
   // Reset the form whenever the drawer opens fresh.
   useEffect(() => { if (open) { setTab('send'); setType('bug'); setTitle(''); setDescription(''); setFile(null); } }, [open]);
 
-  const pickFile = (f: File | null) => {
+  const pickFile = useCallback((f: File | null) => {
     if (f && f.size > MAX) { toast.error('File is too large (max 10MB).'); return; }
     if (f && !(f.type.startsWith('image/') || f.type.startsWith('video/'))) { toast.error('Attach an image or a short video clip.'); return; }
     setFile(f);
-  };
+  }, []);
+
+  const handlePaste = useCallback((e: ClipboardEvent) => {
+    if (tab !== 'send') return;
+
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.kind === 'file' && (item.type.startsWith('image/') || item.type.startsWith('video/'))) {
+        const fileBlob = item.getAsFile();
+        if (fileBlob) {
+          const ext = item.type.split('/')[1] || 'png';
+          const pastedFile = new File([fileBlob], `pasted-image-${Date.now()}.${ext}`, { type: item.type });
+          pickFile(pastedFile);
+          e.preventDefault();
+          break;
+        }
+      }
+    }
+  }, [tab, pickFile]);
+
+  useEffect(() => {
+    if (open && tab === 'send') {
+      window.addEventListener('paste', handlePaste);
+      return () => {
+        window.removeEventListener('paste', handlePaste);
+      };
+    }
+  }, [open, tab, handlePaste]);
 
   const submit = async () => {
     if (!title.trim()) { toast.error('Add a short title.'); return; }
@@ -104,16 +135,35 @@ export function FeedbackDrawer({ open, onClose }: { open: boolean; onClose: () =
               placeholder="What happened, what did you expect, steps to reproduce…"
               className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500" />
           </div>
-          <div>
+          <div
+            onDragOver={(e) => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragLeave={(e) => {
+              e.preventDefault();
+              setIsDragging(false);
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              setIsDragging(false);
+              if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+                pickFile(e.dataTransfer.files[0]);
+              }
+            }}
+          >
             <label className="block text-sm text-slate-700 mb-1">Screenshot or short clip <span className="text-slate-400">(optional)</span></label>
             {file ? (
-              <div className="flex items-center justify-between gap-2 px-3 py-2 border border-slate-200 rounded-lg text-sm">
+              <div className="flex items-center justify-between gap-2 px-3 py-2 border border-slate-200 rounded-lg text-sm bg-card">
                 <span className="inline-flex items-center gap-2 min-w-0"><Paperclip className="w-4 h-4 text-slate-400 shrink-0" /><span className="truncate">{file.name}</span></span>
                 <button onClick={() => setFile(null)} className="text-slate-400 hover:text-red-500 shrink-0"><X className="w-4 h-4" /></button>
               </div>
             ) : (
-              <label className="flex items-center gap-2 px-3 py-2 border border-dashed border-slate-300 rounded-lg text-sm text-slate-500 cursor-pointer hover:border-brand-400">
-                <Paperclip className="w-4 h-4" />Attach image or video (max 10MB)
+              <label className={`flex items-center gap-2 px-3 py-2 border border-dashed rounded-lg text-sm text-slate-500 cursor-pointer transition-colors ${
+                isDragging ? 'border-brand-500 bg-brand-50 text-brand-700' : 'border-slate-300 hover:border-brand-400'
+              }`}>
+                <Paperclip className="w-4 h-4 pointer-events-none" />
+                <span className="pointer-events-none">Attach image or video (max 10MB)</span>
                 <input type="file" accept="image/*,video/*" className="hidden" onChange={(e) => pickFile(e.target.files?.[0] ?? null)} />
               </label>
             )}

--- a/client-interface/components/shared/FeedbackDrawer.tsx
+++ b/client-interface/components/shared/FeedbackDrawer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { toast } from 'sonner';
 import { Bug, Lightbulb, MessageSquarePlus, Paperclip, Loader2, X, Send } from 'lucide-react';
 import { Drawer } from '@/components/shared/Drawer';
+import { FileDragDrop } from './FileDragDrop';
 import { feedbackApi, type FeedbackType, type FeedbackReport } from '@/lib/services/feedback-api';
 import { extractApiErrorMessage } from '@/lib/utils/api-error';
 
@@ -33,7 +34,6 @@ export function FeedbackDrawer({ open, onClose }: { open: boolean; onClose: () =
   const [submitting, setSubmitting] = useState(false);
   const [mine, setMine] = useState<FeedbackReport[]>([]);
   const [loadingMine, setLoadingMine] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
 
   const loadMine = useCallback(async () => {
     setLoadingMine(true);
@@ -43,42 +43,6 @@ export function FeedbackDrawer({ open, onClose }: { open: boolean; onClose: () =
   useEffect(() => { if (open && tab === 'mine') loadMine(); }, [open, tab, loadMine]);
   // Reset the form whenever the drawer opens fresh.
   useEffect(() => { if (open) { setTab('send'); setType('bug'); setTitle(''); setDescription(''); setFile(null); } }, [open]);
-
-  const pickFile = useCallback((f: File | null) => {
-    if (f && f.size > MAX) { toast.error('File is too large (max 10MB).'); return; }
-    if (f && !(f.type.startsWith('image/') || f.type.startsWith('video/'))) { toast.error('Attach an image or a short video clip.'); return; }
-    setFile(f);
-  }, []);
-
-  const handlePaste = useCallback((e: ClipboardEvent) => {
-    if (tab !== 'send') return;
-
-    const items = e.clipboardData?.items;
-    if (!items) return;
-
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i];
-      if (item.kind === 'file' && (item.type.startsWith('image/') || item.type.startsWith('video/'))) {
-        const fileBlob = item.getAsFile();
-        if (fileBlob) {
-          const ext = item.type.split('/')[1] || 'png';
-          const pastedFile = new File([fileBlob], `pasted-image-${Date.now()}.${ext}`, { type: item.type });
-          pickFile(pastedFile);
-          e.preventDefault();
-          break;
-        }
-      }
-    }
-  }, [tab, pickFile]);
-
-  useEffect(() => {
-    if (open && tab === 'send') {
-      window.addEventListener('paste', handlePaste);
-      return () => {
-        window.removeEventListener('paste', handlePaste);
-      };
-    }
-  }, [open, tab, handlePaste]);
 
   const submit = async () => {
     if (!title.trim()) { toast.error('Add a short title.'); return; }
@@ -135,39 +99,32 @@ export function FeedbackDrawer({ open, onClose }: { open: boolean; onClose: () =
               placeholder="What happened, what did you expect, steps to reproduce…"
               className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500" />
           </div>
-          <div
-            onDragOver={(e) => {
-              e.preventDefault();
-              setIsDragging(true);
-            }}
-            onDragLeave={(e) => {
-              e.preventDefault();
-              setIsDragging(false);
-            }}
-            onDrop={(e) => {
-              e.preventDefault();
-              setIsDragging(false);
-              if (e.dataTransfer.files && e.dataTransfer.files[0]) {
-                pickFile(e.dataTransfer.files[0]);
-              }
-            }}
-          >
+          <div>
             <label className="block text-sm text-slate-700 mb-1">Screenshot or short clip <span className="text-slate-400">(optional)</span></label>
-            {file ? (
-              <div className="flex items-center justify-between gap-2 px-3 py-2 border border-slate-200 rounded-lg text-sm bg-card">
-                <span className="inline-flex items-center gap-2 min-w-0"><Paperclip className="w-4 h-4 text-slate-400 shrink-0" /><span className="truncate">{file.name}</span></span>
-                <button onClick={() => setFile(null)} className="text-slate-400 hover:text-red-500 shrink-0"><X className="w-4 h-4" /></button>
-              </div>
-            ) : (
-              <label className={`flex items-center gap-2 px-3 py-2 border border-dashed rounded-lg text-sm text-slate-500 cursor-pointer transition-colors ${
-                isDragging ? 'border-brand-500 bg-brand-50 text-brand-700' : 'border-slate-300 hover:border-brand-400'
-              }`}>
-                <Paperclip className="w-4 h-4 pointer-events-none" />
-                <span className="pointer-events-none">Attach image or video (max 10MB)</span>
-                <input type="file" accept="image/*,video/*" className="hidden" onChange={(e) => pickFile(e.target.files?.[0] ?? null)} />
-              </label>
-            )}
-            <p className="mt-1 text-xs text-slate-400">We also capture the page you're on and your browser to help us debug.</p>
+            <FileDragDrop
+              onFilesSelected={(files) => setFile(files[0] || null)}
+              multiple={false}
+              accept="image/*,video/*"
+              maxSize={MAX}
+              enablePaste={true}
+            >
+              {({ isDragging, openFilePicker }) => (
+                file ? (
+                  <div className="flex items-center justify-between gap-2 px-3 py-2 border border-slate-200 rounded-lg text-sm bg-card">
+                    <span className="inline-flex items-center gap-2 min-w-0"><Paperclip className="w-4 h-4 text-slate-400 shrink-0" /><span className="truncate">{file.name}</span></span>
+                    <button type="button" onClick={() => setFile(null)} className="text-slate-400 hover:text-red-500 shrink-0"><X className="w-4 h-4" /></button>
+                  </div>
+                ) : (
+                  <button type="button" onClick={openFilePicker} className={`w-full flex items-center gap-2 px-3 py-2 border border-dashed rounded-lg text-sm text-slate-500 cursor-pointer transition-colors ${
+                    isDragging ? 'border-brand-500 bg-brand-50 text-brand-700' : 'border-slate-300 hover:border-brand-400'
+                  }`}>
+                    <Paperclip className="w-4 h-4 pointer-events-none" />
+                    <span className="pointer-events-none">Attach image or video (max 10MB)</span>
+                  </button>
+                )
+              )}
+            </FileDragDrop>
+            <p className="mt-1 text-xs text-slate-400">We also capture the page you&apos;re on and your browser to help us debug.</p>
           </div>
           <div className="flex justify-end pt-2">
             <button onClick={submit} disabled={submitting}
@@ -181,7 +138,7 @@ export function FeedbackDrawer({ open, onClose }: { open: boolean; onClose: () =
           {loadingMine ? (
             <div className="flex items-center justify-center py-12"><Loader2 className="w-6 h-6 animate-spin text-brand-500" /></div>
           ) : mine.length === 0 ? (
-            <p className="text-sm text-slate-400 text-center py-10">You haven't submitted any feedback yet.</p>
+            <p className="text-sm text-slate-400 text-center py-10">You haven&apos;t submitted any feedback yet.</p>
           ) : (
             <div className="space-y-2">
               {mine.map((r) => (

--- a/client-interface/components/shared/FileDragDrop.tsx
+++ b/client-interface/components/shared/FileDragDrop.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import { toast } from 'sonner';
+
+interface FileDragDropProps {
+  onFilesSelected: (files: File[]) => void;
+  multiple?: boolean;
+  accept?: string;
+  maxSize?: number; // in bytes
+  enablePaste?: boolean;
+  disabled?: boolean;
+  className?: string;
+  onError?: (error: string) => void;
+  children: React.ReactNode | ((props: { isDragging: boolean; openFilePicker: () => void }) => React.ReactNode);
+}
+
+export function FileDragDrop({
+  onFilesSelected,
+  multiple = false,
+  accept,
+  maxSize,
+  enablePaste = false,
+  disabled = false,
+  className = '',
+  onError,
+  children,
+}: FileDragDropProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragCounter = useRef(0);
+
+  // Keep latest callbacks in refs to avoid useEffect / event listener churn
+  const onFilesSelectedRef = useRef(onFilesSelected);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onFilesSelectedRef.current = onFilesSelected;
+  }, [onFilesSelected]);
+
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
+
+  const openFilePicker = useCallback(() => {
+    if (!disabled && fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  }, [disabled]);
+
+  const validateFiles = useCallback((files: File[]): File[] => {
+    return files.filter((file) => {
+      // Validate file size
+      if (maxSize && file.size > maxSize) {
+        const errorMsg = `File "${file.name}" is too large (max ${Math.round(maxSize / (1024 * 1024))}MB).`;
+        if (onErrorRef.current) onErrorRef.current(errorMsg);
+        else toast.error(errorMsg);
+        return false;
+      }
+
+      // Validate file type
+      if (accept) {
+        const acceptedTypes = accept.split(',').map((t) => t.trim());
+        const matches = acceptedTypes.some((type) => {
+          if (type.endsWith('/*')) {
+            const base = type.replace('/*', '');
+            return file.type.startsWith(base);
+          }
+          return file.type === type;
+        });
+
+        if (!matches) {
+          const errorMsg = `Attach a valid file type (${accept}).`;
+          if (onErrorRef.current) onErrorRef.current(errorMsg);
+          else toast.error(errorMsg);
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [accept, maxSize]);
+
+  const handleFiles = useCallback((selectedFiles: File[]) => {
+    if (selectedFiles.length === 0) return;
+    const validFiles = validateFiles(selectedFiles);
+    if (validFiles.length > 0) {
+      const filesToEmit = multiple ? validFiles : [validFiles[0]];
+      onFilesSelectedRef.current(filesToEmit);
+    }
+  }, [multiple, validateFiles]);
+
+  // Drag and drop handlers
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (disabled) return;
+    dragCounter.current += 1;
+    if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
+      setIsDragging(true);
+    }
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (disabled) return;
+    dragCounter.current -= 1;
+    if (dragCounter.current === 0) {
+      setIsDragging(false);
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (disabled) return;
+    setIsDragging(false);
+    dragCounter.current = 0;
+
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      handleFiles(Array.from(e.dataTransfer.files));
+    }
+  };
+
+  // Clipboard paste handler
+  useEffect(() => {
+    if (!enablePaste || disabled) return;
+
+    const handlePaste = (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      const pastedFiles: File[] = [];
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.kind === 'file') {
+          const fileBlob = item.getAsFile();
+          if (fileBlob) {
+            const ext = item.type.split('/')[1] || 'png';
+            const pastedFile = new File(
+              [fileBlob],
+              `pasted-file-${Date.now()}.${ext}`,
+              { type: item.type }
+            );
+            pastedFiles.push(pastedFile);
+          }
+        }
+      }
+
+      if (pastedFiles.length > 0) {
+        e.preventDefault();
+        handleFiles(pastedFiles);
+      }
+    };
+
+    window.addEventListener('paste', handlePaste);
+    return () => {
+      window.removeEventListener('paste', handlePaste);
+    };
+  }, [enablePaste, disabled, handleFiles]);
+
+  return (
+    <div
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      className={className}
+    >
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={(e) => {
+          if (e.target.files && e.target.files.length > 0) {
+            handleFiles(Array.from(e.target.files));
+            e.target.value = '';
+          }
+        }}
+        multiple={multiple}
+        accept={accept}
+        disabled={disabled}
+        className="hidden"
+      />
+      {typeof children === 'function'
+        // eslint-disable-next-line react-hooks/refs
+        ? children({ isDragging, openFilePicker })
+        : children}
+    </div>
+  );
+}

--- a/client-interface/components/shared/index.ts
+++ b/client-interface/components/shared/index.ts
@@ -31,3 +31,4 @@ export { default as Navigation } from './Navigation';
 export { default as OnboardingGuard } from './OnboardingGuard';
 export { RoleGuard } from './RoleGuard';
 export { default as RichTextEditor } from './RichTextEditor';
+export { FileDragDrop } from './FileDragDrop';


### PR DESCRIPTION
## Description
This PR enhances the feedback reporting experience by allowing users to attach screenshots and videos much faster. Previously, users had to manually save files to their device before uploading. This PR adds two new capabilities to the `FeedbackDrawer` component:
1. **Drag and Drop**: Users can now drag an image or video file directly over the feedback drawer to attach it. A visual dropzone overlay indicates when a file is hovering correctly.
2. **Clipboard Paste (Ctrl+V)**: Users can paste an image directly from their clipboard anywhere while the drawer is open, which automatically attaches the file and prepares it for upload.

## Related Issue
Closes #660 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist
- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed
