### PR TITLE
Fix dark mode styling for review drawers

### DIFF
--- a/client-interface/components/mentor/InterviewReviewDrawer.tsx
+++ b/client-interface/components/mentor/InterviewReviewDrawer.tsx
@@ -22,6 +22,12 @@ const FLAG_LABEL: Record<string, string> = {
   context_menu_blocked: 'Right-click blocked',
   camera_off: 'Camera turned off',
   camera_restored: 'Camera restored',
+  // From the phone app — same log, different vocabulary. Without these a mobile
+  // interview showed raw event keys next to the web's readable ones.
+  app_background: 'Left the app',
+  app_foreground: 'Came back to the app',
+  camera_live: 'Camera on',
+  snapshot_failed: 'A photo failed to send',
 };
 
 /**

--- a/client-interface/components/mentor/InterviewReviewDrawer.tsx
+++ b/client-interface/components/mentor/InterviewReviewDrawer.tsx
@@ -14,7 +14,6 @@ import { useConfirm } from '@/lib/context/ConfirmContext';
 import { fmtClock } from '@/lib/utils/interviewMedia';
 
 const FLAG_LABEL: Record<string, string> = {
-  // From a browser
   focus_loss: 'Left the tab',
   window_blur: 'Window lost focus',
   fullscreen_exit: 'Exited fullscreen',
@@ -23,12 +22,6 @@ const FLAG_LABEL: Record<string, string> = {
   context_menu_blocked: 'Right-click blocked',
   camera_off: 'Camera turned off',
   camera_restored: 'Camera restored',
-  // From the phone app — same log, different vocabulary. Without these a mobile
-  // interview showed raw event keys next to the web's readable ones.
-  app_background: 'Left the app',
-  app_foreground: 'Came back to the app',
-  camera_live: 'Camera on',
-  snapshot_failed: 'A photo failed to send',
 };
 
 /**
@@ -332,7 +325,7 @@ export function InterviewReviewDrawer({
                       )}
                       <input type="number" min={0} max={it.points} value={sc.points}
                         onChange={(e) => saveScore(it, { points: e.target.value })}
-                        className="shrink-0 w-14 border border-slate-300 rounded-lg px-2 py-1 text-sm tabular-nums text-right focus:outline-none focus:ring-2 focus:ring-brand-500" />
+                        className="shrink-0 w-14 bg-transparent border border-slate-300 rounded-lg px-2 py-1 text-sm tabular-nums text-right focus:outline-none focus:ring-2 focus:ring-brand-500" />
                       <span className="shrink-0 text-xs text-slate-400 w-7">/{it.points}</span>
                     </div>
                   );
@@ -398,7 +391,7 @@ export function InterviewReviewDrawer({
 
           {/* AI grading hint — where the key lives + what "AI grade" does. */}
           {canReview && (
-            <div className="rounded-xl border border-brand-100 bg-brand-50/50 p-3 text-xs text-slate-600 flex items-start gap-2">
+            <div className="rounded-xl border border-brand-100 dark:border-brand-900 bg-brand-50/50 dark:bg-brand-950/50 p-3 text-xs text-slate-600 flex items-start gap-2">
               <Sparkles className="w-4 h-4 text-brand-500 shrink-0 mt-0.5" />
               <span>
                 Hit <span className="font-medium text-slate-800">AI grade</span> on any question to score it against your rubric. Voice answers are re-transcribed with Whisper — more accurate than the live transcript when pronunciation trips it up. It runs on your own AI key: add or manage it in{' '}
@@ -476,10 +469,10 @@ export function InterviewReviewDrawer({
                     browser's live STT, shown once AI grading has run. */}
                 {a?.aiDraft?.transcript && (
                   <details className="mt-2" open>
-                    <summary className="text-xs font-medium text-emerald-700 cursor-pointer inline-flex items-center gap-1">
+                    <summary className="text-xs font-medium text-emerald-700 dark:text-emerald-500 cursor-pointer inline-flex items-center gap-1">
                       <Sparkles className="w-3 h-3" /> AI transcript (from audio)
                     </summary>
-                    <div className="text-sm text-slate-700 bg-emerald-50/60 border border-emerald-100 rounded-lg p-3 mt-1.5 whitespace-pre-wrap">{a.aiDraft.transcript}</div>
+                    <div className="text-sm text-slate-700 bg-emerald-50/60 dark:bg-emerald-950/30 border border-emerald-100 dark:border-emerald-900/50 rounded-lg p-3 mt-1.5 whitespace-pre-wrap">{a.aiDraft.transcript}</div>
                   </details>
                 )}
 
@@ -508,8 +501,8 @@ export function InterviewReviewDrawer({
                 {/* Reference answer (mentor only) */}
                 {it.referenceAnswer && (
                   <details className="mt-3">
-                    <summary className="text-xs font-medium text-brand-600 cursor-pointer">Reference answer</summary>
-                    <div className="text-sm text-slate-600 bg-amber-50/50 rounded-lg p-3 mt-1.5 whitespace-pre-wrap">{it.referenceAnswer}</div>
+                    <summary className="text-xs font-medium text-brand-600 dark:text-brand-400 cursor-pointer">Reference answer</summary>
+                    <div className="text-sm text-slate-600 bg-amber-50/50 dark:bg-amber-950/30 rounded-lg p-3 mt-1.5 whitespace-pre-wrap">{it.referenceAnswer}</div>
                   </details>
                 )}
 
@@ -521,21 +514,21 @@ export function InterviewReviewDrawer({
                         Score
                         <input type="number" min={0} max={it.points} value={sc.points}
                           onChange={(e) => saveScore(it, { points: e.target.value })}
-                          className="w-16 border border-slate-300 rounded-lg px-2 py-1 text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-500" />
+                          className="w-16 bg-transparent border border-slate-300 rounded-lg px-2 py-1 text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-500" />
                         <span className="text-slate-400">/ {it.points}</span>
                       </label>
                       <button onClick={() => runAiDraft(it)} disabled={aiBusy === it.questionId}
                         title={it.kind === 'voice'
                           ? 'Transcribes the audio with Whisper and scores it against the rubric — uses your AI key (Settings → AI Connections)'
                           : 'Scores this answer against the rubric — uses your AI key (Settings → AI Connections)'}
-                        className="ml-auto inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-lg border border-brand-200 text-brand-700 hover:bg-brand-50 disabled:opacity-50">
+                        className="ml-auto inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-lg border border-brand-200 dark:border-brand-800 text-brand-700 dark:text-brand-400 hover:bg-brand-50 dark:hover:bg-brand-950/50 disabled:opacity-50">
                         {aiBusy === it.questionId ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Sparkles className="w-3.5 h-3.5" />}
                         {it.kind === 'voice' && a?.audioUrl ? 'AI grade (from audio)' : 'AI draft'}
                       </button>
                     </div>
                     <input value={sc.note} onChange={(e) => saveScore(it, { note: e.target.value })}
                       placeholder="Note on this answer (optional)"
-                      className="mt-2 w-full border border-slate-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500" />
+                      className="mt-2 w-full bg-transparent border border-slate-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500" />
                   </div>
                 ) : (
                   (a?.pointsAwarded != null || a?.scoreNote) && (
@@ -557,7 +550,7 @@ export function InterviewReviewDrawer({
               </label>
               <textarea value={overallNote} onChange={(e) => setOverallNote(e.target.value)} rows={3}
                 placeholder="Summary the mentee will see when you finalize…"
-                className="w-full border border-slate-300 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500" />
+                className="w-full bg-transparent border border-slate-300 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500" />
             </div>
           )}
 

--- a/client-interface/components/mentor/ReviewDrawer.tsx
+++ b/client-interface/components/mentor/ReviewDrawer.tsx
@@ -128,11 +128,11 @@ export function ReviewDrawer({
             {busy === 'approved_notes' ? <Loader2 className="w-4 h-4 animate-spin" /> : null}Approve w/ notes
           </button>
           <button onClick={() => submit('changes')} disabled={!!busy}
-            className="inline-flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-xl bg-amber-50 hover:bg-amber-100 border border-amber-300 text-amber-700 text-sm font-medium disabled:opacity-50">
+            className="inline-flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-xl bg-amber-50 dark:bg-amber-950/30 hover:bg-amber-100 dark:hover:bg-amber-900/40 border border-amber-300 dark:border-amber-900/50 text-amber-700 dark:text-amber-400 text-sm font-medium disabled:opacity-50">
             {busy === 'changes' ? <Loader2 className="w-4 h-4 animate-spin" /> : null}Request changes
           </button>
           <button onClick={() => submit('rejected')} disabled={!!busy}
-            className="inline-flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-xl bg-card hover:bg-red-50 border border-red-300 text-red-700 text-sm font-medium disabled:opacity-50">
+            className="inline-flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-xl bg-card hover:bg-red-50 dark:hover:bg-red-950/30 border border-red-300 dark:border-red-900/50 text-red-700 dark:text-red-400 text-sm font-medium disabled:opacity-50">
             {busy === 'rejected' ? <Loader2 className="w-4 h-4 animate-spin" /> : null}Reject
           </button>
         </div>
@@ -140,7 +140,7 @@ export function ReviewDrawer({
     >
       <div className="space-y-6">
         {item.isLate && (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-red-50 text-red-700 text-xs"><Clock className="w-3 h-3" />Submitted late</span>
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400 text-xs"><Clock className="w-3 h-3" />Submitted late</span>
         )}
 
         {/* The task being reviewed */}
@@ -150,7 +150,7 @@ export function ReviewDrawer({
               <div>
                 <p className="text-xs font-medium text-slate-500 mb-0.5">The task</p>
                 {looksLikeHtml(item.brief)
-                  ? <div className="prose prose-sm max-w-none dark:prose-invert text-slate-700 dark:text-slate-300" dangerouslySetInnerHTML={{ __html: item.brief }} />
+                  ? <div className="prose prose-sm max-w-none dark:prose-invert text-slate-700" dangerouslySetInnerHTML={{ __html: item.brief }} />
                   : <p className="text-sm text-slate-700 whitespace-pre-wrap">{item.brief}</p>}
               </div>
             )}
@@ -168,7 +168,7 @@ export function ReviewDrawer({
           <h3 className="text-sm font-medium text-slate-700 mb-2">Submission</h3>
           <RichContent
             html={item.submissionText}
-            className="rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 p-4 text-slate-700 dark:text-slate-300"
+            className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-slate-700"
           />
           {item.files.length > 0 && (
             <div className="mt-3">
@@ -233,7 +233,7 @@ export function ReviewDrawer({
             <h3 className="text-sm font-medium text-slate-700 flex items-center gap-2">
               Points awarded
               {isLate && latePenalty > 0 && (
-                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-red-50 text-red-700 text-[11px] font-medium"><Clock className="w-3 h-3" />Late −{latePenalty}</span>
+                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400 text-[11px] font-medium"><Clock className="w-3 h-3" />Late −{latePenalty}</span>
               )}
             </h3>
             {points !== total && (
@@ -250,7 +250,7 @@ export function ReviewDrawer({
                 const v = Math.round(Number(e.target.value));
                 setPoints(Number.isFinite(v) ? Math.max(0, Math.min(total, v)) : 0);
               }}
-              className="w-20 border border-slate-300 rounded-lg px-3 py-2 text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="w-20 bg-transparent border border-slate-300 rounded-lg px-3 py-2 text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-500"
               aria-label="Points awarded"
             />
             <span className="text-sm text-slate-500 tabular-nums">/ {total} pts</span>
@@ -300,7 +300,7 @@ export function ReviewDrawer({
             onChange={(e) => setNotes(e.target.value)}
             rows={4}
             placeholder="What's good, what to change…"
-            className="mt-2 w-full border border-slate-300 rounded-xl p-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 resize-none"
+            className="mt-2 w-full bg-transparent border border-slate-300 rounded-xl p-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 resize-none"
           />
         </div>
       </div>


### PR DESCRIPTION
## Description

This PR fixes a widespread dark mode styling bug in the Mentor Review Portal (specifically affecting `InterviewReviewDrawer` and `ReviewDrawer`). 

Previously, some manual `dark:bg-*` and `dark:text-*` Tailwind classes were added to slate-colored elements. However, our application uses an auto-flipping neutral slate scale in `globals.css` (meaning `slate-50` automatically becomes dark and `slate-900` becomes light when `.dark` is applied). Manually applying `dark:` variants broke this auto-inversion, causing elements to render as dark-on-dark or light-on-light.

**Fixes included:**
- Removed unnecessary `dark:` slate variants to let the global CSS auto-invert the neutral scale properly.
- Added `bg-transparent` to `<input>` and `<textarea>` elements so they correctly inherit the dark background instead of defaulting to a glaring browser-native white in dark mode.
- Explicitly added correct `dark:` variants for non-slate semantic colors (e.g., `amber`, `red`, `brand`, `emerald`) because these colors do not flip automatically and were previously unreadable against flipped text.

## Related Issue

Example: Closes #662 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

<img width="564" height="655" alt="image" src="https://github.com/user-attachments/assets/cadad7a4-a877-4055-a6db-0c47dcb65dac" />

<img width="564" height="655" alt="image" src="https://github.com/user-attachments/assets/e5192aed-59d8-4983-8512-efbfcf10f6c3" />
