### PR TITLE
fix(settings): correct dark mode rendering in Auto Replies and AI Con…

### DIFF
--- a/client-interface/components/settings/AIConnectionsTab.tsx
+++ b/client-interface/components/settings/AIConnectionsTab.tsx
@@ -32,12 +32,12 @@ const FEATURE_META: { key: AIFeature; label: string; hint: string }[] = [
 ];
 
 const STATUS_META: Record<AIKeyStatus, { label: string; cls: string; Icon: typeof CheckCircle2 }> = {
-  connected: { label: 'Connected', cls: 'bg-emerald-50 text-emerald-700', Icon: CheckCircle2 },
-  error: { label: 'Error', cls: 'bg-red-50 text-red-600', Icon: AlertTriangle },
+  connected: { label: 'Connected', cls: 'bg-emerald-50 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-400', Icon: CheckCircle2 },
+  error: { label: 'Error', cls: 'bg-red-50 dark:bg-red-950/30 text-red-600 dark:text-red-400', Icon: AlertTriangle },
   untested: { label: 'Untested', cls: 'bg-slate-100 text-slate-500', Icon: Circle },
 };
 
-const field = 'w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500';
+const field = 'w-full bg-background border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500';
 
 interface AIConnectionsTabProps {
   isMentor?: boolean;
@@ -64,7 +64,7 @@ export default function AIConnectionsTab({ isMentor }: AIConnectionsTabProps = {
           <h2 className="text-slate-900 flex items-center gap-2 mb-2"><Zap className="w-5 h-5 text-brand-600" /> Auto-Reply Quota</h2>
           <p className="text-slate-500 text-sm mb-4">Control how many automatic AI replies can be sent on your behalf each month.</p>
           
-          <div className="bg-white rounded-xl border border-slate-200 p-5">
+          <div className="bg-card rounded-xl border border-slate-200 p-5">
             <div className="flex items-center justify-between mb-2">
               <span className="text-sm font-medium text-slate-800">
                 {quota.count} of {quota.limit} messages used this month
@@ -85,7 +85,7 @@ export default function AIConnectionsTab({ isMentor }: AIConnectionsTabProps = {
             </div>
 
             {editingQuota && (
-              <div className="flex flex-col gap-3 mt-4 pt-4 border-t border-slate-100 max-w-md">
+              <div className="flex flex-col gap-3 mt-4 pt-4 border-t border-slate-200 max-w-md">
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-medium text-slate-500">Monthly Limit: <span className="text-slate-900 font-bold text-sm">{tempQuotaLimit} messages</span></span>
                 </div>
@@ -172,7 +172,7 @@ export default function AIConnectionsTab({ isMentor }: AIConnectionsTabProps = {
                 value={routing[f.key as Exclude<AIFeature, 'auto_reply'>] ?? ''}
                 onChange={(e) => setRoute(f.key as Exclude<AIFeature, 'auto_reply'>, e.target.value || null)}
                 disabled={connections.length === 0}
-                className="border border-slate-300 rounded-lg px-2.5 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 max-w-[160px] disabled:opacity-50"
+                className="bg-background border border-slate-300 rounded-lg px-2.5 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 max-w-[160px] disabled:opacity-50"
               >
                 <option value="">Off</option>
                 {connections.map((c) => <option key={c.id} value={c.id}>{c.label}</option>)}

--- a/client-interface/components/settings/DocumentsTab.tsx
+++ b/client-interface/components/settings/DocumentsTab.tsx
@@ -146,10 +146,10 @@ export function DocumentsTab({ autoReplyEnabled = false, onAutoReplyChange }: Do
       </div>
 
       {/* AI Auto-Reply Toggle Card */}
-      <div className="p-4 sm:p-5 rounded-xl border border-slate-200 bg-white">
+      <div className="p-4 sm:p-5 rounded-xl border border-slate-200 bg-card">
         <div className="flex items-start justify-between gap-4">
           <div className="flex gap-3.5">
-            <div className={`p-2.5 rounded-xl shrink-0 ${autoReplyEnabled ? 'bg-brand-50 text-brand-600' : 'bg-slate-100 text-slate-500'
+            <div className={`p-2.5 rounded-xl shrink-0 ${autoReplyEnabled ? 'bg-brand-50 dark:bg-brand-500/10 text-brand-600 dark:text-brand-400' : 'bg-slate-100 text-slate-500'
               }`}>
               <Bot className="w-5 h-5" />
             </div>
@@ -159,7 +159,7 @@ export function DocumentsTab({ autoReplyEnabled = false, onAutoReplyChange }: Do
                   AI Automatic Replies
                 </h3>
                 <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium ${autoReplyEnabled
-                    ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
+                    ? 'bg-emerald-50 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/50'
                     : 'bg-slate-100 text-slate-600 border border-slate-200'
                   }`}>
                   <span className={`w-1.5 h-1.5 rounded-full ${autoReplyEnabled ? 'bg-emerald-500' : 'bg-slate-400'}`} />
@@ -201,9 +201,9 @@ export function DocumentsTab({ autoReplyEnabled = false, onAutoReplyChange }: Do
           anything is outstanding: a locked switch with no explanation is the
           most frustrating thing a settings page can do. */}
       {steps.length > 0 && !canEnable && (
-        <div className="p-4 sm:p-5 rounded-xl border border-amber-200 bg-amber-50/60">
+        <div className="p-4 sm:p-5 rounded-xl border border-amber-200 dark:border-amber-900/30 bg-amber-50/60 dark:bg-amber-950/10">
           <div className="flex items-start gap-3">
-            <Lock className="w-4 h-4 text-amber-600 shrink-0 mt-0.5" />
+            <Lock className="w-4 h-4 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
             <div className="min-w-0 flex-1">
               <h4 className="text-sm font-medium text-slate-900">Set this up first</h4>
               <p className="text-xs text-slate-600 mt-0.5 mb-3">
@@ -233,7 +233,7 @@ export function DocumentsTab({ autoReplyEnabled = false, onAutoReplyChange }: Do
                             <p className="text-xs text-slate-600 mt-0.5">{step.why}</p>
                             {step.progress && (
                               <div className="mt-1.5 flex items-center gap-2 max-w-xs">
-                                <div className="flex-1 h-1.5 bg-white rounded-full overflow-hidden border border-amber-200">
+                                <div className="flex-1 h-1.5 bg-slate-100 dark:bg-slate-800 rounded-full overflow-hidden border border-amber-200 dark:border-amber-900/30">
                                   <div
                                     className="h-full bg-amber-400 rounded-full"
                                     style={{ width: `${Math.min(100, (step.progress.current / step.progress.needed) * 100)}%` }}
@@ -298,10 +298,10 @@ export function DocumentsTab({ autoReplyEnabled = false, onAutoReplyChange }: Do
         ) : (
           <div className="space-y-3">
             {documents.map((doc) => (
-              <div key={doc.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-3.5 sm:p-4 bg-white border border-slate-200 rounded-xl min-w-0">
+              <div key={doc.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-3.5 sm:p-4 bg-card border border-slate-200 rounded-xl min-w-0">
                 <div className="flex items-center gap-3 min-w-0 flex-1">
-                  <div className="p-2.5 sm:p-3 bg-brand-50 rounded-lg shrink-0">
-                    <FileText className="w-5 h-5 sm:w-6 sm:h-6 text-brand-600" />
+                  <div className="p-2.5 sm:p-3 bg-brand-50 dark:bg-brand-500/10 rounded-lg shrink-0">
+                    <FileText className="w-5 h-5 sm:w-6 sm:h-6 text-brand-600 dark:text-brand-400" />
                   </div>
                   <div className="min-w-0 flex-1">
                     <h4 className="text-slate-900 font-medium text-sm truncate" title={doc.fileName}>
@@ -315,19 +315,19 @@ export function DocumentsTab({ autoReplyEnabled = false, onAutoReplyChange }: Do
 
                 <div className="flex items-center justify-between sm:justify-end gap-3 shrink-0">
                   {doc.status === 'processing' && (
-                    <span className="flex items-center gap-1.5 px-2.5 py-1 bg-amber-50 text-amber-700 rounded-full text-xs font-medium">
+                    <span className="flex items-center gap-1.5 px-2.5 py-1 bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-400 rounded-full text-xs font-medium">
                       <Loader2 className="w-3.5 h-3.5 animate-spin" />
                       Processing
                     </span>
                   )}
                   {doc.status === 'completed' && (
-                    <span className="flex items-center gap-1.5 px-2.5 py-1 bg-green-50 text-green-700 rounded-full text-xs font-medium">
+                    <span className="flex items-center gap-1.5 px-2.5 py-1 bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 rounded-full text-xs font-medium">
                       <CheckCircle2 className="w-3.5 h-3.5" />
                       Ready
                     </span>
                   )}
                   {doc.status === 'failed' && (
-                    <span className="flex items-center gap-1.5 px-2.5 py-1 bg-red-50 text-red-700 rounded-full text-xs font-medium" title={doc.errorMessage}>
+                    <span className="flex items-center gap-1.5 px-2.5 py-1 bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400 rounded-full text-xs font-medium" title={doc.errorMessage}>
                       <AlertCircle className="w-3.5 h-3.5" />
                       Failed
                     </span>
@@ -335,7 +335,7 @@ export function DocumentsTab({ autoReplyEnabled = false, onAutoReplyChange }: Do
 
                   <button
                     onClick={() => setDeleteDocumentId(doc.id)}
-                    className="p-1.5 sm:p-2 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                    className="p-1.5 sm:p-2 text-slate-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 rounded-lg transition-colors"
                     title="Delete document"
                   >
                     <Trash2 className="w-4 h-4" />
@@ -357,36 +357,36 @@ export function DocumentsTab({ autoReplyEnabled = false, onAutoReplyChange }: Do
           The AI reads your uploaded PDFs to automatically answer mentee questions with high accuracy. Follow these practical tips when creating your PDFs:
         </p>
         <div className="grid sm:grid-cols-2 gap-3 text-xs sm:text-sm pt-1">
-          <div className="p-3 bg-white border border-slate-200 rounded-lg space-y-1">
+          <div className="p-3 bg-card border border-slate-200 rounded-lg space-y-1">
             <div className="font-semibold text-slate-800 flex items-center gap-1.5">
-              <BookOpenCheck className="w-4 h-4 text-emerald-600 shrink-0" />
+              <BookOpenCheck className="w-4 h-4 text-emerald-600 dark:text-emerald-400 shrink-0" />
               Clear Headings & Sections
             </div>
             <p className="text-slate-500 text-xs leading-normal">
               Use distinct section titles (e.g. <code className="bg-slate-100 px-1 py-0.5 rounded font-mono text-[11px]">Proposal Guidelines</code>, <code className="bg-slate-100 px-1 py-0.5 rounded font-mono text-[11px]">Office Hours Policy</code>) so the AI retrieves exact relevant paragraphs.
             </p>
           </div>
-          <div className="p-3 bg-white border border-slate-200 rounded-lg space-y-1">
+          <div className="p-3 bg-card border border-slate-200 rounded-lg space-y-1">
             <div className="font-semibold text-slate-800 flex items-center gap-1.5">
-              <HelpCircle className="w-4 h-4 text-brand-600 shrink-0" />
+              <HelpCircle className="w-4 h-4 text-brand-600 dark:text-brand-400 shrink-0" />
               Direct Q&A / FAQ Format
             </div>
             <p className="text-slate-500 text-xs leading-normal">
               Include explicit Q&A blocks (e.g. <em className="text-slate-700">"Q: How long should proposals be? A: Keep proposals between 3-5 pages focusing on architecture."</em>).
             </p>
           </div>
-          <div className="p-3 bg-white border border-slate-200 rounded-lg space-y-1">
+          <div className="p-3 bg-card border border-slate-200 rounded-lg space-y-1">
             <div className="font-semibold text-slate-800 flex items-center gap-1.5">
-              <FileText className="w-4 h-4 text-amber-600 shrink-0" />
+              <FileText className="w-4 h-4 text-amber-600 dark:text-amber-400 shrink-0" />
               Digital Selectable Text (No Scans)
             </div>
             <p className="text-slate-500 text-xs leading-normal">
               Export PDFs directly from Word, Google Docs, or Notion. Scanned photos or flattened images cannot be converted into searchable text chunks.
             </p>
           </div>
-          <div className="p-3 bg-white border border-slate-200 rounded-lg space-y-1">
+          <div className="p-3 bg-card border border-slate-200 rounded-lg space-y-1">
             <div className="font-semibold text-slate-800 flex items-center gap-1.5">
-              <Bot className="w-4 h-4 text-indigo-600 shrink-0" />
+              <Bot className="w-4 h-4 text-indigo-600 dark:text-indigo-400 shrink-0" />
               Explicit Rules & Specific Details
             </div>
             <p className="text-slate-500 text-xs leading-normal">


### PR DESCRIPTION
## Description

This PR fixes multiple dark mode readability and background issues in the **Auto Replies** (`DocumentsTab.tsx`) and **AI Connections** (`AIConnectionsTab.tsx`) settings tabs.

**Key Changes:**
- **Replaced static backgrounds:** Swapped `bg-white` with `bg-card` for cards (like the Quota card, Toggle card, Document items, and Guide items) so they correctly invert into dark slate cards in dark mode.
- **Fixed native input styling:** Added `bg-background` inside the `field` utility class (which is shared by all text inputs, passwords, base URLs, and selects in the Add Connection modal) and to the Routing select fields. This prevents browsers from defaulting input backgrounds to white in dark mode, which was causing invisible white-on-white text.
- **Fixed non-flipping elements:** Added correct `dark:` styles to non-slate colors:
  - `bg-emerald-50`, `bg-green-50`, `bg-red-50`, `bg-amber-50` status badges now use translucent dark backgrounds and lighter text in dark mode (`dark:bg-emerald-950/30`, etc.).
  - Setup Guide list container has proper border & background styling (`dark:bg-amber-950/10` and `dark:border-amber-900/30`).
  - Corrected the progress bar track background (`bg-slate-100 dark:bg-slate-800`) to match other progress bars and remain readable.

## Related Issue

Closes #666 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist

- [x] I ran lint checks for impacted app(s)
- [x] I ran build checks for impacted app(s)
- [x] I ran tests for impacted app(s), or confirmed no test suite exists for this change
- [ ] I updated documentation where needed

## Screenshots (Required for UI changes)

<img width="1366" height="1516" alt="image" src="https://github.com/user-attachments/assets/8c827585-dc86-40e7-a289-01c9a0830f0a" />

