### PR TITLE
Bug(audio): add Hinglish/English smart anchor prompt to Whisper tran…

### DIFF
--- a/server/src/services/groqService.js
+++ b/server/src/services/groqService.js
@@ -56,7 +56,7 @@ class GroqService {
    * return null and the caller falls back to whatever transcript it already had.
    * @returns {Promise<string|null>} transcript text, or null if unavailable.
    */
-  async transcribeAudio({ audioUrl, userId = null, feature = 'feedback' } = {}) {
+  async transcribeAudio({ audioUrl, userId = null, feature = 'feedback', prompt } = {}) {
     if (!audioUrl) return null;
     const ai = await this._resolve(feature, userId);
     if (!ai.enabled) return null;
@@ -69,7 +69,16 @@ class GroqService {
     if (!resp.ok) throw new Error(`could not fetch audio (${resp.status})`);
     const buf = Buffer.from(await resp.arrayBuffer());
     const file = await OpenAI.toFile(buf, 'answer.webm', { type: 'audio/webm' });
-    const out = await ai.client.audio.transcriptions.create({ file, model });
+
+    // Anchor prompt to bias Whisper against random hallucinations in case of silence/noise
+    // and guide it towards English/Urdu/Hinglish switching.
+    const defaultPrompt = "Umm, let me think. Main isko explain karta hoon. So basically, the code does this...";
+
+    const out = await ai.client.audio.transcriptions.create({
+      file,
+      model,
+      prompt: prompt || defaultPrompt,
+    });
     return (out?.text || '').trim() || null;
   }
 


### PR DESCRIPTION
## Description

This PR fixes Whisper AI translation hallucinations (e.g. transcribing silent or noisy audio segments into Welsh, Korean, or Arabic script) during interview review grading.

We resolved this by adding support for a `prompt` parameter to the `transcribeAudio` function inside `groqService.js`, and configuring a Hinglish/English smart anchor prompt as a default fallback:
```javascript
const defaultPrompt = "Umm, let me think. Main isko explain karta hoon. So basically, the code does this...";
```

**Why this fixes it:**
- **Locks Language Focus:** Anchoring the attention mechanism on Roman Urdu/Hindi and English prevents Whisper from mistakenly auto-detecting irrelevant foreign languages on noisy audio clips.
- **Transcribes to Roman Script:** By providing Roman Urdu in the prompt, it biases Whisper to transcribe Urdu words in readable Roman script (Hinglish) rather than Arabic script.
- **Filters Noise:** Standard stutters like "Umm" at the start instruct Whisper to treat low-volume background noise or breathing as pauses/fillers rather than speech tokens in foreign languages.
- **Preserves Pure English:** The prompt acts only as a recommendation/bias. If the candidate speaks pure English, the transcription remains 100% English.

## Related Issue

Closes #664 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

*Backend change only, no UI layout updates.*
