### PR TITLE
fix(tasks): exclude submitted tasks from overdue statistics and statuses

### DIFF
--- a/client-interface/app/mentee/dashboard/page.tsx
+++ b/client-interface/app/mentee/dashboard/page.tsx
@@ -67,7 +67,7 @@ function MenteeDashboardInner() {
   const now = Date.now();
   const taskTitle = (t: any) => t?.roadmapTask?.title || t?.title || 'Task';
   const isLate = (t: any) =>
-    t.dueDate && new Date(t.dueDate).getTime() < now && !['completed', 'cancelled'].includes(t.status);
+    t.dueDate && new Date(t.dueDate).getTime() < now && !['completed', 'submitted', 'cancelled'].includes(t.status);
   const activeTasks = (allTasks || []).filter((t: any) => !['completed', 'cancelled'].includes(t.status));
   const heroTask =
     activeTasks.find(isLate) ||

--- a/client-interface/app/mentee/tasks/[id]/submit/page.tsx
+++ b/client-interface/app/mentee/tasks/[id]/submit/page.tsx
@@ -167,7 +167,7 @@ export default function TaskSubmission({ params }: PageProps) {
   const daysUntilDue = Math.ceil(
     (new Date(task.dueDate).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)
   );
-  const isOverdue = daysUntilDue < 0;
+  const isOverdue = daysUntilDue < 0 && !['completed', 'submitted'].includes(task.status);
 
   // Get task details from roadmapTask or custom task fields
   const taskTitle = task.roadmapTask?.title || task.title;

--- a/client-interface/components/mentee/roadmap/RoadmapLinearStepCard.tsx
+++ b/client-interface/components/mentee/roadmap/RoadmapLinearStepCard.tsx
@@ -67,6 +67,7 @@ export function RoadmapLinearStepCard({
   const isOverdue =
     step.assignedTask?.dueDate &&
     !isDone &&
+    !isSubmitted &&
     new Date(step.assignedTask.dueDate).getTime() < Date.now();
 
   const getStatusBadge = () => {

--- a/client-interface/components/shared/TaskCard.tsx
+++ b/client-interface/components/shared/TaskCard.tsx
@@ -66,7 +66,7 @@ export function TaskCard({
   pointsAwarded,
   href,
 }: TaskCardProps) {
-  const isOverdue = dueDate && new Date(dueDate) < new Date() && status !== 'completed';
+  const isOverdue = dueDate && new Date(dueDate) < new Date() && !['completed', 'submitted'].includes(status);
   const priorityStyle = priority ? priorityConfig[priority] : null;
 
   return (

--- a/server/src/services/taskService.js
+++ b/server/src/services/taskService.js
@@ -1004,7 +1004,7 @@ class TaskService {
     const overdue = allTasks.filter(t => 
       t.dueDate && 
       new Date(t.dueDate) < now && 
-      !['completed', 'cancelled'].includes(t.status)
+      !['completed', 'submitted', 'cancelled'].includes(t.status)
     ).length;
 
     return {


### PR DESCRIPTION
## Description

This PR resolves issue **#670**, where tasks submitted by mentees before their deadline were incorrectly marked as **Overdue** (late) after the due date passed. 

A task that is submitted and awaiting review should remain in the `'submitted'` status and should not trigger overdue warnings.

## Key Changes

### Backend
- **`server/src/services/taskService.js`**: Updated the `getMenteeTaskStats` service calculation. Excluded `'submitted'` tasks from the `overdue` count check so that dashboard metrics (e.g. Overdue: 0) reflect the correct status of submitted tasks.

### Frontend
- **`client-interface/components/mentee/roadmap/RoadmapLinearStepCard.tsx`**: Updated the linear timeline step calculation so that tasks with a `'submitted'` state do not render with an `'Overdue'` badge.
- **`client-interface/components/shared/TaskCard.tsx`**: Prevented task cards from highlighting the due date in red or rendering the "This task is overdue" alert box if the status is `'submitted'`.
- **`client-interface/app/mentee/dashboard/page.tsx`**: Excluded `'submitted'` tasks from the dashboard hero card's `isLate` verification check.
- **`client-interface/app/mentee/tasks/[id]/submit/page.tsx`**: Updated the submit page details so the status banner does not show the task as overdue if it has already been submitted or completed.

## Verification & Build Validation

- **TypeScript Typecheck:** Run `npx tsc --noEmit` on the client interface and verified **0 type errors**.
- **ESLint:** Confirmed no ESLint errors on modified files.
- **Production Build:** Successfully compiled the Next.js client production bundle (`npm run build`).
