### PR TITLE
fix(ui): resolve roadmap task card overlap and optimize mobile scaling

### DIFF
--- a/client-interface/app/mentee/roadmap/page.tsx
+++ b/client-interface/app/mentee/roadmap/page.tsx
@@ -140,8 +140,8 @@ export default function MenteeRoadmapPage() {
                 key={r.roadmapId}
                 onClick={() => setSelectedRoadmapId(r.roadmapId)}
                 className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-all ${activeRoadmap.roadmapId === r.roadmapId
-                    ? 'bg-card text-slate-900 shadow-xs'
-                    : 'text-slate-600 hover:text-slate-900'
+                  ? 'bg-card text-slate-900 shadow-xs'
+                  : 'text-slate-600 hover:text-slate-900'
                   }`}
               >
                 {r.name}
@@ -172,7 +172,7 @@ export default function MenteeRoadmapPage() {
                 <p className="text-xs text-slate-500 mt-0.5">{activeRoadmap.description}</p>
               )}
             </div>
-            <span className="text-xs font-bold text-slate-600 tabular-nums bg-slate-100 px-3 py-1 rounded-full border border-slate-200">
+            <span className="text-xs font-bold text-slate-600 tabular-nums bg-slate-100 px-3 py-1 rounded-full border border-slate-200 text-center">
               {completedStepsCount} / {activeRoadmap.totalSteps} Completed
             </span>
           </div>

--- a/client-interface/components/mentee/roadmap/RoadmapLinearStepCard.tsx
+++ b/client-interface/components/mentee/roadmap/RoadmapLinearStepCard.tsx
@@ -105,10 +105,10 @@ export function RoadmapLinearStepCard({
           type="button"
           onClick={toggleExpand}
           className={`w-8 h-8 sm:w-9 sm:h-9 rounded-full flex items-center justify-center border-2 z-10 transition-all focus:outline-hidden ${isDone
-              ? 'bg-emerald-600 border-emerald-600 text-white shadow-2xs hover:bg-emerald-700'
-              : isCurrent
-                ? 'bg-brand-600 border-brand-600 text-white shadow-md shadow-brand-500/25 ring-4 ring-brand-100 animate-pulse'
-                : 'bg-card border-slate-300 text-slate-500 hover:border-slate-400'
+            ? 'bg-emerald-600 border-emerald-600 text-white shadow-2xs hover:bg-emerald-700'
+            : isCurrent
+              ? 'bg-brand-600 border-brand-600 text-white shadow-md shadow-brand-500/25 ring-4 ring-brand-100 animate-pulse'
+              : 'bg-card border-slate-300 text-slate-500 hover:border-slate-400'
             }`}
         >
           {isDone ? (
@@ -127,11 +127,11 @@ export function RoadmapLinearStepCard({
 
       {/* Main Step Content Card */}
       <div
-        className={`flex-1 rounded-2xl border transition-all duration-200 mb-3.5 ${isCurrent
-            ? 'bg-card border-brand-300 shadow-md ring-1 ring-brand-200'
-            : isDone
-              ? 'bg-card border-slate-200'
-              : 'bg-slate-50/50 border-slate-200/80'
+        className={`flex-1 min-w-0 rounded-2xl border transition-all duration-200 mb-3.5 ${isCurrent
+          ? 'bg-card border-brand-300 shadow-md ring-1 ring-brand-200'
+          : isDone
+            ? 'bg-card border-slate-200'
+            : 'bg-slate-50/50 border-slate-200/80'
           }`}
       >
         {/* Card Header (Always Clickable Bar) */}
@@ -140,14 +140,14 @@ export function RoadmapLinearStepCard({
           className={`p-3.5 sm:p-4 flex items-center justify-between gap-3 cursor-pointer select-none ${isExpanded ? 'border-b border-slate-100' : ''
             }`}
         >
-          <div className="min-w-0 flex-1 flex items-center gap-2.5 flex-wrap sm:flex-nowrap">
+          <div className="min-w-0 flex-1 flex flex-col sm:flex-row items-start sm:items-center gap-1.5 sm:gap-2.5">
             <span
-              className={`px-2 py-0.5 rounded-full text-[11px] font-semibold tracking-wide shrink-0 ${statusBadge.style}`}
+              className={`px-2 py-0.5 rounded-full text-[10px] sm:text-[11px] font-semibold tracking-wide shrink-0 ${statusBadge.style}`}
             >
               {statusBadge.text}
             </span>
 
-            <h3 className="text-sm font-bold text-slate-900 truncate hover:text-brand-700 transition-colors">
+            <h3 className="text-xs sm:text-sm  font-bold text-slate-900 truncate w-full sm:w-auto text-left hover:text-brand-700 transition-colors">
               {step.title}
             </h3>
 
@@ -172,11 +172,11 @@ export function RoadmapLinearStepCard({
               <button
                 type="button"
                 onClick={handleAction}
-                className={`px-3 py-1.5 rounded-xl text-xs font-semibold flex items-center gap-1 transition-all shadow-2xs ${isDone
-                    ? 'bg-slate-100 text-slate-700 hover:bg-slate-200'
-                    : isRevisionNeeded
-                      ? 'bg-rose-600 text-white hover:bg-rose-700'
-                      : 'bg-brand-600 text-white hover:bg-brand-700'
+                className={`px-2 py-1 sm:px-3 sm:py-1.5 rounded-xl text-[11px] sm:text-xs font-semibold flex items-center gap-1 transition-all shadow-2xs ${isDone
+                  ? 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                  : isRevisionNeeded
+                    ? 'bg-rose-600 text-white hover:bg-rose-700'
+                    : 'bg-brand-600 text-white hover:bg-brand-700'
                   }`}
               >
                 {getActionButtonText()}


### PR DESCRIPTION
## Description
This PR fixes a responsive UI bug on the Mentee "My Roadmap" page where task cards rendered inconsistently on mobile screens the status badge, title, and action button overlapped instead of stacking cleanly, and title truncation behaved differently from card to card.
 
The issue occurred because the card header layout wasn't adapting to narrow viewports, causing elements to compete for horizontal space instead of stacking. To fix this:
 
- Refactored the card header in the roadmap task card component to use a `flex-col` layout on mobile, stacking the status badge and title so they no longer overlap the action button.
- Added `w-full` to the task title wrapper so long titles truncate properly instead of overflowing on narrow viewports.
- Reduced font sizes on mobile for the status badge (`text-[10px]`), title (`text-xs`), and action buttons (`text-[11px]`) to improve density and prevent cramped overlap.
- Reduced action button padding on mobile to free up horizontal space for the title.
- Fixed text alignment on the roadmap progress tracker badge, which was misaligned.

## Related Issue
Closes #715 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Validation Checklist
- [ ] I ran lint checks for impacted app(s) 
- [ ] I ran build checks for impacted app(s) 
- [ ] I ran tests for impacted app(s)
- [ ] I updated documentation where needed
## Screenshots
### Before:

<img width="947" height="436" alt="Screenshot 2026-08-26 115055" src="https://github.com/user-attachments/assets/3a7f6b9b-7df5-432e-a6f5-de7c9199ca1c" />

<img width="220" height="373" alt="Screenshot 2026-08-26 115151" src="https://github.com/user-attachments/assets/9756e28a-2d88-405d-97ec-866404dd4069" />

### After:
<img width="950" height="431" alt="image" src="https://github.com/user-attachments/assets/c9b7ff25-bb4a-4fa5-ba47-e1040cb4b175" />

<img width="145" height="287" alt="image" src="https://github.com/user-attachments/assets/d6d12a20-9322-4b46-9af9-3771117fb1b6" />
