### PR TITLE
refactor(certificates): migrate certificate hooks to TanStack React Query

### DIFF
--- a/client-interface/app/mentor/certificates/page.tsx
+++ b/client-interface/app/mentor/certificates/page.tsx
@@ -95,7 +95,7 @@ export default function MentorCertificatesPage() {
   const [aiDetailMentee, setAiDetailMentee] = useState<any | null>(null);
 
   const {
-    aiResults, setAiResults, aiRanAt, setAiRanAt, runningAI,
+    aiResults, aiRanAt, setAiRanAt, runningAI,
     aiProgressCount, aiTotalCount, runAIEvaluation
   } = useAIEvaluationProgress({
     templateId: activeTemplateId,
@@ -134,7 +134,6 @@ export default function MentorCertificatesPage() {
     allSelectedRecipients: []
   });
 
-  const [refreshKey, setRefreshKey] = useState(0);
 
   const [activeTab, setActiveTab] = useState<'issue' | 'my'>('issue');
 
@@ -207,17 +206,13 @@ export default function MentorCertificatesPage() {
       .finally(() => setLoadingTemplates(false));
   }, []);
 
-  useEffect(() => {
+  const fetchQualifications = useCallback(() => {
     if (!activeTemplateId || !user) {
       setQualifiedData({});
       setMentorTiers({});
       return;
     }
-
     setLoadingQualifications(true);
-    setSearch('');
-    setSelectedIds(new Set());
-
     certificatesApi.getQualification(activeTemplateId, { mentorId: user.id })
       .then(res => {
         if (res.success && res.data) {
@@ -238,10 +233,7 @@ export default function MentorCertificatesPage() {
           criteria.forEach(c => {
             const list = data[c.id] || [];
             list.forEach((m: any) => {
-              if (!seenIds.has(m.id)) {
-                seenIds.add(m.id);
-                activeList.push(m);
-              }
+              if (!seenIds.has(m.id)) { seenIds.add(m.id); activeList.push(m); }
             });
           });
 
@@ -249,10 +241,7 @@ export default function MentorCertificatesPage() {
             if (key === 'mentors' || key === 'paused') return;
             const list = data[key] || [];
             list.forEach((m: any) => {
-              if (!seenIds.has(m.id)) {
-                seenIds.add(m.id);
-                activeList.push(m);
-              }
+              if (!seenIds.has(m.id)) { seenIds.add(m.id); activeList.push(m); }
             });
           });
 
@@ -266,33 +255,18 @@ export default function MentorCertificatesPage() {
               let bestTierId = criteria[criteria.length - 1]?.id || 'participation';
               criteria.forEach(c => {
                 const match = m.tierMatches?.[c.id] ?? 0;
-                if (match > maxMatch) {
-                  maxMatch = match;
-                  bestTierId = c.id;
-                }
+                if (match > maxMatch) { maxMatch = match; bestTierId = c.id; }
               });
               defTier = bestTierId;
             }
             initialTiers[m.id] = defTier;
-
             const matchPercent = m.tierMatches?.[defTier] ?? 0;
-            if (matchPercent >= 90) {
-              autoSelected.add(m.id);
-            }
+            if (matchPercent >= 90) autoSelected.add(m.id);
           });
 
-          if (activeTemplate?.aiEvaluation?.results) {
-            const aiRes = activeTemplate.aiEvaluation.results;
-            setAiResults(aiRes);
-            setAiRanAt(activeTemplate.aiEvaluation.ranAt ?? null);
-            aiRes.forEach((r: any) => {
-              if (r.mentee_id && r.certificate_tier && seenIds.has(r.mentee_id)) {
-                initialTiers[r.mentee_id] = r.certificate_tier;
-                autoSelected.add(r.mentee_id);
-              }
-            });
+          if (activeTemplate?.aiEvaluation?.ranAt) {
+            setAiRanAt(activeTemplate.aiEvaluation.ranAt);
           } else {
-            setAiResults([]);
             setAiRanAt(null);
           }
 
@@ -302,7 +276,13 @@ export default function MentorCertificatesPage() {
       })
       .catch(() => toast.error('Failed to load qualification details'))
       .finally(() => setLoadingQualifications(false));
-  }, [activeTemplateId, user, refreshKey]);
+  }, [activeTemplateId, user, templates, setAiRanAt]);
+
+  useEffect(() => {
+    setSearch('');
+    setSelectedIds(new Set());
+    fetchQualifications();
+  }, [activeTemplateId, user]);
 
   const activeMentees = useMemo<MenteeRow[]>(() => {
     const list: MenteeRow[] = [];
@@ -497,7 +477,7 @@ export default function MentorCertificatesPage() {
       if (res.success) {
         toast.success(`Queued ${recipientsList.length} certificate(s) for issuance`);
         setSelectedIds(new Set());
-        setRefreshKey(prev => prev + 1);
+        fetchQualifications();
       }
     } catch (err: any) {
       toast.error(err.message || 'Failed to issue certificates');

--- a/client-interface/components/admin/certificates/CertificateEditor.tsx
+++ b/client-interface/components/admin/certificates/CertificateEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import {
@@ -25,12 +25,14 @@ import {
   DEFAULT_CRITERIA, GOOGLE_FONTS_URL
 } from './certificate-constants';
 import { TierCriteriaModal } from './TierCriteriaModal';
-import { useAIEvaluationProgress, useRecipientSelection } from './hooks';
+import { useAIEvaluationProgress, useRecipientSelection, useCertificateQualifications } from './hooks';
+import { useInvalidate } from '@/lib/query';
+import { qk } from '@/lib/query/keys';
 
 
 
 interface CertificateEditorProps {
-  templateId?: string; 
+  templateId?: string;
 }
 
 export default function CertificateEditor({ templateId }: CertificateEditorProps) {
@@ -59,40 +61,35 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
 
   const [criteria, setCriteria] = useState<TierCriteria[]>(DEFAULT_CRITERIA);
 
-  const [qualifiedData, setQualifiedData] = useState<Record<string, any[]>>({});
-  const [loadingQualifications, setLoadingQualifications] = useState(false);
+
 
   const [aiDetailMentee, setAiDetailMentee] = useState<any | null>(null);
   const [expandedAIRows, setExpandedAIRows] = useState<Set<string>>(new Set());
 
+  const invalidate = useInvalidate();
+
   const {
-    aiResults, setAiResults, aiRanAt, setAiRanAt, runningAI,
+    aiResults, aiRanAt, setAiRanAt, runningAI,
     aiProgressCount, aiTotalCount, aiEvalMap, runAIEvaluation
-  } = useAIEvaluationProgress({
-    templateId,
-    onSingleProgress: (result) => {
-      setAdminTiers(prev => ({ ...prev, [result.mentee_id]: result.certificate_tier }));
-      const menteeObj = [...recipientMenteesList, ...recipientMentorsList, ...recipientPausedList].find(m => m.id === result.mentee_id);
-      if (menteeObj && !menteeObj.isPaused) {
-        setSelectedMenteeIds(prev => new Set(prev).add(result.mentee_id));
-      }
-    },
-    onBatchComplete: (results) => {
-      const newTiers: Record<string, string> = {};
-      const autoSelected = new Set<string>();
-      const pausedSet = new Set(recipientPausedList.map((m: any) => m.id));
-      for (const r of results) {
-        if (r.mentee_id) {
-          newTiers[r.mentee_id] = r.certificate_tier;
-          if (!pausedSet.has(r.mentee_id)) {
-            autoSelected.add(r.mentee_id);
-          }
-        }
-      }
-      setAdminTiers(prev => ({ ...prev, ...newTiers }));
-      setSelectedMenteeIds(autoSelected);
-    }
-  });
+  } = useAIEvaluationProgress({ templateId });
+
+  const [availableTasks, setAvailableTasks] = useState<Array<{ id: string; title: string }>>([]);
+  const [allRoadmaps, setAllRoadmaps] = useState<any[]>([]);
+  const [programs, setPrograms] = useState<Array<{ id: string; name: string }>>([]);
+  const [selectedProgramId, setSelectedProgramId] = useState<string>('');
+
+  const {
+    qualifiedData,
+    loadingQualifications,
+    criteriaTasks,
+    issuing,
+    sendingToMentors,
+    executeIssuance,
+    handleSendToMentors,
+    duplicateWarningModal: duplicateWarnState,
+    setDuplicateWarningModal: setDuplicateWarnState,
+    refetchQualifications,
+  } = useCertificateQualifications({ templateId: templateId ?? null, selectedProgramId, criteria });
 
   const {
     recipientSearch, setRecipientSearch,
@@ -106,22 +103,13 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
     bulkSetBadge: bulkSetBadgeHook, resetToAIRecommendations: resetToAIRecommendationsHook
   } = useRecipientSelection({ criteria, qualifiedData, aiResults: aiEvalMap });
 
-  const [availableTasks, setAvailableTasks] = useState<Array<{ id: string; title: string }>>([]);
-  const [allRoadmaps, setAllRoadmaps] = useState<any[]>([]);
-  const [programs, setPrograms] = useState<Array<{ id: string; name: string }>>([]);
-  const [selectedProgramId, setSelectedProgramId] = useState<string>('');
-
-  const [issuing, setIssuing] = useState(false);
-  const [sendingToMentors, setSendingToMentors] = useState(false);
   const [isRulesDrawerOpen, setIsRulesDrawerOpen] = useState(false);
-  const [criteriaTasks, setCriteriaTasks] = useState<Array<{ id: string; title: string }>>([]);
 
   const handleProgramChange = (val: string) => {
     if (criteria.some(c => (c.keywords?.length ?? 0) > 0)) {
       if (window.confirm("Changing the program will clear the keyword criteria. Do you want to proceed?")) {
         setSelectedProgramId(val);
         setCriteria(prev => prev.map(c => ({ ...c, keywords: [] })));
-        setAiResults([]);
         setAiRanAt(null);
       }
     } else {
@@ -138,19 +126,45 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
   const bulkSetBadge = (badge: string) => bulkSetBadgeHook(badge, getTierName);
   const resetToAIRecommendations = () => resetToAIRecommendationsHook(aiResults);
 
-  const [duplicateWarnState, setDuplicateWarnState] = useState<{
-    isOpen: boolean;
-    duplicates: Array<{ id: string; name: string; email: string; tier: string }>;
-    allSelectedRecipients: Array<{ menteeId: string; tier: string }>;
-  }>({
-    isOpen: false,
-    duplicates: [],
-    allSelectedRecipients: []
-  });
-
-  const [refreshKey, setRefreshKey] = useState(0);
-
-
+  const handleIssue = useCallback(async () => {
+    if (selectedMenteeIds.size === 0) {
+      toast.error('Please select at least one mentee to issue certificates');
+      return;
+    }
+    const defaultTier = criteria[criteria.length - 1]?.id ?? 'participation';
+    const recipients = Array.from(selectedMenteeIds).map((id) => ({
+      menteeId: id,
+      tier: adminTiers[id] ?? defaultTier,
+    }));
+    const allMentees: any[] = [];
+    const seenIds = new Set<string>();
+    Object.keys(qualifiedData).forEach((key) => {
+      if (key === 'mentors' || key === 'paused') return;
+      (qualifiedData[key] ?? []).forEach((m: any) => {
+        if (!seenIds.has(m.id)) { seenIds.add(m.id); allMentees.push(m); }
+      });
+    });
+    const allActive = [...allMentees, ...(qualifiedData.mentors ?? [])];
+    const duplicates = recipients
+      .filter((r) => {
+        const m = allActive.find((x) => x.id === r.menteeId);
+        return m && Array.isArray(m.issuedTiers) && m.issuedTiers.includes(r.tier);
+      })
+      .map((r) => {
+        const m = allActive.find((x) => x.id === r.menteeId);
+        return {
+          id: r.menteeId,
+          name: m ? `${m.firstName} ${m.lastName}`.trim() || m.email : 'Recipient',
+          email: m?.email ?? '',
+          tier: getTierName(r.tier),
+        };
+      });
+    if (duplicates.length > 0) {
+      setDuplicateWarnState({ isOpen: true, duplicates, allSelectedRecipients: recipients });
+    } else {
+      await executeIssuance(recipients);
+    }
+  }, [selectedMenteeIds, adminTiers, qualifiedData, criteria, getTierName, executeIssuance, setDuplicateWarnState]);
 
   const [isTierModalOpen, setIsTierModalOpen] = useState(false);
   const [editingTier, setEditingTier] = useState<TierCriteria | null>(null);
@@ -227,25 +241,24 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
           setElements(t.config || []);
           if (Array.isArray(t.criteria)) {
             const loaded = t.criteria.map((c: any, fallbackIdx: number) => ({
-              id:                c.id,
-              name:              c.name,
-              priority:          c.priority ?? fallbackIdx + 1,
-              badgeUrl:          c.badgeUrl ?? '',
-              keywords:          Array.isArray(c.keywords) ? c.keywords : [],
-              minScorePercent:   c.minScorePercent ?? null,
-              maxOpenBlockers:   c.maxOpenBlockers ?? null,
+              id: c.id,
+              name: c.name,
+              priority: c.priority ?? fallbackIdx + 1,
+              badgeUrl: c.badgeUrl ?? '',
+              keywords: Array.isArray(c.keywords) ? c.keywords : [],
+              minScorePercent: c.minScorePercent ?? null,
+              maxOpenBlockers: c.maxOpenBlockers ?? null,
               minCompletionRate: c.minCompletionRate ?? null,
-              minOnTimeRate:     c.minOnTimeRate ?? null,
-              minAvgRating:      c.minAvgRating ?? null,
+              minOnTimeRate: c.minOnTimeRate ?? null,
+              minAvgRating: c.minAvgRating ?? null,
               minAttendanceRate: c.minAttendanceRate ?? null,
-              customRule:        c.customRule ?? ''
+              customRule: c.customRule ?? ''
             }));
             loaded.sort((a: any, b: any) => (a.priority ?? Infinity) - (b.priority ?? Infinity));
             setCriteria(loaded);
           }
-          if (t.aiEvaluation?.results) {
-            setAiResults(t.aiEvaluation.results);
-            setAiRanAt(t.aiEvaluation.ranAt ?? null);
+          if (t.aiEvaluation?.ranAt) {
+            setAiRanAt(t.aiEvaluation.ranAt);
           }
         }
       } catch (err: any) {
@@ -259,74 +272,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
     fetchTemplate();
   }, [templateId]);
 
-  useEffect(() => {
-    if (!templateId || !selectedProgramId) return;
 
-    const fetchQualifications = async () => {
-      try {
-        setLoadingQualifications(true);
-        const res = await certificatesApi.getQualification(templateId, { programId: selectedProgramId });
-        if (res.success && res.data) {
-          setQualifiedData(res.data);
-          if (res.criteriaTasks) {
-            setCriteriaTasks(res.criteriaTasks);
-          } else {
-            setCriteriaTasks([]);
-          }
-
-          const activeList: any[] = [];
-          const seenIds = new Set<string>();
-
-          criteria.forEach(c => {
-            const list = res.data[c.id] || [];
-            list.forEach((m: any) => {
-              if (!seenIds.has(m.id)) {
-                seenIds.add(m.id);
-                activeList.push(m);
-              }
-            });
-          });
-
-          Object.keys(res.data).forEach(key => {
-            if (key === 'mentors' || key === 'paused') return;
-            const list = res.data[key] || [];
-            list.forEach((m: any) => {
-              if (!seenIds.has(m.id)) {
-                seenIds.add(m.id);
-                activeList.push(m);
-              }
-            });
-          });
-
-          const mentorsList = res.data.mentors ?? [];
-
-          const initialTiers: Record<string, string> = {};
-          const autoSelected = new Set<string>();
-
-          activeList.forEach(m => {
-            const defTier = m.assignedTier || aiEvalMap[m.id]?.certificate_tier || criteria[criteria.length - 1]?.id || 'participation';
-            initialTiers[m.id] = defTier;
-            autoSelected.add(m.id);
-          });
-
-          const mentorDefaultTier = criteria[criteria.length - 1]?.id || 'participation';
-          mentorsList.forEach(m => {
-            initialTiers[m.id] = mentorDefaultTier;
-            autoSelected.add(m.id);
-          });
-
-          setAdminTiers(initialTiers);
-          setSelectedMenteeIds(autoSelected);
-        }
-      } catch (err) {
-        console.error('Failed to calculate qualification counts:', err);
-      } finally {
-        setLoadingQualifications(false);
-      }
-    };
-
-    fetchQualifications();
-  }, [templateId, selectedProgramId, refreshKey]);
 
   const handleMouseMove = (e: React.MouseEvent) => {
     if (!activeDragId || !canvasRef.current) return;
@@ -561,7 +507,9 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
 
       if (res.success && res.data) {
         toast.success(templateId ? 'Template updated successfully' : 'Template created successfully');
-        setRefreshKey(prev => prev + 1);
+        if (templateId && selectedProgramId) {
+          await invalidate(qk.certificates.qualifications(templateId, selectedProgramId));
+        }
         if (!templateId) {
           router.push(`/admin/certificates/${res.data.id}/edit`);
         }
@@ -573,84 +521,9 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
     }
   };
 
-  const executeIssuance = async (recipientsList: Array<{ menteeId: string; tier: string }>) => {
-    try {
-      setIssuing(true);
-      const res = await certificatesApi.issueCertificates({
-        templateId: templateId!,
-        recipients: recipientsList
-      });
-      if (res.success) {
-        toast.success(`Successfully enqueued ${recipientsList.length} certificate(s) for rendering!`);
-        setSelectedMenteeIds(new Set());
-        setRefreshKey(prev => prev + 1);
-      }
-    } catch (err: any) {
-      toast.error(err.message || 'Failed to issue certificates');
-    } finally {
-      setIssuing(false);
-    }
-  };
 
-  const handleIssue = async () => {
-    if (selectedMenteeIds.size === 0) {
-      toast.error('Please select at least one mentee to issue certificates');
-      return;
-    }
 
-    const defaultTier = criteria[criteria.length - 1]?.id ?? 'participation';
-    const recipients = Array.from(selectedMenteeIds).map(id => ({
-      menteeId: id,
-      tier: adminTiers[id] ?? defaultTier
-    }));
 
-    const allMentees: any[] = [];
-    const seenIds = new Set<string>();
-    Object.keys(qualifiedData).forEach(key => {
-      if (key === 'mentors' || key === 'paused') return;
-      (qualifiedData[key] ?? []).forEach((m: any) => {
-        if (!seenIds.has(m.id)) { seenIds.add(m.id); allMentees.push(m); }
-      });
-    });
-    const allMentors: any[] = qualifiedData.mentors ?? [];
-    const allActiveRecipients = [...allMentees, ...allMentors];
-
-    const duplicateInstances = recipients.filter(r => {
-      const m = allActiveRecipients.find(item => item.id === r.menteeId);
-      return m && m.issuedTiers && m.issuedTiers.includes(r.tier);
-    }).map(r => {
-      const m = allActiveRecipients.find(item => item.id === r.menteeId);
-      return {
-        id: r.menteeId,
-        name: m ? `${m.firstName} ${m.lastName}` : 'Recipient',
-        email: m?.email ?? '',
-        tier: getTierName(r.tier)
-      };
-    });
-
-    if (duplicateInstances.length > 0) {
-      setDuplicateWarnState({
-        isOpen: true,
-        duplicates: duplicateInstances,
-        allSelectedRecipients: recipients
-      });
-    } else {
-      await executeIssuance(recipients);
-    }
-  };
-
-  const handleSendToMentors = async () => {
-    if (!templateId || !selectedProgramId) return;
-    try {
-      setSendingToMentors(true);
-      const res = await certificatesApi.sendToMentors(templateId, selectedProgramId);
-      if (res.success) toast.success(res.message);
-    } catch (err: any) {
-      toast.error(err.message || 'Failed to send to mentors');
-    } finally {
-      setSendingToMentors(false);
-    }
-  };
 
   const openTierModal = (tier?: TierCriteria) => {
     setEditingTier(tier || null);
@@ -700,9 +573,9 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
         __html: `@import url('${GOOGLE_FONTS_URL}');`
       }} />
 
-      {}
+      { }
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-5 border-b border-border/60 pb-5">
-        {}
+        { }
         <div className="space-y-2 flex-1 max-w-2xl">
           <div className="flex items-center gap-1.5 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
             <span>Certificates</span>
@@ -721,9 +594,9 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
           <p className="text-xs text-muted-foreground font-medium">Create, customize and issue certificates for this fellowship cycle.</p>
         </div>
 
-        {}
+        { }
         <div className="flex items-center gap-3 flex-wrap md:justify-end shrink-0">
-          {}
+          { }
           <div className="relative inline-flex items-center shadow-3xs rounded-xl border border-border/80 bg-background hover:bg-muted/30 transition-colors">
             <span className="pl-3.5 pr-1.5 text-[9px] font-extrabold text-muted-foreground uppercase tracking-wider select-none border-r border-border/60 py-2">
               Program
@@ -760,7 +633,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
         </div>
       </div>
 
-      {}
+      { }
       <div className="bg-card border border-border rounded-3xl p-6 shadow-xs space-y-5">
         <div className="flex items-start gap-3.5 border-b border-border pb-4">
           <div className="w-8 h-8 rounded-full bg-brand-500/10 flex items-center justify-center font-bold text-brand-500 text-sm">
@@ -773,9 +646,9 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
         </div>
 
         <div className="grid grid-cols-1 xl:grid-cols-12 gap-6">
-          {}
+          { }
           <div className="xl:col-span-8 flex flex-col items-center gap-4">
-            {}
+            { }
             <div className="flex items-center gap-2 bg-muted/40 border border-border px-3 py-1.5 rounded-2xl text-[10px] font-bold text-muted-foreground">
               <button type="button" onClick={() => setZoom(z => Math.max(0.5, z - 0.1))} className="p-1 hover:bg-muted text-foreground rounded-lg transition-colors">
                 <ZoomOut className="w-3.5 h-3.5" />
@@ -790,7 +663,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
               </button>
             </div>
 
-            {}
+            { }
             <div className="w-full bg-muted/30 border border-border rounded-3xl p-6 flex items-center justify-center overflow-auto min-h-[480px]">
               <div
                 ref={canvasRef}
@@ -808,7 +681,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
                 }}
                 className="relative rounded-lg shadow-lg overflow-hidden cursor-default select-none border border-border shrink-0"
               >
-                {}
+                { }
                 {elements.map((el) => {
                   const isSelected = selectedId === el.id;
 
@@ -910,14 +783,14 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
               </div>
             </div>
 
-            {}
+            { }
             <div className="space-y-3 w-full animate-fade-in">
               <div className="flex items-center justify-between border-b border-border pb-2">
                 <label className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">Background template paper</label>
                 <span className="text-[9px] font-bold text-brand-600 bg-brand-500/10 px-2 py-0.5 rounded-full uppercase tracking-wider select-none">Design Setup</span>
               </div>
 
-              {}
+              { }
               <div className="w-full">
                 <button
                   type="button"
@@ -937,9 +810,9 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
             </div>
           </div>
 
-          {}
+          { }
           <div className="xl:col-span-4 space-y-5">
-            {}
+            { }
             <div className="bg-card border border-border rounded-2xl p-5 space-y-3.5 shadow-2xs">
               <div>
                 <h3 className="text-xs font-bold text-foreground uppercase tracking-wide">Variables</h3>
@@ -1005,7 +878,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
               </div>
             </div>
 
-            {}
+            { }
             {selectedElement ? (
               <div className="bg-card border border-border rounded-2xl p-5 space-y-4 shadow-2xs">
                 <div className="flex items-center justify-between border-b border-border pb-3">
@@ -1141,7 +1014,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
         </div>
       </div>
 
-      {}
+      { }
       <CriteriaTable
         criteria={criteria}
         onAdd={() => openTierModal()}
@@ -1150,7 +1023,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
         onReorder={setCriteria}
       />
 
-      {}
+      { }
       <div className="bg-card border border-border rounded-3xl p-6 shadow-xs space-y-5">
         <div className="flex items-start justify-between border-b border-border pb-4">
           <div className="flex items-start gap-3.5">
@@ -1203,7 +1076,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
               totalCount={aiTotalCount}
             />
 
-            {}
+            { }
             <AIDetailDrawer
               mentee={aiDetailMentee}
               onClose={() => setAiDetailMentee(null)}
@@ -1213,8 +1086,8 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
               overrideLabel="Override Tier (Admin)"
             />
 
-            {}
-            {}
+            { }
+            { }
             <div className="flex items-center justify-between border-b border-border -mx-6 px-6 pb-px mb-2">
               <div className="flex gap-4">
                 {(['all', 'mentees', 'mentors', 'paused'] as const).map(type => (
@@ -1260,7 +1133,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
               </button>
             </div>
 
-            {}
+            { }
             <div className="flex flex-col sm:flex-row gap-3 mb-5">
               <div className="relative flex-1">
                 <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/60" />
@@ -1282,7 +1155,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
                 )}
               </div>
 
-              {}
+              { }
               <div className="relative min-w-[150px]">
                 <select
                   value={badgeFilter}
@@ -1297,7 +1170,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
                 <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/60 pointer-events-none" />
               </div>
 
-              {}
+              { }
               <div className="relative min-w-[150px]">
                 <select
                   value={sortBy}
@@ -1312,7 +1185,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
               </div>
             </div>
 
-            {}
+            { }
             {filtered.length > 0 && (
               <div className="flex items-center gap-1.5 flex-wrap bg-muted/20 border border-border rounded-2xl p-3 text-xs w-full">
                 <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider mr-1">Set All to:</span>
@@ -1338,7 +1211,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
               </div>
             )}
 
-            {}
+            { }
             <RecipientRosterTable
               filtered={filtered}
               criteria={criteria}
@@ -1357,7 +1230,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
               emptyMessage={`No ${recipientType === 'paused' ? 'paused mentees' : recipientType === 'all' ? 'active recipients' : 'active ' + recipientType} found in this program.`}
             />
 
-            {}
+            { }
             {selectedMenteeIds.size > 0 && (
               <div className="bg-muted/20 border border-border rounded-2xl p-4 flex flex-wrap gap-4 text-xs font-semibold text-muted-foreground">
                 {criteria.map(c => (
@@ -1370,7 +1243,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
               </div>
             )}
 
-            {}
+            { }
             <div className="flex items-center justify-between border-t border-border pt-4">
               <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground">
                 <Users className="w-4 h-4 text-brand-500" />
@@ -1399,7 +1272,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
 
       </div>
 
-      {}
+      { }
       {templateId && (
         <div className="bg-card border border-border rounded-3xl p-6 shadow-xs space-y-5">
           <div className="border-b border-border pb-4">
@@ -1410,7 +1283,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
         </div>
       )}
 
-      {}
+      { }
       <TierCriteriaModal
         isOpen={isTierModalOpen}
         editingTier={editingTier}
@@ -1455,7 +1328,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
                       </p>
                     ) : (
                       <>
-                        {}
+                        { }
                         <div className="space-y-1">
                           <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">Keywords / Tech Stack</p>
                           {kws.length === 0 ? (
@@ -1469,7 +1342,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
                           )}
                         </div>
 
-                        {}
+                        { }
                         <div className="space-y-1">
                           <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">Hard Constraints (AI cannot bypass)</p>
                           <div className="grid grid-cols-3 gap-2">
@@ -1496,7 +1369,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
                           </div>
                         </div>
 
-                        {}
+                        { }
                         {customRule && (
                           <div className="space-y-1">
                             <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">Custom AI Rule</p>
@@ -1543,7 +1416,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
         width="lg"
       >
         <div className="grid grid-cols-2 gap-4 py-2">
-          {}
+          { }
           {(() => {
             const hasCustomImage = bgImageUrl && !bgImageUrl.startsWith('data:image/svg+xml;base64,');
             const isCustomActive = !activePresetId && hasCustomImage;
@@ -1564,7 +1437,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
                     }}
                     className="w-full flex flex-col items-start focus:outline-none flex-1"
                   >
-                    {}
+                    { }
                     <div className="w-full aspect-[1.414] rounded-xl overflow-hidden border border-border bg-muted/30 relative flex items-center justify-center">
                       <img
                         src={bgImageUrl}
@@ -1590,7 +1463,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
                     </div>
                   </button>
 
-                  {}
+                  { }
                   <div className="mt-3 flex items-center justify-between w-full border-t border-border/40 pt-2 shrink-0">
                     {isCustomActive ? (
                       <span className="inline-flex items-center gap-1 text-[8px] font-bold text-emerald-600 bg-emerald-500/10 px-2 py-1 rounded-full uppercase tracking-wider select-none">
@@ -1668,7 +1541,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
                   : 'border-border hover:border-brand-500/30'
                   }`}
               >
-                {}
+                { }
                 <div className="w-full aspect-[1.414] rounded-xl overflow-hidden border border-border bg-muted/30 relative flex items-center justify-center">
                   <img
                     src={preset.imageUrl}
@@ -1692,7 +1565,7 @@ export default function CertificateEditor({ templateId }: CertificateEditorProps
                     </p>
                   </div>
 
-                  {}
+                  { }
                   <div className="mt-3">
                     {isActive ? (
                       <span className="inline-flex items-center gap-1 text-[8px] font-bold text-emerald-600 bg-emerald-500/10 px-2 py-1 rounded-full uppercase tracking-wider">

--- a/client-interface/components/admin/certificates/hooks/useAIEvaluationProgress.ts
+++ b/client-interface/components/admin/certificates/hooks/useAIEvaluationProgress.ts
@@ -2,8 +2,12 @@
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { toast } from 'sonner';
-import { certificatesApi } from '@/lib/services/certificates-api';
+import { certificatesApi, AIEvaluationResult } from '@/lib/services/certificates-api';
 import { getSocket } from '@/lib/services/socket-client';
+import { useApiQuery } from '@/lib/query';
+import { useQueryClient } from '@tanstack/react-query';
+import { qk } from '@/lib/query/keys';
+import { STALE } from '@/lib/query/client';
 
 export interface UseAIEvaluationProgressOptions {
   templateId?: string | null;
@@ -11,46 +15,81 @@ export interface UseAIEvaluationProgressOptions {
   onBatchComplete?: (results: any[]) => void;
 }
 
+const EMPTY_ARRAY: AIEvaluationResult[] = [];
+
 export function useAIEvaluationProgress(options: UseAIEvaluationProgressOptions = {}) {
   const { templateId, onSingleProgress, onBatchComplete } = options;
 
-  const [aiResults, setAiResults] = useState<any[]>([]);
+  const [aiEvaluationRunId, setAiEvaluationRunId] = useState<string | null>(null);
   const [aiRanAt, setAiRanAt] = useState<string | null>(null);
   const [runningAI, setRunningAI] = useState(false);
   const [aiProgressCount, setAiProgressCount] = useState(0);
   const [aiTotalCount, setAiTotalCount] = useState(0);
-  const [aiEvaluationRunId, setAiEvaluationRunId] = useState<string | null>(null);
+
+  const queryClient = useQueryClient();
+
+  const { data: statusRes, refetch: refetchStatus } = useApiQuery({
+    queryKey: qk.certificates.aiStatus(templateId ?? '', aiEvaluationRunId),
+    queryFn: async () => certificatesApi.getAIEvaluationStatus(templateId!, aiEvaluationRunId ?? undefined),
+    enabled: !!templateId,
+    staleTime: STALE.short,
+    refetchInterval: (data) => {
+      if (!data) return false;
+      return data.data?.isDone ? false : 4_000;
+    },
+  });
+
+  const aiResults = useMemo<AIEvaluationResult[]>(() => {
+    if (!statusRes?.data?.data) return EMPTY_ARRAY;
+    return Array.isArray(statusRes.data.data) ? statusRes.data.data : EMPTY_ARRAY;
+  }, [statusRes]);
+
+  useEffect(() => {
+    if (!statusRes?.success || !statusRes.data) return;
+
+    const statusData = statusRes.data;
+    const isDone = statusData.isDone ?? true;
+    const activeRunId = statusData.runId;
+    const completed = statusData.completed ?? 0;
+    const total = statusData.total ?? 0;
+
+    setAiProgressCount(completed);
+    setAiTotalCount(total);
+
+    if (!isDone && activeRunId) {
+      setAiEvaluationRunId(activeRunId);
+      setRunningAI(true);
+    } else if (isDone && runningAI) {
+      setAiRanAt(statusData.ranAt || new Date().toISOString());
+      setRunningAI(false);
+      setAiEvaluationRunId(null);
+      const resultsList = Array.isArray(statusData.data) ? statusData.data : [];
+      if (resultsList.length > 0) {
+        if (onBatchComplete) onBatchComplete(resultsList);
+        toast.success('AI evaluation completed successfully!');
+      }
+    }
+  }, [statusRes, runningAI, onBatchComplete]);
 
   useEffect(() => {
     if (!aiEvaluationRunId || !templateId) return;
 
     const socket = getSocket();
-    let pollInterval: NodeJS.Timeout | null = null;
 
     const handleProgress = (data: { runId: string; menteeId: string; result: any; completed: number; total: number }) => {
       if (data.runId !== aiEvaluationRunId) return;
       setAiProgressCount(data.completed);
       setAiTotalCount(data.total);
 
-      setAiResults(prev => {
-        const index = prev.findIndex(r => r.mentee_id === data.result.mentee_id);
-        if (index > -1) {
-          const updated = [...prev];
-          updated[index] = data.result;
-          return updated;
-        } else {
-          return [...prev, data.result];
-        }
-      });
-
       if (onSingleProgress) {
         onSingleProgress(data.result);
       }
+
+      queryClient.invalidateQueries({ queryKey: qk.certificates.aiStatus(templateId, aiEvaluationRunId) });
     };
 
     const handleComplete = (data: { runId: string; results: any[]; ranAt: string }) => {
       if (data.runId !== aiEvaluationRunId) return;
-      setAiResults(data.results || []);
       setAiRanAt(data.ranAt);
       setRunningAI(false);
       setAiEvaluationRunId(null);
@@ -60,6 +99,7 @@ export function useAIEvaluationProgress(options: UseAIEvaluationProgressOptions 
       }
 
       toast.success(`AI evaluation completed successfully for ${(data.results || []).length} mentees!`);
+      queryClient.invalidateQueries({ queryKey: qk.certificates.aiStatus(templateId) });
     };
 
     if (socket) {
@@ -67,113 +107,53 @@ export function useAIEvaluationProgress(options: UseAIEvaluationProgressOptions 
       socket.on('ai-eval:complete', handleComplete);
     }
 
-    pollInterval = setInterval(async () => {
-      try {
-        const res: any = await certificatesApi.getAIEvaluationStatus(templateId, aiEvaluationRunId);
-        if (res.success) {
-          const payload = res.data?.data ? res.data : res;
-          const completed = payload.completed ?? res.completed ?? 0;
-          const total = payload.total ?? res.total ?? 0;
-          const isDone = payload.isDone ?? res.isDone ?? false;
-          const resultsList = payload.data ?? res.data ?? [];
-
-          setAiProgressCount(completed);
-          setAiTotalCount(total);
-
-          if (Array.isArray(resultsList) && resultsList.length > 0) {
-            setAiResults(resultsList);
-            if (onBatchComplete) {
-              onBatchComplete(resultsList);
-            }
-          }
-
-          if (isDone) {
-            setAiRanAt(payload.ranAt || res.ranAt || new Date().toISOString());
-            setRunningAI(false);
-            setAiEvaluationRunId(null);
-            if (pollInterval) clearInterval(pollInterval);
-            toast.success(`AI evaluation completed successfully!`);
-          }
-        }
-      } catch (err) {
-        console.error('AI status poll error:', err);
-      }
-    }, 4000);
-
     return () => {
       if (socket) {
         socket.off('ai-eval:progress', handleProgress);
         socket.off('ai-eval:complete', handleComplete);
       }
-      if (pollInterval) clearInterval(pollInterval);
     };
-  }, [aiEvaluationRunId, templateId, onSingleProgress, onBatchComplete]);
+  }, [aiEvaluationRunId, templateId, onSingleProgress, onBatchComplete, queryClient]);
 
-  const runAIEvaluation = useCallback(async (targetTemplateId?: string) => {
-    const idToUse = targetTemplateId || templateId;
-    if (!idToUse) return;
+  const runAIEvaluation = useCallback(
+    async (targetTemplateId?: string) => {
+      const idToUse = targetTemplateId || templateId;
+      if (!idToUse) return;
 
-    try {
-      setRunningAI(true);
-      setAiProgressCount(0);
-      setAiTotalCount(0);
-      setAiResults([]);
-
-      const res: any = await certificatesApi.runAIEvaluation(idToUse);
-      const runId = res.runId || res.data?.runId;
-      const total = res.total ?? res.data?.total ?? 0;
-
-      if (res.success && runId) {
-        setAiEvaluationRunId(runId);
-        setAiTotalCount(total);
-        toast.info(`AI evaluation started for ${total} mentees...`);
-      }
-    } catch (err: any) {
-      toast.error(err.message || 'AI evaluation failed. Check AI connection in Settings.');
-      setRunningAI(false);
-    }
-  }, [templateId]);
-
-  useEffect(() => {
-    if (!templateId) return;
-
-    let isMounted = true;
-    async function checkInitialStatus() {
       try {
-        const statusRes: any = await certificatesApi.getAIEvaluationStatus(templateId!);
-        if (statusRes.success && isMounted) {
-          const payload = statusRes.data?.data ? statusRes.data : statusRes;
-          const activeRunId = payload.runId || statusRes.runId;
-          const isDone = payload.isDone ?? statusRes.isDone ?? true;
-          const completed = payload.completed ?? statusRes.completed ?? 0;
-          const total = payload.total ?? statusRes.total ?? 0;
+        setRunningAI(true);
+        setAiProgressCount(0);
+        setAiTotalCount(0);
 
-          if (!isDone && activeRunId) {
-            setAiEvaluationRunId(activeRunId);
-            setRunningAI(true);
-            setAiProgressCount(completed);
-            setAiTotalCount(total);
-          }
+        const res: any = await certificatesApi.runAIEvaluation(idToUse);
+        const runId = res.runId || res.data?.runId;
+        const total = res.total ?? res.data?.total ?? 0;
+
+        if (res.success && runId) {
+          setAiEvaluationRunId(runId);
+          setAiTotalCount(total);
+          toast.info(`AI evaluation started for ${total} mentees...`);
+          queryClient.invalidateQueries({ queryKey: qk.certificates.aiStatus(idToUse, runId) });
         }
-      } catch (e) {
+      } catch (err: any) {
+        toast.error(err.message || 'AI evaluation failed. Check AI connection in Settings.');
+        setRunningAI(false);
       }
-    }
-
-    checkInitialStatus();
-    return () => { isMounted = false; };
-  }, [templateId]);
+    },
+    [templateId, queryClient]
+  );
 
   const aiEvalMap = useMemo(() => {
-    const map: Record<string, any> = {};
-    (aiResults || []).forEach(r => {
-      if (r.mentee_id) map[r.mentee_id] = r;
+    const map: Record<string, AIEvaluationResult> = {};
+    const safeResults = Array.isArray(aiResults) ? aiResults : EMPTY_ARRAY;
+    safeResults.forEach((r) => {
+      if (r && r.mentee_id) map[r.mentee_id] = r;
     });
     return map;
   }, [aiResults]);
 
   return {
     aiResults,
-    setAiResults,
     aiRanAt,
     setAiRanAt,
     runningAI,
@@ -186,5 +166,6 @@ export function useAIEvaluationProgress(options: UseAIEvaluationProgressOptions 
     setAiEvaluationRunId,
     aiEvalMap,
     runAIEvaluation,
+    refetchStatus,
   };
 }

--- a/client-interface/components/admin/certificates/hooks/useCertificateCanvas.ts
+++ b/client-interface/components/admin/certificates/hooks/useCertificateCanvas.ts
@@ -34,7 +34,7 @@ export function useCertificateCanvas({ elements, setElements }: UseCertificateCa
     }
   }, [bgImageUrl]);
 
-  const selectedElement = elements.find(el => el.id === selectedId) || null;
+  const selectedElement = elements.find((el) => el.id === selectedId) || null;
 
   const handleMouseMove = (e: React.MouseEvent) => {
     if (!activeDragId || !canvasRef.current) return;
@@ -49,9 +49,9 @@ export function useCertificateCanvas({ elements, setElements }: UseCertificateCa
     xPercent = Math.max(0, Math.min(100, xPercent));
     yPercent = Math.max(0, Math.min(100, yPercent));
 
-    setElements(prev => prev.map(el =>
-      el.id === activeDragId ? { ...el, xPercent, yPercent } : el
-    ));
+    setElements((prev) =>
+      prev.map((el) => (el.id === activeDragId ? { ...el, xPercent, yPercent } : el))
+    );
   };
 
   const handleMouseUp = () => {
@@ -72,8 +72,8 @@ export function useCertificateCanvas({ elements, setElements }: UseCertificateCa
   };
 
   const addVariableElement = (key: string, label: string) => {
-    if (elements.some(el => el.dynamicKey === key)) {
-      const match = elements.find(el => el.dynamicKey === key);
+    if (elements.some((el) => el.dynamicKey === key)) {
+      const match = elements.find((el) => el.dynamicKey === key);
       if (match) setSelectedId(match.id);
       toast.info(`${label} variable is already added to workspace`);
       return;
@@ -91,10 +91,10 @@ export function useCertificateCanvas({ elements, setElements }: UseCertificateCa
       color: '#1e293b',
       fontWeight: 'bold',
       alignment: 'center',
-      fontStyle: 'Montserrat, sans-serif'
+      fontStyle: 'Montserrat, sans-serif',
     };
 
-    setElements(prev => [...prev, newEl]);
+    setElements((prev) => [...prev, newEl]);
     setSelectedId(id);
     toast.success(`Added ${label} variable to template canvas!`);
   };
@@ -111,14 +111,14 @@ export function useCertificateCanvas({ elements, setElements }: UseCertificateCa
       color: '#1e293b',
       fontWeight: 'normal',
       alignment: 'center',
-      fontStyle: 'Montserrat, sans-serif'
+      fontStyle: 'Montserrat, sans-serif',
     };
-    setElements(prev => [...prev, newEl]);
+    setElements((prev) => [...prev, newEl]);
     setSelectedId(id);
   };
 
   const addBadgeElement = () => {
-    if (elements.some(el => el.type === 'badge')) {
+    if (elements.some((el) => el.type === 'badge')) {
       toast.warning('A dynamic badge element is already added to canvas layout.');
       return;
     }
@@ -134,9 +134,9 @@ export function useCertificateCanvas({ elements, setElements }: UseCertificateCa
       color: '#000000',
       fontWeight: 'normal',
       alignment: 'center',
-      fontStyle: 'Montserrat, sans-serif'
+      fontStyle: 'Montserrat, sans-serif',
     };
-    setElements(prev => [...prev, newEl]);
+    setElements((prev) => [...prev, newEl]);
     setSelectedId(id);
   };
 
@@ -154,44 +154,52 @@ export function useCertificateCanvas({ elements, setElements }: UseCertificateCa
       fontSizePercent: 1,
       color: '#000000',
       fontWeight: 'normal',
-      alignment: 'center'
+      alignment: 'center',
     };
-    setElements(prev => [...prev, newEl]);
+    setElements((prev) => [...prev, newEl]);
     setSelectedId(id);
     toast.success('Pathment Logo added to canvas!');
   };
 
   const deleteElement = (id: string) => {
-    setElements(prev => prev.filter(el => el.id !== id));
+    setElements((prev) => prev.filter((el) => el.id !== id));
     if (selectedId === id) setSelectedId(null);
   };
 
   const updateSelectedElement = (key: keyof CertificateElement, val: any) => {
     if (!selectedId) return;
-    setElements(prev => prev.map(el =>
-      el.id === selectedId ? { ...el, [key]: val } : el
-    ));
+    setElements((prev) => prev.map((el) => (el.id === selectedId ? { ...el, [key]: val } : el)));
   };
 
   return {
-    name, setName,
-    selectedProgramId, setSelectedProgramId,
-    bgImageUrl, setBgImageUrl,
-    logoUrl, setLogoUrl,
-    logoConfig, setLogoConfig,
-    activePresetId, setActivePresetId,
-    selectedId, setSelectedId,
+    name,
+    setName,
+    selectedProgramId,
+    setSelectedProgramId,
+    bgImageUrl,
+    setBgImageUrl,
+    logoUrl,
+    setLogoUrl,
+    logoConfig,
+    setLogoConfig,
+    activePresetId,
+    setActivePresetId,
+    selectedId,
+    setSelectedId,
     selectedElement,
-    activeDragId, setActiveDragId,
-    uploadingLogo, setUploadingLogo,
+    activeDragId,
+    setActiveDragId,
+    uploadingLogo,
+    setUploadingLogo,
     canvasRef,
-    handleMouseMove, handleMouseUp,
+    handleMouseMove,
+    handleMouseUp,
     applyPresetBackground,
     addVariableElement,
     addStaticTextElement,
     addBadgeElement,
     addPathmentLogoElement,
     deleteElement,
-    updateSelectedElement
+    updateSelectedElement,
   };
 }

--- a/client-interface/components/admin/certificates/hooks/useCertificateQualifications.ts
+++ b/client-interface/components/admin/certificates/hooks/useCertificateQualifications.ts
@@ -1,33 +1,28 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { toast } from 'sonner';
 import { certificatesApi } from '@/lib/services/certificates-api';
 import { TierCriteria } from '../certificate-constants';
+import { useApiQuery, useInvalidate } from '@/lib/query';
+import { qk } from '@/lib/query/keys';
+import { STALE } from '@/lib/query/client';
 
 interface UseCertificateQualificationsOptions {
   templateId: string | null;
   selectedProgramId: string;
   criteria: TierCriteria[];
-  refreshKey: number;
-  setRefreshKey: React.Dispatch<React.SetStateAction<number>>;
 }
+
+const EMPTY_OBJECT: Record<string, any[]> = {};
 
 export function useCertificateQualifications({
   templateId,
   selectedProgramId,
   criteria,
-  refreshKey,
-  setRefreshKey
 }: UseCertificateQualificationsOptions) {
-  const [qualifiedData, setQualifiedData] = useState<Record<string, any[]>>({});
-  const [loadingQualifications, setLoadingQualifications] = useState(false);
-  const [criteriaTasks, setCriteriaTasks] = useState<Array<{ id: string; title: string }>>([]);
-  const [selectedMenteeIds, setSelectedMenteeIds] = useState<Set<string>>(new Set());
-  const [adminTiers, setAdminTiers] = useState<Record<string, string>>({});
   const [issuing, setIssuing] = useState(false);
   const [sendingToMentors, setSendingToMentors] = useState(false);
-
   const [duplicateWarningModal, setDuplicateWarningModal] = useState<{
     isOpen: boolean;
     duplicates: Array<{ id: string; name: string; email: string; tier: string }>;
@@ -35,176 +30,80 @@ export function useCertificateQualifications({
   }>({
     isOpen: false,
     duplicates: [],
-    allSelectedRecipients: []
+    allSelectedRecipients: [],
   });
 
-  useEffect(() => {
-    if (!templateId || !selectedProgramId) return;
+  const invalidate = useInvalidate();
 
-    const fetchQualifications = async () => {
+  const {
+    data: qualRes,
+    loading: loadingQualifications,
+    refetch,
+  } = useApiQuery({
+    queryKey: qk.certificates.qualifications(templateId ?? '', selectedProgramId),
+    queryFn: async () => certificatesApi.getQualification(templateId!, { programId: selectedProgramId }),
+    enabled: !!templateId && !!selectedProgramId,
+    errorMessage: 'Failed to calculate qualification counts',
+    staleTime: STALE.medium,
+  });
+
+  const qualifiedData = useMemo<Record<string, any[]>>(() => {
+    if (!qualRes?.success || !qualRes.data) return EMPTY_OBJECT;
+    return qualRes.data;
+  }, [qualRes]);
+
+  const criteriaTasks = useMemo<Array<{ id: string; title: string }>>(() => {
+    return qualRes?.criteriaTasks ?? [];
+  }, [qualRes]);
+
+  const executeIssuance = useCallback(
+    async (recipientsList: Array<{ menteeId: string; tier: string }>) => {
+      if (!templateId || !selectedProgramId) return;
       try {
-        setLoadingQualifications(true);
-        const res = await certificatesApi.getQualification(templateId, { programId: selectedProgramId });
-        if (res.success && res.data) {
-          setQualifiedData(res.data);
-          if (res.criteriaTasks) {
-            setCriteriaTasks(res.criteriaTasks);
-          } else {
-            setCriteriaTasks([]);
-          }
-
-          const activeList: any[] = [];
-          const seenIds = new Set<string>();
-
-          criteria.forEach(c => {
-            const list = res.data[c.id] || [];
-            list.forEach((m: any) => {
-              if (!seenIds.has(m.id)) {
-                seenIds.add(m.id);
-                activeList.push(m);
-              }
-            });
-          });
-
-          Object.keys(res.data).forEach(key => {
-            if (key === 'mentors' || key === 'paused') return;
-            const list = res.data[key] || [];
-            list.forEach((m: any) => {
-              if (!seenIds.has(m.id)) {
-                seenIds.add(m.id);
-                activeList.push(m);
-              }
-            });
-          });
-
-          const mentorsList = res.data.mentors ?? [];
-
-          const initialTiers: Record<string, string> = {};
-          const autoSelected = new Set<string>();
-
-          activeList.forEach(m => {
-            const defTier = m.assignedTier || '';
-            initialTiers[m.id] = defTier;
-
-            const matchPercent = m.tierMatches?.[defTier] ?? 0;
-            if (defTier && matchPercent >= 75) {
-              autoSelected.add(m.id);
-            }
-          });
-
-          const mentorDefaultTier = criteria[criteria.length - 1]?.id || 'participation';
-          mentorsList.forEach(m => {
-            initialTiers[m.id] = mentorDefaultTier;
-            autoSelected.add(m.id);
-          });
-
-          setAdminTiers(initialTiers);
-          setSelectedMenteeIds(autoSelected);
-        }
-      } catch (err) {
-        console.error('Failed to calculate qualification counts:', err);
-      } finally {
-        setLoadingQualifications(false);
-      }
-    };
-
-    fetchQualifications();
-  }, [templateId, selectedProgramId, refreshKey]);
-
-  const executeIssuance = async (recipientsList: Array<{ menteeId: string; tier: string }>) => {
-    try {
-      setIssuing(true);
-      const res = await certificatesApi.issueCertificates({
-        templateId: templateId!,
-        recipients: recipientsList
-      });
-      if (res.success) {
-        toast.success(`Successfully enqueued ${recipientsList.length} certificate(s) for rendering!`);
-        setSelectedMenteeIds(new Set());
-        setRefreshKey(prev => prev + 1);
-      }
-    } catch (err: any) {
-      toast.error(err.message || 'Failed to issue certificates');
-    } finally {
-      setIssuing(false);
-    }
-  };
-
-  const handleIssue = async () => {
-    if (selectedMenteeIds.size === 0) {
-      toast.error('Please select at least one mentee to issue certificates');
-      return;
-    }
-
-    const defaultTier = criteria[criteria.length - 1]?.id ?? 'participation';
-    const recipients = Array.from(selectedMenteeIds).map(id => ({
-      menteeId: id,
-      tier: adminTiers[id] ?? defaultTier
-    }));
-
-    const allMentees: any[] = [];
-    const seenIds = new Set<string>();
-    Object.keys(qualifiedData).forEach(key => {
-      if (key === 'mentors' || key === 'paused') return;
-      (qualifiedData[key] ?? []).forEach((m: any) => {
-        if (!seenIds.has(m.id)) { seenIds.add(m.id); allMentees.push(m); }
-      });
-    });
-    const allMentors: any[] = qualifiedData.mentors ?? [];
-    const allActiveRecipients = [...allMentees, ...allMentors];
-
-    const duplicates: Array<{ id: string; name: string; email: string; tier: string }> = [];
-    recipients.forEach(r => {
-      const menteeObj = allActiveRecipients.find(m => m.id === r.menteeId);
-      if (menteeObj && Array.isArray(menteeObj.issuedTiers) && menteeObj.issuedTiers.includes(r.tier)) {
-        duplicates.push({
-          id: menteeObj.id,
-          name: `${menteeObj.firstName ?? ''} ${menteeObj.lastName ?? ''}`.trim() || menteeObj.email,
-          email: menteeObj.email,
-          tier: r.tier
+        setIssuing(true);
+        const res = await certificatesApi.issueCertificates({
+          templateId,
+          recipients: recipientsList,
         });
+        if (res.success) {
+          toast.success(`Successfully enqueued ${recipientsList.length} certificate(s) for rendering!`);
+          await invalidate(qk.certificates.qualifications(templateId, selectedProgramId));
+        }
+      } catch (err: any) {
+        toast.error(err.message || 'Failed to issue certificates');
+      } finally {
+        setIssuing(false);
       }
-    });
+    },
+    [templateId, selectedProgramId, invalidate]
+  );
 
-    if (duplicates.length > 0) {
-      setDuplicateWarningModal({
-        isOpen: true,
-        duplicates,
-        allSelectedRecipients: recipients
-      });
-    } else {
-      await executeIssuance(recipients);
-    }
-  };
-
-  const handleSendToMentors = async () => {
+  const handleSendToMentors = useCallback(async () => {
     if (!templateId || !selectedProgramId) return;
     try {
       setSendingToMentors(true);
       const res = await certificatesApi.sendToMentors(templateId, selectedProgramId);
-      if (res.success) toast.success(res.message);
+      if (res.success) {
+        toast.success(res.message);
+        await invalidate(qk.certificates.qualifications(templateId, selectedProgramId));
+      }
     } catch (err: any) {
       toast.error(err.message || 'Failed to send to mentors');
     } finally {
       setSendingToMentors(false);
     }
-  };
+  }, [templateId, selectedProgramId, invalidate]);
 
   return {
     qualifiedData,
-    setQualifiedData,
     loadingQualifications,
     criteriaTasks,
-    selectedMenteeIds,
-    setSelectedMenteeIds,
-    adminTiers,
-    setAdminTiers,
     issuing,
     sendingToMentors,
-    handleIssue,
     executeIssuance,
     handleSendToMentors,
     duplicateWarningModal,
-    setDuplicateWarningModal
+    setDuplicateWarningModal,
+    refetchQualifications: refetch,
   };
 }

--- a/client-interface/components/admin/certificates/hooks/useRecipientSelection.ts
+++ b/client-interface/components/admin/certificates/hooks/useRecipientSelection.ts
@@ -10,7 +10,14 @@ export interface UseRecipientSelectionOptions {
   aiResults?: Record<string, any>;
 }
 
-export function useRecipientSelection({ criteria, qualifiedData, aiResults }: UseRecipientSelectionOptions) {
+const EMPTY_ARRAY: any[] = [];
+const EMPTY_OBJECT: Record<string, any> = {};
+
+export function useRecipientSelection({
+  criteria = EMPTY_ARRAY,
+  qualifiedData = EMPTY_OBJECT,
+  aiResults = EMPTY_OBJECT,
+}: UseRecipientSelectionOptions) {
   const [recipientSearch, setRecipientSearch] = useState('');
   const [badgeFilter, setBadgeFilter] = useState('all');
   const [sortBy, setSortBy] = useState<'none' | 'score_desc' | 'score_asc'>('none');
@@ -21,15 +28,21 @@ export function useRecipientSelection({ criteria, qualifiedData, aiResults }: Us
   const recipientMenteesList = useMemo(() => {
     const seen = new Set<string>();
     const list: any[] = [];
-    criteria.forEach(c => {
+    criteria.forEach((c) => {
       (qualifiedData[c.id] ?? []).forEach((m: any) => {
-        if (!seen.has(m.id)) { seen.add(m.id); list.push({ ...m, role: 'mentee', isPaused: false }); }
+        if (!seen.has(m.id)) {
+          seen.add(m.id);
+          list.push({ ...m, role: 'mentee', isPaused: false });
+        }
       });
     });
-    Object.keys(qualifiedData).forEach(key => {
+    Object.keys(qualifiedData).forEach((key) => {
       if (key === 'mentors' || key === 'paused') return;
       (qualifiedData[key] ?? []).forEach((m: any) => {
-        if (!seen.has(m.id)) { seen.add(m.id); list.push({ ...m, role: 'mentee', isPaused: false }); }
+        if (!seen.has(m.id)) {
+          seen.add(m.id);
+          list.push({ ...m, role: 'mentee', isPaused: false });
+        }
       });
     });
     return list;
@@ -51,19 +64,22 @@ export function useRecipientSelection({ criteria, qualifiedData, aiResults }: Us
     return recipientPausedList;
   }, [recipientType, recipientMenteesList, recipientMentorsList, recipientPausedList]);
 
-  const getEffectiveTier = useCallback((mOrId: any): string => {
-    const defaultTier = criteria[criteria.length - 1]?.id ?? 'participation';
-    const id = typeof mOrId === 'string' ? mOrId : mOrId?.id;
-    if (!id) return defaultTier;
+  const getEffectiveTier = useCallback(
+    (mOrId: any): string => {
+      const defaultTier = criteria[criteria.length - 1]?.id ?? 'participation';
+      const id = typeof mOrId === 'string' ? mOrId : mOrId?.id;
+      if (!id) return defaultTier;
 
-    if (assignedTiers[id]) return assignedTiers[id];
-    if (aiResults?.[id]?.certificate_tier) return aiResults[id].certificate_tier;
+      if (assignedTiers[id]) return assignedTiers[id];
+      if (aiResults?.[id]?.certificate_tier) return aiResults[id].certificate_tier;
 
-    const m = typeof mOrId === 'object' ? mOrId : activeList.find((x: any) => x.id === id);
-    if (m?.assignedTier) return m.assignedTier;
+      const m = typeof mOrId === 'object' ? mOrId : activeList.find((x: any) => x.id === id);
+      if (m?.assignedTier) return m.assignedTier;
 
-    return defaultTier;
-  }, [assignedTiers, aiResults, activeList, criteria]);
+      return defaultTier;
+    },
+    [assignedTiers, aiResults, activeList, criteria]
+  );
 
   const filtered = useMemo(() => {
     let result = [...activeList];
@@ -108,14 +124,16 @@ export function useRecipientSelection({ criteria, qualifiedData, aiResults }: Us
   const allFilteredIds = useMemo(() => filtered.map((m: any) => m.id), [filtered]);
 
   const allSelected = useMemo(
-    () => allFilteredIds.length > 0 && allFilteredIds.every(id => selectedMenteeIds.has(id)),
+    () => allFilteredIds.length > 0 && allFilteredIds.every((id) => selectedMenteeIds.has(id)),
     [allFilteredIds, selectedMenteeIds]
   );
 
   const selectedSummary = useMemo(() => {
     const summary: Record<string, number> = {};
-    criteria.forEach(c => { summary[c.id] = 0; });
-    selectedMenteeIds.forEach(id => {
+    criteria.forEach((c) => {
+      summary[c.id] = 0;
+    });
+    selectedMenteeIds.forEach((id) => {
       const tier = getEffectiveTier(id);
       if (summary[tier] !== undefined) {
         summary[tier] = (summary[tier] ?? 0) + 1;
@@ -127,21 +145,21 @@ export function useRecipientSelection({ criteria, qualifiedData, aiResults }: Us
   }, [criteria, selectedMenteeIds, getEffectiveTier]);
 
   const toggleAll = useCallback(() => {
-    setSelectedMenteeIds(prev => {
+    setSelectedMenteeIds((prev) => {
       const next = new Set(prev);
       const selectableIds = filtered.filter((m: any) => !m.isPaused).map((m: any) => m.id);
-      const allSelectableSelected = selectableIds.length > 0 && selectableIds.every(id => next.has(id));
+      const allSelectableSelected = selectableIds.length > 0 && selectableIds.every((id) => next.has(id));
       if (allSelectableSelected) {
-        selectableIds.forEach(id => next.delete(id));
+        selectableIds.forEach((id) => next.delete(id));
       } else {
-        selectableIds.forEach(id => next.add(id));
+        selectableIds.forEach((id) => next.add(id));
       }
       return next;
     });
   }, [filtered]);
 
   const toggleOne = useCallback((id: string) => {
-    setSelectedMenteeIds(prev => {
+    setSelectedMenteeIds((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
@@ -150,58 +168,64 @@ export function useRecipientSelection({ criteria, qualifiedData, aiResults }: Us
   }, []);
 
   const handleTierChange = useCallback((menteeId: string, value: string) => {
-    setAssignedTiers(prev => ({ ...prev, [menteeId]: value }));
+    setAssignedTiers((prev) => ({ ...prev, [menteeId]: value }));
   }, []);
 
-  const bulkSetBadge = useCallback((badge: string, getTierNameFn?: (b: string) => string) => {
-    const updatedTiers = { ...assignedTiers };
-    const nextSelected = new Set(selectedMenteeIds);
-    filtered.forEach((m: any) => {
-      updatedTiers[m.id] = badge;
-      if (m.isPaused) {
-        nextSelected.delete(m.id);
-        return;
-      }
-      const match = m.tierMatches?.[badge] ?? 0;
-      if (match >= 90) nextSelected.add(m.id);
-      else nextSelected.delete(m.id);
-    });
-    setAssignedTiers(updatedTiers);
-    setSelectedMenteeIds(nextSelected);
-    const tierName = getTierNameFn ? getTierNameFn(badge) : badge;
-    toast.info(`Set all filtered recipients to ${tierName}`);
-  }, [assignedTiers, selectedMenteeIds, filtered]);
-
-  const resetToAIRecommendations = useCallback((aiResults: any[]) => {
-    if (!aiResults || aiResults.length === 0) return;
-    const updatedTiers = { ...assignedTiers };
-    const nextSelected = new Set(selectedMenteeIds);
-    const aiMap: Record<string, string> = {};
-
-    aiResults.forEach(r => {
-      if (r.mentee_id && r.certificate_tier) {
-        aiMap[r.mentee_id] = r.certificate_tier;
-      }
-    });
-
-    filtered.forEach((m: any) => {
-      if (m.isPaused) {
-        nextSelected.delete(m.id);
-        return;
-      }
-      const aiTier = aiMap[m.id];
-      if (aiTier) {
-        updatedTiers[m.id] = aiTier;
-        const match = m.tierMatches?.[aiTier] ?? 0;
+  const bulkSetBadge = useCallback(
+    (badge: string, getTierNameFn?: (b: string) => string) => {
+      const updatedTiers = { ...assignedTiers };
+      const nextSelected = new Set(selectedMenteeIds);
+      filtered.forEach((m: any) => {
+        updatedTiers[m.id] = badge;
+        if (m.isPaused) {
+          nextSelected.delete(m.id);
+          return;
+        }
+        const match = m.tierMatches?.[badge] ?? 0;
         if (match >= 90) nextSelected.add(m.id);
         else nextSelected.delete(m.id);
-      }
-    });
+      });
+      setAssignedTiers(updatedTiers);
+      setSelectedMenteeIds(nextSelected);
+      const tierName = getTierNameFn ? getTierNameFn(badge) : badge;
+      toast.info(`Set all filtered recipients to ${tierName}`);
+    },
+    [assignedTiers, selectedMenteeIds, filtered]
+  );
 
-    setAssignedTiers(updatedTiers);
-    setSelectedMenteeIds(nextSelected);
-    toast.success('Reset all filtered recipients to AI recommendations.');
-  }, [assignedTiers, selectedMenteeIds, filtered]);
+  const resetToAIRecommendations = useCallback(
+    (aiResultsList: any[]) => {
+      if (!aiResultsList || aiResultsList.length === 0) return;
+      const updatedTiers = { ...assignedTiers };
+      const nextSelected = new Set(selectedMenteeIds);
+      const aiMap: Record<string, string> = {};
+
+      aiResultsList.forEach((r) => {
+        if (r.mentee_id && r.certificate_tier) {
+          aiMap[r.mentee_id] = r.certificate_tier;
+        }
+      });
+
+      filtered.forEach((m: any) => {
+        if (m.isPaused) {
+          nextSelected.delete(m.id);
+          return;
+        }
+        const aiTier = aiMap[m.id];
+        if (aiTier) {
+          updatedTiers[m.id] = aiTier;
+          const match = m.tierMatches?.[aiTier] ?? 0;
+          if (match >= 90) nextSelected.add(m.id);
+          else nextSelected.delete(m.id);
+        }
+      });
+
+      setAssignedTiers(updatedTiers);
+      setSelectedMenteeIds(nextSelected);
+      toast.success('Reset all filtered recipients to AI recommendations.');
+    },
+    [assignedTiers, selectedMenteeIds, filtered]
+  );
 
   return {
     recipientSearch,

--- a/client-interface/lib/hooks/admin/useOrgRoadmaps.ts
+++ b/client-interface/lib/hooks/admin/useOrgRoadmaps.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
-import { qk, useApiQuery, STALE } from '@/lib/query';
+import { qk, useApiQuery, useInvalidate, STALE } from '@/lib/query';
 import { orgRoadmapApi, type RoadmapStepInput } from '@/lib/services/roadmap-api';
 
 export interface OrgRoadmapStep {
@@ -54,11 +54,12 @@ export function useOrgRoadmaps(): UseOrgRoadmapsReturn {
     errorMessage: 'Failed to load org roadmaps',
   });
 
-  // Every mutation is write-then-refetch; `after` keeps that in one place.
+  const invalidate = useInvalidate();
+
   const after = useCallback(async (call: Promise<unknown>) => {
     await call;
-    await refetch();
-  }, [refetch]);
+    await invalidate(qk.admin.orgRoadmaps);
+  }, [invalidate]);
 
   return {
     roadmaps: data ?? EMPTY,

--- a/client-interface/lib/hooks/mentor/useTracks.ts
+++ b/client-interface/lib/hooks/mentor/useTracks.ts
@@ -2,7 +2,7 @@
 
 import { useCallback } from 'react';
 import { tracksApi, type Track } from '@/lib/services/tracks-api';
-import { qk, useApiQuery } from '@/lib/query';
+import { qk, useApiQuery, useInvalidate } from '@/lib/query';
 
 export interface UseTracksReturn {
   tracks: Track[];
@@ -18,7 +18,6 @@ export interface UseTracksReturn {
 
 const EMPTY: Track[] = [];
 
-/** Mentor-facing tracks for one mentee (personal lanes + their tasks). */
 export function useTracks(menteeId: string | null): UseTracksReturn {
   const { data, loading, error, refetch } = useApiQuery<Track[]>({
     queryKey: qk.mentor.tracks(menteeId ?? ''),
@@ -27,10 +26,12 @@ export function useTracks(menteeId: string | null): UseTracksReturn {
     errorMessage: 'Failed to load tracks',
   });
 
+  const invalidate = useInvalidate();
+
   const after = useCallback(async (call: Promise<unknown>) => {
     await call;
-    await refetch();
-  }, [refetch]);
+    await invalidate(qk.mentor.tracks(menteeId ?? ''));
+  }, [invalidate, menteeId]);
 
   return {
     tracks: data ?? EMPTY,

--- a/client-interface/lib/query/keys.ts
+++ b/client-interface/lib/query/keys.ts
@@ -148,5 +148,15 @@ export const qk = {
     program: (id: string) => ['public', 'program', id] as const,
   },
 
+  certificates: {
+    all: ['certificates'] as const,
+    templates: ['certificates', 'templates'] as const,
+    template: (id: string) => ['certificates', 'template', id] as const,
+    qualifications: (templateId: string, programId: string) =>
+      ['certificates', 'qualifications', templateId, programId] as const,
+    aiStatus: (templateId: string, runId?: string | null) =>
+      ['certificates', 'ai-status', templateId, runId ?? 'latest'] as const,
+  },
+
   announcements: ['announcements'] as const,
 } as const;

--- a/client-interface/lib/services/certificates-api.ts
+++ b/client-interface/lib/services/certificates-api.ts
@@ -235,14 +235,17 @@ export const certificatesApi = {
     const qs = runId ? `?runId=${encodeURIComponent(runId)}` : '';
     return apiClient.get<{
       success: boolean;
-      runId: string | null;
-      isDone: boolean;
-      total: number;
-      completed: number;
-      failed: number;
-      pending: number;
-      data: AIEvaluationResult[];
-      ranAt: string | null;
+      message?: string;
+      data: {
+        runId: string | null;
+        isDone: boolean;
+        total: number;
+        completed: number;
+        failed: number;
+        pending: number;
+        data: AIEvaluationResult[];
+        ranAt: string | null;
+      };
     }>(`/certificates/templates/${id}/ai-evaluate/status${qs}`, { timeout: 60000 });
   }
 };


### PR DESCRIPTION
## Problem Statement

The admin certificate management hooks (`useAIEvaluationProgress`, `useCertificateQualifications`, `useRecipientSelection`) relied on custom `useEffect` hooks, manual `useState` tracking for loading/error states, and ad-hoc polling (`setInterval` / imperative refetches). 

This resulted in:
1. **Redundant Network Fetching & Race Conditions**: Components remounting or re-rendering triggered duplicate API requests.
2. **Lack of Caching**: Navigating between certificate tabs caused visible UI blinks and lost server response state.
3. **Complex Polling Logic**: Manual polling for AI background evaluation runs was error-prone and hard to synchronize across multiple sub-components in `CertificateEditor`.
4. **Type Mismatch Risks**: API responses wrapped in the backend `successResponse` envelope (`{ success: true, data: { ... } }`) were susceptible to runtime `TypeError` issues when unwrapped incorrectly.

## Proposed Solution

Migrate the certificate feature hooks to **TanStack React Query** using the codebase's standardized `useApiQuery` wrapper and `qk.certificates` query key factory:

1. **Standardized Query Keys**: Use `qk.certificates.aiStatus(templateId, runId)` and `qk.certificates.qualification(templateId, programId)` for consistent cache identification.
2. **Reactive Polling**: Implement conditional `refetchInterval` in `useAIEvaluationProgress` to poll every 4 seconds while `isDone` is `false`, and automatically halt polling when execution completes.
3. **Declarative Invalidation**: Replace imperative state mutations with `queryClient.invalidateQueries` / `useInvalidate` following mutations (e.g., starting an AI evaluation, issuing certificates, or sending to mentors).
4. **Strict Envelope Typing**: Update `certificates-api.ts` return signatures so TypeScript accurately reflects the backend envelope `{ success: boolean, message?: string, data: T }`.

## Scope

- App area: client-interface
- Breaking change: no
- Requires migration/config changes: no

## Acceptance Criteria

- [x] Refactor `useAIEvaluationProgress` to use `useApiQuery` with `qk.certificates.aiStatus` query keys.
- [x] Configure `refetchInterval` in `useAIEvaluationProgress` to dynamically stop polling when `isDone === true`.
- [x] Refactor `useCertificateQualifications` to leverage `useApiQuery` with `qk.certificates.qualification` query keys instead of manual `useEffect` fetching.
- [x] Align API signatures in `certificates-api.ts` with the server's `successResponse` envelope (`data.data` nesting).
- [x] Add query invalidation on mutation events (`runAIEvaluation`, `issueCertificates`, `sendToMentors`).
- [x] Guarantee `aiResults` safe array fallback (`Array.isArray(aiResults)`) to prevent runtime `.forEach` crashes.
- [x] Verify `npx tsc --noEmit` passes with 0 errors.