### PR TITLE
feat: send automatic meeting reminder email 30 minutes before meetings

### DIFF
--- a/server/src/config/notificationMatrix.js
+++ b/server/src/config/notificationMatrix.js
@@ -25,6 +25,7 @@ EXTENSION_HANDLED: 'extension_handled',
   MENTOR_FEEDBACK_REQUESTED: 'mentor_feedback_requested',
   MEETING_CANCELLED: 'meeting_cancelled',
   MEETING_BOOKED: 'meeting_booked',
+  MEETING_REMINDER: 'meeting_reminder',
   CROSS_CLAN_ASSIGNED: 'cross_clan_assigned',
   NEW_MENTEE_IN_CLAN: 'new_mentee_in_clan',
   MENTEE_TRANSFER_REQUESTED: 'mentee_transfer_requested',
@@ -246,6 +247,12 @@ const NOTIFICATION_MATRIX = {
     preferenceKey: 'meeting_booked',
     channels: { inApp: true, email: true, chat: false }
   },
+  [NOTIFICATION_EVENTS.MEETING_REMINDER]: {
+    type: 'system',
+    audience: 'any',
+    preferenceKey: 'meeting_reminder',
+    channels: { inApp: true, email: true, chat: false }
+  },
   [NOTIFICATION_EVENTS.CROSS_CLAN_ASSIGNED]: {
     type: 'system',
     audience: 'mentor',
@@ -403,6 +410,7 @@ const EMAIL_PREFERENCE_CATEGORIES = [
   { group: 'Program', key: 'program_updates', label: 'Program updates' },
   { group: 'Program', key: 'meeting_booked', label: 'A 1:1 is booked' },
   { group: 'Program', key: 'meeting_cancelled', label: 'A 1:1 is cancelled' },
+  { group: 'Program', key: 'meeting_reminder', label: 'A 1:1 meeting reminder is sent (30m before)' },
   { group: 'Program', key: 'cross_clan_assigned', label: 'I\'m asked to cover or help another clan' },
   { group: 'Program', key: 'new_mentee_in_clan', label: 'A new mentee joins my clan' },
   { group: 'Program', key: 'promotion_nominated', label: 'A mentee is nominated for promotion (admins)' },

--- a/server/src/services/notificationScheduler.js
+++ b/server/src/services/notificationScheduler.js
@@ -20,6 +20,7 @@ class NotificationScheduler {
   }
 
   async run() {
+    await this.sendMeetingReminders();
     await this.notifyDeadlineApproaching();
     await this.notifyDeadlinePassed();
     await this.sendWeeklyProgressReports();
@@ -65,6 +66,79 @@ class NotificationScheduler {
       if (sent) console.log(`[scheduler] sent ${sent} re-engagement reminder(s)`);
     } catch (error) {
       console.error('re-engagement reminder run failed:', error.message);
+    }
+  }
+
+  async sendMeetingReminders() {
+    try {
+      const now = new Date();
+      // Look for meetings starting in ~30 minutes (covering [29m, 31m] to ensure overlap with 1m scheduler interval)
+      const minTime = new Date(now.getTime() + 29 * 60 * 1000);
+      const maxTime = new Date(now.getTime() + 31 * 60 * 1000);
+
+      const meetings = await models.ScheduledMeeting.findAll({
+        where: {
+          startsAt: {
+            [Op.gte]: minTime,
+            [Op.lte]: maxTime
+          },
+          status: 'scheduled'
+        },
+        include: [
+          { model: models.User, as: 'mentor', attributes: ['id', 'firstName', 'lastName'] },
+          { model: models.User, as: 'mentee', attributes: ['id', 'firstName', 'lastName'] }
+        ]
+      });
+
+      for (const meeting of meetings) {
+        const mentor = meeting.mentor;
+        const mentee = meeting.mentee;
+        if (!mentor || !mentee) continue;
+
+        const formattedTime = `${meeting.day} at ${meeting.time}`;
+
+        // Send to Mentee
+        await notificationOrchestrator.dispatch({
+          eventKey: NOTIFICATION_EVENTS.MEETING_REMINDER,
+          recipients: [{ userId: mentee.id }],
+          payload: {
+            title: 'Your review meeting starts in 30 minutes!',
+            message: `Your Pathment review meeting is about to begin. Join on time so you don't miss it.`,
+            actionUrl: '/mentee/meetings',
+            actionLabel: 'Join Meeting',
+            relatedEntityType: 'scheduled_meeting',
+            relatedEntityId: meeting.id,
+            emailSubject: 'Pathment: Your review meeting starts in 30 minutes!',
+            emailText: `Hi ${mentee.firstName || ''}, your Pathment review meeting with ${mentor.firstName} ${mentor.lastName} is booked for ${formattedTime}. Join on time so you don't miss it.`
+          },
+          dedupe: {
+            relatedEntityType: 'meeting_reminder',
+            relatedEntityId: meeting.id
+          }
+        });
+
+        // Send to Mentor
+        await notificationOrchestrator.dispatch({
+          eventKey: NOTIFICATION_EVENTS.MEETING_REMINDER,
+          recipients: [{ userId: mentor.id }],
+          payload: {
+            title: 'Your review meeting starts in 30 minutes!',
+            message: `Your Pathment review meeting is about to begin. Join on time so you don't miss it.`,
+            actionUrl: '/mentor/schedules',
+            actionLabel: 'Join Meeting',
+            relatedEntityType: 'scheduled_meeting',
+            relatedEntityId: meeting.id,
+            emailSubject: 'Pathment: Your review meeting starts in 30 minutes!',
+            emailText: `Hi ${mentor.firstName || ''}, your Pathment review meeting with ${mentee.firstName} ${mentee.lastName} is booked for ${formattedTime}. Join on time so you don't miss it.`
+          },
+          dedupe: {
+            relatedEntityType: 'meeting_reminder',
+            relatedEntityId: meeting.id
+          }
+        });
+      }
+    } catch (error) {
+      console.error('[scheduler] send meeting reminders failed:', error.message);
     }
   }
 


### PR DESCRIPTION
## Description
This PR implements an automatic meeting reminder email sent to both mentors and mentees 30 minutes before their scheduled 1:1 meetings.

### Key Changes

#### 1. Config (`server/src/config/notificationMatrix.js`):
- Added the `MEETING_REMINDER` event key and mapped it to the `meeting_reminder` preference key.
- Allowed channels: `inApp` and `email` enabled.
- Added `meeting_reminder` category to `EMAIL_PREFERENCE_CATEGORIES` so it displays in User Settings and can be configured/opted out.

#### 2. Scheduler Service (`server/src/services/notificationScheduler.js`):
- Added `sendMeetingReminders` tick job to the scheduler.
- Evaluates meetings starting 30 minutes in the future (between 29 and 31 minutes ahead) and checks for active `scheduled` status.
- Dispatches reminders using `notificationOrchestrator.dispatch` to both mentor and mentee with appropriate content (names, time, CTA links).
- Utilizes the orchestrator's built-in deduplication parameters (`dedupe: { relatedEntityType: 'meeting_reminder', relatedEntityId: meeting.id }`) to guarantee each participant receives exactly one reminder per meeting.

### Verification
- Run server syntax validation (`npm run lint`): Passed.
- Verified scheduler time windows, active checks, email subject, and deduplication correctly work via manual Jest testing.
