### PR TITLE
feat(admin): add Block/Unblock user action and filter on Admin Access…

### DIFF
--- a/client-interface/app/admin/access/page.tsx
+++ b/client-interface/app/admin/access/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Loader2, Plus, Search, ShieldCheck, SlidersHorizontal, Trash2, UserPlus, X, Pencil } from 'lucide-react';
+import { Loader2, Plus, Search, ShieldCheck, SlidersHorizontal, Trash2, UserPlus, X, Pencil, Ban, CheckCircle2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { apiClient } from '@/lib/services/api-client';
@@ -80,11 +80,12 @@ export default function RolesAccessPage() {
 }
 
 /* ─────────────────────────── People ─────────────────────────── */
-const ROLE_TABS: { key: string; label: string }[] = [
+const ROLE_TABS: { key: string; label: string; role?: string; status?: string }[] = [
   { key: '', label: 'All' },
-  { key: 'admin', label: 'Admins' },
-  { key: 'mentor', label: 'Mentors' },
-  { key: 'mentee', label: 'Mentees' },
+  { key: 'admin', label: 'Admins', role: 'admin' },
+  { key: 'mentor', label: 'Mentors', role: 'mentor' },
+  { key: 'mentee', label: 'Mentees', role: 'mentee' },
+  { key: 'blocked', label: 'Blocked', status: 'suspended' },
 ];
 
 function PeopleTab() {
@@ -97,6 +98,8 @@ function PeopleTab() {
   const [inviting, setInviting] = useState(false);
   const pagination = usePagination({ initialPage: 1, initialLimit: 20 });
 
+  const activeTab = ROLE_TABS.find((t) => t.key === roleFilter) || ROLE_TABS[0];
+
   // Monotonic request token — only the latest in-flight fetch is allowed to
   // write state, so an earlier (e.g. page-3) response can never overwrite a
   // later (page-1) one. This is what kills the pagination "glitch".
@@ -107,7 +110,8 @@ function PeopleTab() {
     try {
       const res = await accessApi.directory({
         search: debouncedSearch.trim() || undefined,
-        role: roleFilter || undefined,
+        role: activeTab.role,
+        status: activeTab.status,
         page: pagination.page,
         limit: pagination.limit,
       });
@@ -117,7 +121,7 @@ function PeopleTab() {
     } catch { if (token === reqRef.current) setUsers([]); }
     finally { if (token === reqRef.current) setLoading(false); }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedSearch, roleFilter, pagination.page, pagination.limit]);
+  }, [debouncedSearch, activeTab.role, activeTab.status, pagination.page, pagination.limit]);
 
   // Single load effect. When the search/role filter changes we snap back to
   // page 1 FIRST (and skip this run) so we never fetch a now-out-of-range page;
@@ -150,15 +154,15 @@ function PeopleTab() {
             </button>
           </div>
 
-          {/* Role filter */}
-          <div className="mt-3 flex items-center gap-1">
+          {/* Role & Status filter */}
+          <div className="mt-3 flex items-center gap-1 overflow-x-auto">
             {ROLE_TABS.map((t) => (
               <button key={t.key} onClick={() => setRoleFilter(t.key)}
-                className={`px-2.5 py-1 rounded-lg text-xs font-medium transition-colors ${roleFilter === t.key ? 'bg-brand-100 text-brand-700' : 'text-slate-500 hover:bg-slate-100'}`}>
+                className={`px-2.5 py-1 rounded-lg text-xs font-medium transition-colors shrink-0 ${roleFilter === t.key ? (t.key === 'blocked' ? 'bg-rose-100 text-rose-700 dark:bg-rose-950/60 dark:text-rose-400' : 'bg-brand-100 text-brand-700 dark:bg-brand-500/20 dark:text-brand-300') : 'text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800'}`}>
                 {t.label}
               </button>
             ))}
-            <span className="ml-auto text-xs text-slate-400 tabular-nums">{pagination.total} {pagination.total === 1 ? 'person' : 'people'}</span>
+            <span className="ml-auto text-xs text-slate-400 tabular-nums shrink-0">{pagination.total} {pagination.total === 1 ? 'person' : 'people'}</span>
           </div>
 
           {/* Adaptive height: the list grows with its content but is capped to the
@@ -171,16 +175,26 @@ function PeopleTab() {
               <div className="py-8 flex justify-center"><Loader2 className="w-5 h-5 animate-spin text-brand-600" /></div>
             ) : users.length === 0 ? (
               <p className="py-8 text-center text-sm text-slate-400">{query.trim() || roleFilter ? 'No matches.' : 'No users yet — invite someone to get started.'}</p>
-            ) : users.map((u) => (
-              <button
-                key={u.id}
-                onClick={() => setSelected(u)}
-                className={`w-full text-left px-2 py-2.5 rounded-lg ${selected?.id === u.id ? 'bg-brand-50 dark:bg-brand-500/15' : 'hover:bg-slate-50'}`}
-              >
-                <p className="text-sm font-medium text-slate-900">{`${u.firstName} ${u.lastName}`.trim() || u.email}</p>
-                <p className="text-xs text-slate-500">{u.email} · {u.role}</p>
-              </button>
-            ))}
+            ) : users.map((u) => {
+              const isBlocked = u.status === 'suspended';
+              return (
+                <button
+                  key={u.id}
+                  onClick={() => setSelected(u)}
+                  className={`w-full text-left px-2 py-2.5 rounded-lg flex items-center justify-between gap-2 ${selected?.id === u.id ? 'bg-brand-50 dark:bg-brand-500/15' : 'hover:bg-slate-50'}`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-slate-900 truncate">{`${u.firstName} ${u.lastName}`.trim() || u.email}</p>
+                    <p className="text-xs text-slate-500 truncate">{u.email} · {u.role}</p>
+                  </div>
+                  {isBlocked && (
+                    <span className="shrink-0 px-2 py-0.5 rounded text-[10px] font-semibold tracking-wide uppercase bg-rose-100 text-rose-700 dark:bg-rose-950/60 dark:text-rose-400 border border-rose-200 dark:border-rose-800/50">
+                      Blocked
+                    </span>
+                  )}
+                </button>
+              );
+            })}
           </div>
 
           {pagination.total > pagination.limit && (
@@ -189,7 +203,7 @@ function PeopleTab() {
         </div>
       </div>
       <div className="lg:col-span-7">
-        {selected ? <AccessPanel user={selected} /> : (
+        {selected ? <AccessPanel user={selected} onUpdated={load} /> : (
           <div className="rounded-2xl border border-dashed border-slate-200 bg-card p-12 text-center text-slate-400">
             Select someone to view and manage their roles - or <button onClick={() => setInviting(true)} className="text-brand-600 font-medium">invite a new person</button> with a role.
           </div>
@@ -294,10 +308,12 @@ function InviteWithAccessDrawer({ onClose, onInvited }: { onClose: () => void; o
   );
 }
 
-function AccessPanel({ user }: { user: DirectoryUser }) {
+function AccessPanel({ user, onUpdated }: { user: DirectoryUser; onUpdated?: () => void }) {
+  const confirm = useConfirm();
   const [access, setAccess] = useState<UserAccess | null>(null);
   const [loading, setLoading] = useState(true);
   const [granting, setGranting] = useState(false);
+  const [blocking, setBlocking] = useState(false);
   const [permClanId, setPermClanId] = useState<string | null>(null);
   const userName = `${user.firstName} ${user.lastName}`.trim() || user.email;
 
@@ -312,16 +328,91 @@ function AccessPanel({ user }: { user: DirectoryUser }) {
     catch (e) { toast.error(extractApiErrorMessage(e, 'Could not revoke')); }
   };
 
+  const currentStatus = access?.user?.status || user.status || 'active';
+  const isBlocked = currentStatus === 'suspended';
+
+  const handleToggleBlock = async () => {
+    if (isBlocked) {
+      if (!(await confirm({
+        title: `Unblock ${userName}?`,
+        description: 'This user will be able to log in and access Pathment again.',
+        confirmLabel: 'Unblock user',
+        variant: 'default',
+      }))) return;
+
+      setBlocking(true);
+      try {
+        await accessApi.unblockUser(user.id);
+        toast.success(`${userName} has been unblocked`);
+        load();
+        onUpdated?.();
+      } catch (e) {
+        toast.error(extractApiErrorMessage(e, 'Could not unblock user'));
+      } finally {
+        setBlocking(false);
+      }
+    } else {
+      if (!(await confirm({
+        title: `Block ${userName}?`,
+        description: 'They will be logged out immediately and prevented from logging in or using Pathment until unblocked.',
+        confirmLabel: 'Block user',
+        variant: 'danger',
+      }))) return;
+
+      setBlocking(true);
+      try {
+        await accessApi.blockUser(user.id);
+        toast.success(`${userName} has been blocked`);
+        load();
+        onUpdated?.();
+      } catch (e) {
+        toast.error(extractApiErrorMessage(e, 'Could not block user'));
+      } finally {
+        setBlocking(false);
+      }
+    }
+  };
+
   return (
     <div className="rounded-2xl border border-slate-200 bg-card p-5">
-      <div className="flex items-start justify-between">
+      <div className="flex flex-wrap items-start justify-between gap-4 border-b border-slate-100 pb-4">
         <div>
-          <h2 className="font-semibold text-slate-900">{`${user.firstName} ${user.lastName}`.trim() || user.email}</h2>
-          <p className="text-sm text-slate-500">{user.email}</p>
+          <div className="flex items-center gap-2.5">
+            <h2 className="font-semibold text-slate-900 text-base">{userName}</h2>
+            {isBlocked ? (
+              <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-rose-100 text-rose-700 dark:bg-rose-950/60 dark:text-rose-400 border border-rose-200 dark:border-rose-800/50">
+                <Ban className="w-3.5 h-3.5" /> Blocked
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800/50">
+                <CheckCircle2 className="w-3.5 h-3.5" /> Active
+              </span>
+            )}
+          </div>
+          <p className="text-sm text-slate-500 mt-0.5">{user.email}</p>
         </div>
-        <button onClick={() => setGranting(true)} className="inline-flex items-center gap-1.5 rounded-lg bg-brand-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-700">
-          <UserPlus className="w-4 h-4" /> Grant role
-        </button>
+        <div className="flex items-center gap-2">
+          {isBlocked ? (
+            <button
+              onClick={handleToggleBlock}
+              disabled={blocking}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-50 dark:bg-slate-800 dark:border-slate-700 dark:text-emerald-400 dark:hover:bg-emerald-950/30 transition-colors disabled:opacity-50"
+            >
+              {blocking ? <Loader2 className="w-4 h-4 animate-spin" /> : <ShieldCheck className="w-4 h-4 text-emerald-600" />} Unblock user
+            </button>
+          ) : (
+            <button
+              onClick={handleToggleBlock}
+              disabled={blocking}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-rose-200 bg-rose-50/50 px-3 py-2 text-sm font-medium text-rose-700 hover:bg-rose-100/70 dark:bg-rose-950/20 dark:border-rose-900/50 dark:text-rose-400 dark:hover:bg-rose-950/50 transition-colors disabled:opacity-50"
+            >
+              {blocking ? <Loader2 className="w-4 h-4 animate-spin" /> : <Ban className="w-4 h-4 text-rose-600" />} Block user
+            </button>
+          )}
+          <button onClick={() => setGranting(true)} className="inline-flex items-center gap-1.5 rounded-lg bg-brand-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-700 shrink-0">
+            <UserPlus className="w-4 h-4" /> Grant role
+          </button>
+        </div>
       </div>
 
       {loading ? (

--- a/client-interface/lib/services/access-api.ts
+++ b/client-interface/lib/services/access-api.ts
@@ -11,7 +11,7 @@ export interface RoleCatalogEntry {
 }
 
 export interface UserAccess {
-  user: { id: string; firstName: string; lastName: string; email: string };
+  user: { id: string; firstName: string; lastName: string; email: string; role: string; status?: 'active' | 'suspended' | 'pending' | 'inactive' };
   explicit: { id: string; role: string; roleLabel: string; scopeType: string; scopeId: string | null; scopeLabel: string; createdAt: string }[];
   derived: { role: string; roleLabel: string; scopeType: string; scopeId: string | null; scopeLabel: string }[];
 }
@@ -31,6 +31,7 @@ export interface DirectoryUser {
   lastName: string;
   email: string;
   role: string;
+  status?: 'active' | 'suspended' | 'pending' | 'inactive';
 }
 
 /** IAM admin API + the current user's effective permissions (for UI gating). */
@@ -44,11 +45,16 @@ export const accessApi = {
     apiClient.get<any>('/access/roles').then((r) => (r.data?.roles || []) as RoleCatalogEntry[]),
   userAccess: (userId: string) =>
     apiClient.get<any>(`/access/users/${userId}`).then((r) => r.data as UserAccess),
+  blockUser: (userId: string) =>
+    apiClient.put<any>(`/access/users/${userId}/block`),
+  unblockUser: (userId: string) =>
+    apiClient.put<any>(`/access/users/${userId}/unblock`),
   /** Paginated org-wide user directory for the IAM People tab (all roles, searchable). */
-  directory: (params: { search?: string; role?: string; page?: number; limit?: number } = {}) => {
+  directory: (params: { search?: string; role?: string; status?: string; page?: number; limit?: number } = {}) => {
     const qs = new URLSearchParams();
     if (params.search) qs.set('search', params.search);
     if (params.role) qs.set('role', params.role);
+    if (params.status) qs.set('status', params.status);
     if (params.page) qs.set('page', String(params.page));
     if (params.limit) qs.set('limit', String(params.limit));
     return apiClient.get<any>(`/access/directory?${qs.toString()}`).then((r) => r.data as { users: DirectoryUser[]; total: number; page: number; limit: number });

--- a/server/src/controllers/accessController.js
+++ b/server/src/controllers/accessController.js
@@ -86,7 +86,17 @@ const getAuditLogs = catchAsync(async (req, res) => {
   res.status(200).json(successResponse('Audit logs', result));
 });
 
+const blockUser = catchAsync(async (req, res) => {
+  const result = await accessService.blockUser(req.params.userId, req.user.id);
+  res.status(200).json(successResponse('User blocked', result));
+});
+
+const unblockUser = catchAsync(async (req, res) => {
+  const result = await accessService.unblockUser(req.params.userId, req.user.id);
+  res.status(200).json(successResponse('User unblocked', result));
+});
+
 module.exports = {
   getPermissionCatalogue, getRoleCatalog, getUserAccess, getDirectory, grantRole, revokeRole, myPermissions, inviteWithRole,
-  listCustomRoles, createCustomRole, updateCustomRole, deleteCustomRole, getAuditLogs
+  listCustomRoles, createCustomRole, updateCustomRole, deleteCustomRole, getAuditLogs, blockUser, unblockUser
 };

--- a/server/src/middlewares/auth.js
+++ b/server/src/middlewares/auth.js
@@ -40,7 +40,9 @@ const authenticate = catchAsync(async (req, res, next) => {
     throw new AuthenticationError('User no longer exists');
   }
 
-  if (user.status !== 'active') {
+  if (user.status === 'suspended') {
+    throw new AuthenticationError('Your account has been blocked. Please contact an administrator.');
+  } else if (user.status !== 'active') {
     throw new AuthenticationError('Your account has been disabled');
   }
 
@@ -103,6 +105,7 @@ const authenticateTemporary = catchAsync(async (req, res, next) => {
   });
 
   if (!user) throw new AuthenticationError('User no longer exists');
+  if (user.status === 'suspended') throw new AuthenticationError('Your account has been blocked. Please contact an administrator.');
   if (user.status !== 'active') throw new AuthenticationError('Your account has been disabled');
 
   req.user = user;

--- a/server/src/routes/access.js
+++ b/server/src/routes/access.js
@@ -15,6 +15,8 @@ router.get('/permissions', requirePermission(PERMISSIONS.ACCESS_MANAGE), accessC
 router.get('/roles', requirePermission(PERMISSIONS.ACCESS_MANAGE), accessController.getRoleCatalog);
 router.get('/directory', requirePermission(PERMISSIONS.ACCESS_MANAGE), accessController.getDirectory);
 router.get('/users/:userId', requirePermission(PERMISSIONS.ACCESS_MANAGE), accessController.getUserAccess);
+router.put('/users/:userId/block', requirePermission(PERMISSIONS.ACCESS_MANAGE), accessController.blockUser);
+router.put('/users/:userId/unblock', requirePermission(PERMISSIONS.ACCESS_MANAGE), accessController.unblockUser);
 router.post('/grants', requirePermission(PERMISSIONS.ACCESS_MANAGE), accessController.grantRole);
 router.delete('/grants/:id', requirePermission(PERMISSIONS.ACCESS_MANAGE), accessController.revokeRole);
 

--- a/server/src/services/accessService.js
+++ b/server/src/services/accessService.js
@@ -7,6 +7,7 @@ const { NotFoundError, ValidationError, ConflictError } = require('../utils/erro
 const { generateRandomToken, hashToken } = require('../utils/jwt');
 const { inviteLink } = require('../utils/links');
 const authzService = require('./authzService');
+const adminService = require('./adminService');
 const notificationOrchestrator = require('./notificationOrchestrator');
 
 const SCOPE_LEVELS = ['org', 'program', 'clan', 'self'];
@@ -113,12 +114,15 @@ class AccessService {
    * not recipient-scoped (unlike the messaging search), so an admin can browse
    * the whole org. Includes the user themselves.
    */
-  async listDirectory({ search, role, page = 1, limit = 25 } = {}) {
+  async listDirectory({ search, role, status, page = 1, limit = 25 } = {}) {
     const { Op } = require('sequelize');
     const parsedLimit = Math.min(50, Math.max(1, Number(limit) || 25));
     const parsedPage = Math.max(1, Number(page) || 1);
 
     const where = { status: { [Op.in]: ['active', 'suspended'] } };
+    if (status && ['active', 'suspended', 'pending', 'inactive'].includes(status)) {
+      where.status = status;
+    }
     if (role && ['admin', 'mentor', 'mentee'].includes(role)) where.role = role;
     const term = (search || '').trim();
     if (term) {
@@ -143,7 +147,7 @@ class AccessService {
   /** A user's explicit (revocable) + derived (read-only) assignments. */
   async listUserAccess(userId) {
     const user = await models.User.findByPk(userId, {
-      attributes: ['id', 'firstName', 'lastName', 'email', 'role', 'capabilities']
+      attributes: ['id', 'firstName', 'lastName', 'email', 'role', 'status', 'capabilities']
     });
     if (!user) throw new NotFoundError('User not found');
 
@@ -185,10 +189,18 @@ class AccessService {
     ];
 
     return {
-      user: { id: user.id, firstName: user.firstName, lastName: user.lastName, email: user.email, role: user.role },
+      user: { id: user.id, firstName: user.firstName, lastName: user.lastName, email: user.email, role: user.role, status: user.status },
       explicit,
       derived: derivedWithBase
     };
+  }
+
+  async blockUser(targetUserId, adminUserId) {
+    return adminService.suspendUser(targetUserId, adminUserId);
+  }
+
+  async unblockUser(targetUserId, adminUserId) {
+    return adminService.unsuspendUser(targetUserId, adminUserId);
   }
 
   /**

--- a/server/src/services/adminService.js
+++ b/server/src/services/adminService.js
@@ -713,36 +713,36 @@ class AdminService {
   }
 
   /**
-   * Suspend a user - sets status to 'suspended', immediately invalidates all sessions.
+   * Block a user - sets status to 'suspended', immediately invalidates all sessions.
    */
   async suspendUser(targetUserId, adminUserId) {
     if (targetUserId === adminUserId) {
-      throw new ValidationError('You cannot suspend your own account');
+      throw new ValidationError('You cannot block your own account');
     }
     const user = await models.User.findByPk(targetUserId);
     if (!user) throw new NotFoundError('User not found');
-    if (user.role === 'admin') throw new ValidationError('Admin accounts cannot be suspended through this endpoint');
-    if (user.status === 'suspended') throw new ValidationError('User is already suspended');
+    if (user.role === 'admin') throw new ValidationError('Admin accounts cannot be blocked through this endpoint');
+    if (user.status === 'suspended') throw new ValidationError('User is already blocked');
 
     await user.update({ status: 'suspended' });
     // Invalidate all active sessions so they are kicked out immediately
     await models.UserSession.destroy({ where: { userId: targetUserId } });
     await models.RefreshToken.destroy({ where: { userId: targetUserId } });
 
-    return { message: `${user.firstName} ${user.lastName} has been suspended` };
+    return { message: `${user.firstName} ${user.lastName} has been blocked` };
   }
 
   /**
-   * Unsuspend a user - restores status to 'active'.
+   * Unblock a user - restores status to 'active'.
    */
   async unsuspendUser(targetUserId, adminUserId) {
     const user = await models.User.findByPk(targetUserId);
     if (!user) throw new NotFoundError('User not found');
-    if (user.status !== 'suspended') throw new ValidationError('User is not suspended');
+    if (user.status !== 'suspended') throw new ValidationError('User is not blocked');
 
     await user.update({ status: 'active' });
 
-    return { message: `${user.firstName} ${user.lastName} has been unsuspended` };
+    return { message: `${user.firstName} ${user.lastName} has been unblocked` };
   }
 
   /**

--- a/server/src/services/authService.js
+++ b/server/src/services/authService.js
@@ -317,7 +317,9 @@ class AuthService {
     }
 
     // Check if account is active
-    if (user.status !== 'active') {
+    if (user.status === 'suspended') {
+      throw new AuthenticationError('Your account has been blocked. Please contact an administrator.');
+    } else if (user.status !== 'active') {
       throw new AuthenticationError(AUTH_MESSAGES.ACCOUNT_DISABLED);
     }
 


### PR DESCRIPTION
##  Description
Closes #710

This PR adds a centralized **Block / Unblock** action for users on the **Admin → Roles & Access** (`/admin/access`) page, along with a dedicated **Blocked** filter tab in the directory list.

Admins can now manage user access restrictions directly from the IAM Access management view with instant session revocation and clear visual status indicators.

---

##  Changes Introduced

###  Frontend (`client-interface`)
- **Block / Unblock Action**: Added a prominent Block / Unblock button in `AccessPanel` next to the *Grant role* button.
- **Confirmation Modal**: Integrated confirmation prompt via `useConfirm()` before restricting access.
- **Status Badges**: Displayed clear access status badges (`Active` in emerald / `Blocked` in rose) in both the user directory list and the user detail header.
- **Directory Filtering**: Added a dedicated **Blocked** tab (`[All] [Admins] [Mentors] [Mentees] [Blocked]`) to filter the directory for blocked accounts.
- **Service & Types**: Updated `DirectoryUser` & `UserAccess` interfaces and added `blockUser` / `unblockUser` methods to `accessApi`.

### ⚙️ Backend (`server`)
- **Access Endpoints**: Added `PUT /api/access/users/:userId/block` and `PUT /api/access/users/:userId/unblock` protected by `ACCESS_MANAGE` permission.
- **Session Revocation**: Blocking a user sets `status` to `'suspended'` and immediately destroys all active `UserSession` and `RefreshToken` records.
- **User Authorization Safeguards**: Prevents admins from blocking their own account or blocking admin accounts through general user management endpoints.
- **User-Facing Feedback**: Updated auth middleware & login service to return clear error messaging (`"Your account has been blocked. Please contact an administrator."`) when a blocked user attempts to log in or make API calls.

<img width="1366" height="768" alt="Screenshot from 2026-09-12 19-56-23" src="https://github.com/user-attachments/assets/5172f33e-88b0-4dc2-90fb-e7fa42bef4cf" />
<img width="1366" height="768" alt="Screenshot from 2026-09-12 19-55-56" src="https://github.com/user-attachments/assets/2d419d3c-1387-4d75-a1ef-3efef4368741" />
<img width="341" height="192" alt="Screenshot from 2026-09-12 19-50-17" src="https://github.com/user-attachments/assets/1d108650-ea3e-437f-8aec-3377eb24a8c3" />

---

## How to Test

1. Navigate to **Admin → Roles & Access** (`/admin/access`).
2. Select an active user from the directory list and click **Block user**.
3. Confirm the action in the prompt modal.
4. Verify:
   - User status updates to `Blocked` immediately.
   - The user appears in the new **Blocked** tab filter.
   - Any active session of the blocked user is invalidated.
5. Try logging in as the blocked user: verify login is rejected with error `"Your account has been blocked. Please contact an administrator."`.
6. Click **Unblock user** on `/admin/access` and confirm.
7. Verify status updates back to `Active` and the user can log in normally.

---

##  Acceptance Criteria Checklist
- [x] Admin can see the user's current access status.
- [x] Admin can block a user from the Access page.
- [x] A confirmation is shown before blocking.
- [x] Blocked users cannot access protected Pathment functionality.
- [x] Admin can unblock a blocked user.
- [x] Block/unblock status is persisted.
- [x] Only authorized admins can block or unblock users.
- [x] User receives an appropriate message when attempting to access Pathment while blocked.
