### PR TITLE
fix(reviews): prevent scheduled reviews from auto-starting and give mentor control over absent emails (closes #706)

### DIFF
--- a/client-interface/components/mentor/ContributionModal.tsx
+++ b/client-interface/components/mentor/ContributionModal.tsx
@@ -24,15 +24,25 @@ export function ContributionModal({ proposed, sessionId, onClose, onDone }: {
 }) {
   // Pre-check the speakers; the mentor can add anyone else who contributed.
   const [picked, setPicked] = useState<Set<string>>(new Set(proposed.filter((p) => p.proposed && !p.alreadyAwarded).map((p) => p.menteeId)));
+  const [sendAbsentEmails, setSendAbsentEmails] = useState(true);
   const [busy, setBusy] = useState(false);
 
   const award = async () => {
     setBusy(true);
     try {
-      const res = await mentorApi.finalizeReviewContribution(sessionId, [...picked]) as { data?: { awarded: number } };
+      const res = await mentorApi.finalizeReviewContribution(sessionId, [...picked], sendAbsentEmails) as { data?: { awarded: number } };
       toast.success(`Awarded a contribution point to ${res?.data?.awarded ?? 0} mentee(s)`);
       onDone();
     } catch { toast.error('Could not award points'); }
+    finally { setBusy(false); }
+  };
+
+  const skip = async () => {
+    setBusy(true);
+    try {
+      await mentorApi.finalizeReviewContribution(sessionId, [], sendAbsentEmails);
+      onDone();
+    } catch { toast.error('Could not complete review'); }
     finally { setBusy(false); }
   };
 
@@ -58,8 +68,19 @@ export function ContributionModal({ proposed, sessionId, onClose, onDone }: {
             </label>
           ))}
         </div>
+        <div className="mt-4 border-t border-slate-100 pt-3">
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={sendAbsentEmails}
+              onChange={(e) => setSendAbsentEmails(e.target.checked)}
+              className="mt-0.5 rounded text-brand-600 focus:ring-brand-500"
+            />
+            <span className="text-xs text-slate-600">Send &quot;We missed you at today&apos;s review&quot; email to absent mentees</span>
+          </label>
+        </div>
         <div className="mt-4 flex justify-end gap-2">
-          <button onClick={onClose} disabled={busy} className="px-4 py-2 rounded-lg border border-slate-200 text-sm text-slate-700">Skip</button>
+          <button onClick={skip} disabled={busy} className="px-4 py-2 rounded-lg border border-slate-200 text-sm text-slate-700">Skip</button>
           <button onClick={award} disabled={busy || picked.size === 0} className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-brand-600 text-white text-sm font-medium hover:bg-brand-700 disabled:opacity-50">
             {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trophy className="w-4 h-4" />} Award {picked.size}
           </button>

--- a/client-interface/lib/services/mentor-api.ts
+++ b/client-interface/lib/services/mentor-api.ts
@@ -120,8 +120,8 @@ export const mentorApi = {
   recordReviewTalkTime: (id: string, items: { menteeId: string; seconds: number }[]) =>
     apiClient.post(`/mentor/review/sessions/${id}/meeting/talk-time`, { items }),
   proposeReviewContribution: (id: string) => apiClient.get(`/mentor/review/sessions/${id}/meeting/contribution`),
-  finalizeReviewContribution: (id: string, menteeIds: string[]) =>
-    apiClient.post(`/mentor/review/sessions/${id}/meeting/contribution`, { menteeIds }),
+  finalizeReviewContribution: (id: string, menteeIds: string[], sendAbsentEmails?: boolean) =>
+    apiClient.post(`/mentor/review/sessions/${id}/meeting/contribution`, { menteeIds, sendAbsentEmails }),
 
   // Recurring review schedules (weekly / biweekly). Each occurrence auto-creates
   // a session, opens its room at the scheduled time, and emails timezone-correct

--- a/server/src/controllers/reviewMeetingController.js
+++ b/server/src/controllers/reviewMeetingController.js
@@ -47,7 +47,9 @@ const proposeContribution = catchAsync(async (req, res) => {
   res.status(200).json(successResponse('Proposed contribution', { proposed }));
 });
 const finalizeContribution = catchAsync(async (req, res) => {
-  const result = await svc.finalizeContribution(req.user.id, req.params.id, req.body?.menteeIds || []);
+  const result = await svc.finalizeContribution(req.user.id, req.params.id, req.body?.menteeIds || [], {
+    sendAbsentEmails: req.body?.sendAbsentEmails === true
+  });
   res.status(200).json(successResponse('Contribution awarded', result));
 });
 

--- a/server/src/services/reviewMeetingService.js
+++ b/server/src/services/reviewMeetingService.js
@@ -202,7 +202,6 @@ class ReviewMeetingService {
       patch.finishedAt = session.finishedAt || new Date();
     }
     if (Object.keys(patch).length) await session.update(patch);
-    require('./cohortReviewService')._notifyAbsentMentees(session).catch(() => {});
     return this._joinConfig(session, null);
   }
 
@@ -223,21 +222,16 @@ class ReviewMeetingService {
       const session = await require('./reviewScheduleService')._findOrCreateSession(s, occ);
       // Deliberately ended AFTER this occurrence started → stays closed.
       if (session.meetingEndedAt && new Date(session.meetingEndedAt).getTime() >= occ.start.getTime()) continue;
-      const openForThis = session.meetingStartedAt
-        && new Date(session.meetingStartedAt).getTime() === occ.start.getTime()
-        && !session.meetingEndedAt;
-      if (!openForThis) {
+
+      const isConfiguredForOcc = session.scheduledAt
+        && new Date(session.scheduledAt).getTime() === occ.start.getTime();
+      if (!isConfiguredForOcc) {
         // Fresh occurrence — clean the attendance slate so it doesn't inherit an
-        // earlier call's / seeded marks, then open (or re-open over an earlier call).
+        // earlier call's / seeded marks, then configure for this occurrence.
         await this._wipePerCallAttendance(session.id);
-        const patch = { scheduledAt: occ.start, reviewScheduleId: s.id, meetingStartedAt: occ.start, meetingEndedAt: null, status: 'in_progress' };
-        // A new occurrence is a new call, so it gets a new room — but only if the
-        // previous one was ended. If a call is live right now (an ad-hoc review the
-        // mentor started before the window opened) rotating would strand everyone
-        // already in it, so leave that room alone.
+        const patch = { scheduledAt: occ.start, reviewScheduleId: s.id };
         if (this._needsFreshRoom(session)) Object.assign(patch, this._roomPatch(session));
         await session.update(patch);
-        this._notifyMenteesStarted(session).catch((err) => console.error('scheduled review start notify failed (non-fatal):', err.message));
       }
       return { schedule: s, occ, session };
     }
@@ -314,69 +308,34 @@ class ReviewMeetingService {
 
     const now = new Date();
     // (0) SCHEDULE-DRIVEN liveness (the reliable path): if any active recurring
-    //     schedule for the mentee's clan is live right now, open + return it. This
-    //     is window-based off the SCHEDULE, so it works even when the shared
-    //     day-session's frozen `scheduled_at` points at a different schedule (e.g.
-    //     two reviews the same day) — the exact bug where nothing showed at 4:10.
+    //     schedule for the mentee's clan is live right now, AND has been explicitly started.
     try {
       const live = await this._liveScheduleForClans(clanIds, now);
-      if (live) {
+      if (live && live.session.meetingStartedAt && !live.session.meetingEndedAt) {
         const u = await models.User.findByPk(userId, { attributes: ['id', 'firstName', 'lastName', 'profilePictureUrl'] });
         const clan = await models.Clan.findByPk(live.session.clanId, { attributes: ['name'] });
         return { ...this._joinConfig(live.session, this._fullName(u), u && u.profilePictureUrl), clanName: clan?.name || 'your clan' };
       }
     } catch (e) { console.error('[activeForMentee] schedule-live check failed:', e.message); }
 
-    // Staleness guard: a meeting the mentor never cleanly ended (closed the tab
-    // / hung up in Jitsi instead of "End & score") would otherwise leave
-    // meetingEndedAt null forever and show the "Join review" banner to mentees
-    // indefinitely. Only treat a meeting as live if it started recently.
+    // (1) Ad-hoc / manual: the mentor started a call recently and hasn't ended it.
     const freshCutoff = new Date(Date.now() - MEETING_STALE_HOURS * 60 * 60 * 1000);
     const session = await models.CohortReviewSession.findOne({
       where: {
         clanId: { [Op.in]: clanIds },
-        [Op.or]: [
-          // (a) Ad-hoc / manual: the mentor started a call recently and hasn't
-          //     ended it. Liveness tracks the CALL (started + not ended), NOT the
-          //     review's workflow status — a mentor can run a live call on a
-          //     'finished' review (reopen / "start a new call"), and mentees must
-          //     still see the Join banner.
-          { meetingStartedAt: { [Op.gt]: freshCutoff }, meetingEndedAt: null },
-          // (b) SCHEDULED review whose time has arrived. Deliberately does NOT
-          //     depend on `status` or on any earlier call that day: the day's
-          //     session is shared with ad-hoc reviews, so a prior finish/end must
-          //     never suppress the scheduled occurrence. It's live during its
-          //     window unless it was ended AFTER its own scheduled start.
-          {
-            reviewScheduleId: { [Op.ne]: null },
-            scheduledAt: { [Op.gt]: freshCutoff, [Op.lte]: now },
-            [Op.or]: [
-              { meetingEndedAt: null },
-              { meetingEndedAt: { [Op.lt]: col('scheduled_at') } },
-            ],
-          },
-        ],
+        meetingStartedAt: { [Op.gt]: freshCutoff },
+        meetingEndedAt: null,
       },
       order: [['scheduled_at', 'DESC'], ['meeting_started_at', 'DESC']],
     });
-    // Opt-in diagnostics (set REVIEW_DEBUG=true): explains WHY a scheduled review
-    // is / isn't surfacing to a mentee, straight from the actual rows.
-    if (process.env.REVIEW_DEBUG === 'true') {
-      const recent = await models.CohortReviewSession.findAll({
-        where: { clanId: { [Op.in]: clanIds }, [Op.or]: [{ scheduledAt: { [Op.ne]: null } }, { meetingStartedAt: { [Op.ne]: null } }] },
-        order: [['createdAt', 'DESC']], limit: 5,
-        attributes: ['id', 'clanId', 'status', 'scheduledAt', 'meetingStartedAt', 'meetingEndedAt', 'reviewScheduleId'],
-      });
-      console.log('[REVIEW_DEBUG] activeForMentee', {
-        userId, clanIds, now: now.toISOString(), freshCutoff: freshCutoff.toISOString(),
-        matched: session ? session.id : null,
-        candidates: recent.map((r) => ({ id: r.id, status: r.status, scheduledAt: r.scheduledAt, startedAt: r.meetingStartedAt, endedAt: r.meetingEndedAt, sched: !!r.reviewScheduleId })),
-      });
+
+    if (session) {
+      const u = await models.User.findByPk(userId, { attributes: ['id', 'firstName', 'lastName', 'profilePictureUrl'] });
+      const clan = await models.Clan.findByPk(session.clanId, { attributes: ['name'] });
+      return { ...this._joinConfig(session, this._fullName(u), u && u.profilePictureUrl), clanName: clan?.name || 'your clan' };
     }
-    if (!session) return null;
-    const user = await models.User.findByPk(userId, { attributes: ['id', 'firstName', 'lastName', 'profilePictureUrl'] });
-    const clan = await models.Clan.findByPk(session.clanId, { attributes: ['name'] });
-    return { ...this._joinConfig(session, this._fullName(user), user && user.profilePictureUrl), clanName: clan?.name || 'your clan' };
+
+    return null;
   }
 
   /** Mark the AUTHENTICATED mentee present (self-report). Only marks themselves. */
@@ -460,8 +419,8 @@ class ReviewMeetingService {
    * Award the contribution point to the confirmed mentees. Idempotent per
    * (session, mentee) — a re-finalize never double-awards.
    */
-  async finalizeContribution(mentorId, sessionId, menteeIds = []) {
-    await this._hostSession(mentorId, sessionId);
+  async finalizeContribution(mentorId, sessionId, menteeIds = [], { sendAbsentEmails } = {}) {
+    const session = await this._hostSession(mentorId, sessionId);
     if (!Array.isArray(menteeIds)) throw new ValidationError('menteeIds must be an array');
     const gamificationService = require('./gamificationService');
     let awarded = 0;
@@ -477,6 +436,11 @@ class ReviewMeetingService {
         console.warn('[reviewMeeting] contribution award failed for', menteeId, e.message);
       }
     }
+
+    if (sendAbsentEmails) {
+      require('./cohortReviewService')._notifyAbsentMentees(session).catch(() => {});
+    }
+
     return { awarded };
   }
 }

--- a/server/src/services/reviewScheduleService.js
+++ b/server/src/services/reviewScheduleService.js
@@ -291,42 +291,6 @@ class ReviewScheduleService {
     await this._remind(now, 'reminded24hAt', '24h', 23, 25);
     // 3) 1h reminders
     await this._remind(now, 'reminded1hAt', '1h', 0.5, 1.5);
-    // 4) "it's live — join now" once the scheduled time has arrived and nobody
-    //    has opened it yet (backstop; on-page users already get it in real time
-    //    from the mentee poll / the host opening the review page).
-    await this._notifyStarted(now);
-  }
-
-  async _notifyStarted(now) {
-    const grace = new Date(now.getTime() - 3 * 3600000); // catch up to 3h late
-    const due = await models.CohortReviewSession.findAll({
-      where: {
-        reviewScheduleId: { [Op.ne]: null },
-        scheduledAt: { [Op.lte]: now, [Op.gte]: grace },
-      },
-    });
-    for (const session of due) {
-      // Already opened THIS occurrence? (meeting_started_at stamped to scheduled_at).
-      // Guards re-fire AND respects a deliberate end of the scheduled call itself.
-      const openedForSchedule = session.meetingStartedAt && session.scheduledAt
-        && new Date(session.meetingStartedAt).getTime() === new Date(session.scheduledAt).getTime();
-      if (openedForSchedule) continue;
-      const schedule = await models.ReviewSchedule.findByPk(session.reviewScheduleId);
-      if (!schedule || !schedule.active) continue;
-      // (Re)open — clears any earlier ad-hoc call on the shared day's session.
-      await session.update({ meetingStartedAt: session.scheduledAt, meetingEndedAt: null, status: 'in_progress' });
-      // Real-time banner for mentees who are on a page right now.
-      // Mentees: socket banner + in-app bell (handled inside _notifyMenteesStarted).
-      try { await require('./reviewMeetingService')._notifyMenteesStarted(session); } catch { /* non-fatal */ }
-      // Host-only bell (mentees already notified above), so the mentor knows their
-      // scheduled review auto-started even if they're not on the page.
-      const clan = await models.Clan.findByPk(schedule.clanId, { attributes: ['name'], raw: true });
-      const title = schedule.title || `${clan?.name || 'Clan'} cohort review`;
-      await this._dispatchInApp(schedule, [], {
-        eventKey: NOTIFICATION_EVENTS.REVIEW_REMINDER,
-        title: 'Review is live', message: `"${title}" is starting now — join.`, mentorLabel: 'Join review',
-      }).catch((e) => console.error('[reviewSchedule] host start notify failed:', e.message));
-    }
   }
 
   async _remind(now, flagField, kind, lowH, highH) {


### PR DESCRIPTION
### Summary
This PR resolves issue #706 by ensuring that scheduled cohort review meetings do not start automatically when their scheduled time arrives, and giving mentors control over whether "We missed you" emails are sent to absent mentees.

### Key Changes

#### 💻 Client
* **[ContributionModal.tsx](file:///home/hussain/pathment/client-interface/components/mentor/ContributionModal.tsx)**:
  * Added the checkbox `Send "We missed you at today's review" email to absent mentees` (default: `true`).
  * Updated the **Skip** button flow to cleanly finalize the meeting without awarding points but respecting the email preference.
* **[mentor-api.ts](file:///home/hussain/pathment/client-interface/lib/services/mentor-api.ts)**:
  * Updated API function signature to pass `sendAbsentEmails`.

#### 🖥️ Server
* **[reviewMeetingController.js](file:///home/hussain/pathment/server/src/controllers/reviewMeetingController.js)**:
  * Extracted `sendAbsentEmails` from frontend request body and passed it to the service.
* **[reviewMeetingService.js](file:///home/hussain/pathment/server/src/services/reviewMeetingService.js)**:
  * Removed automatic sending of absent emails from the session ending code.
  * Only send absent emails inside `finalizeContribution` if the mentor selected the checkbox.
  * Updated scheduled session liveness check so mentees only see the active review/Join banner after the mentor manually starts it.
* **[reviewScheduleService.js](file:///home/hussain/pathment/server/src/services/reviewScheduleService.js)**:
  * Removed the automatic background scheduler routine (`_notifyStarted`) that was starting sessions and notifying users when their scheduled time arrived. Scheduled reviews will now remain in their scheduled state until manually started.
