### PR TITLE
fix(settings): limit accent colors in light/dark mode and sanitize selections (#693)

### DIFF
--- a/client-interface/components/settings/AppearanceTab.tsx
+++ b/client-interface/components/settings/AppearanceTab.tsx
@@ -16,7 +16,15 @@ const MODES: { key: ThemeMode; label: string; Icon: typeof Sun }[] = [
  * neutrals and status colors are always safe.
  */
 export function AppearanceTab() {
-  const { accent, setAccent, presets, mode, setMode } = useTheme();
+  const { accent, setAccent, presets, mode, setMode, theme } = useTheme();
+
+  const filteredPresets = presets.filter((p) => {
+    if (theme === 'dark') {
+      return p.key !== 'violet' && p.key !== 'rose' && p.key !== 'sky' && p.key !== 'graphite';
+    } else {
+      return p.key !== 'graphite';
+    }
+  });
 
   return (
     <div className="space-y-8">
@@ -44,7 +52,7 @@ export function AppearanceTab() {
       </div>
 
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-        {presets.map((p) => {
+        {filteredPresets.map((p) => {
           const selected = accent === p.key;
           return (
             <button

--- a/client-interface/lib/context/ThemeContext.tsx
+++ b/client-interface/lib/context/ThemeContext.tsx
@@ -32,12 +32,23 @@ const prefersDark = () =>
 
 const resolve = (mode: ThemeMode): Theme => (mode === 'system' ? (prefersDark() ? 'dark' : 'light') : mode);
 
+function sanitizeAccent(theme: Theme, accent: AccentKey): AccentKey {
+  if (theme === 'dark' && ['violet', 'rose', 'sky', 'graphite'].includes(accent)) {
+    return DEFAULT_ACCENT;
+  }
+  if (theme === 'light' && accent === 'graphite') {
+    return DEFAULT_ACCENT;
+  }
+  return accent;
+}
+
 function applyToRoot(theme: Theme, accent: AccentKey) {
   const root = document.documentElement;
   root.classList.toggle('dark', theme === 'dark');
   root.setAttribute('data-theme', theme);
-  if (accent === DEFAULT_ACCENT) root.removeAttribute('data-accent');
-  else root.setAttribute('data-accent', accent);
+  const sanitized = sanitizeAccent(theme, accent);
+  if (sanitized === DEFAULT_ACCENT) root.removeAttribute('data-accent');
+  else root.setAttribute('data-accent', sanitized);
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
@@ -62,21 +73,32 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     } catch { /* ignore */ }
 
     modeRef.current = initialMode;
-    accentRef.current = initialAccent;
     const resolved = resolve(initialMode);
-    applyToRoot(resolved, initialAccent);
+    const sanitizedAccent = sanitizeAccent(resolved, initialAccent);
+    accentRef.current = sanitizedAccent;
+    applyToRoot(resolved, sanitizedAccent);
     setModeState(initialMode);
     setThemeStateResolved(resolved);
-    setAccentState(initialAccent);
+    setAccentState(sanitizedAccent);
     setMounted(true);
+    if (sanitizedAccent !== initialAccent) {
+      try { localStorage.setItem(ACCENT_STORAGE_KEY, sanitizedAccent); } catch {}
+    }
 
     // Follow the OS when in system mode.
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const onChange = () => {
       if (modeRef.current !== 'system') return;
       const r = prefersDark() ? 'dark' : 'light';
+      const currentAccent = accentRef.current;
+      const sanitized = sanitizeAccent(r, currentAccent);
       setThemeStateResolved(r);
-      applyToRoot(r, accentRef.current);
+      if (sanitized !== currentAccent) {
+        accentRef.current = sanitized;
+        setAccentState(sanitized);
+        persist({ accent: sanitized });
+      }
+      applyToRoot(r, sanitized);
     };
     mq.addEventListener?.('change', onChange);
 
@@ -85,11 +107,15 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       if (getToken()) {
         appearanceApi.get().then((res: any) => {
           const data = res?.data ?? res ?? {};
-          if (isAccentKey(data.colorTheme) && data.colorTheme !== accentRef.current) {
-            accentRef.current = data.colorTheme;
-            setAccentState(data.colorTheme);
-            applyToRoot(resolve(modeRef.current), data.colorTheme);
-            localStorage.setItem(ACCENT_STORAGE_KEY, data.colorTheme);
+          if (isAccentKey(data.colorTheme)) {
+            const resolvedTheme = resolve(modeRef.current);
+            const sanitized = sanitizeAccent(resolvedTheme, data.colorTheme);
+            if (sanitized !== accentRef.current) {
+              accentRef.current = sanitized;
+              setAccentState(sanitized);
+              applyToRoot(resolvedTheme, sanitized);
+              localStorage.setItem(ACCENT_STORAGE_KEY, sanitized);
+            }
           }
         }).catch(() => { /* offline - cache wins */ });
       }
@@ -116,7 +142,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setModeState(m);
     const r = resolve(m);
     setThemeStateResolved(r);
-    applyToRoot(r, accent);
+    const currentAccent = accentRef.current;
+    const sanitized = sanitizeAccent(r, currentAccent);
+    if (sanitized !== currentAccent) {
+      accentRef.current = sanitized;
+      setAccentState(sanitized);
+      persist({ accent: sanitized });
+    }
+    applyToRoot(r, sanitized);
     persist({ mode: m, resolvedTheme: r });
   };
 
@@ -125,6 +158,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const setAccent = (key: AccentKey) => {
     if (!isAccentKey(key)) return;
+    const sanitized = sanitizeAccent(theme, key);
+    if (sanitized !== key) return;
     accentRef.current = key;
     setAccentState(key);
     applyToRoot(theme, key);


### PR DESCRIPTION
### Summary
This PR resolves issue #693 by cleaning up the available accent color palette in the Appearance settings:
- In **Dark Mode**, the `Violet`, `Rose`, and `Sky` color options are removed.
- In both **Light Mode** and **Dark Mode**, `Graphite` is removed.

Existing appearance settings are automatically sanitized (defaulting back to `Ocean` if a user had a removed color selected) to prevent UI styling issues or orphaned states.

### Key Changes

#### 💻 Client
* **[AppearanceTab.tsx](file:///home/hussain/pathment/client-interface/components/settings/AppearanceTab.tsx)**:
  * Extracted the resolved `theme` from `useTheme()` context.
  * Filtered `presets` dynamically:
    * In dark mode, filter out `violet`, `rose`, `sky`, and `graphite`.
    * In light mode, filter out `graphite`.
* **[ThemeContext.tsx](file:///home/hussain/pathment/client-interface/lib/context/ThemeContext.tsx)**:
  * Implemented a `sanitizeAccent` helper to validate that the selected accent color is allowed in the current active theme mode.
  * Applied `sanitizeAccent` during provider initialization (mount), user theme mode toggling (`setMode`), client-to-server settings synchronization, and OS color-scheme preference changes (`prefers-color-scheme` listener).
  * Automatically updates local storage and remote user settings when a sanitization adjustment is made.

### Verification Plan
* Verified code compilation.
* Verified that selecting light/dark modes updates the available accent choices dynamically.
* Tested setting removal by ensuring that fallback/cleanup correctly defaults to Ocean if a removed option is loaded.


<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/80a5b500-03af-4b29-915b-6353f190de86" />
